### PR TITLE
Pretty print catalog.json

### DIFF
--- a/pmd-cataloger/build.gradle.kts
+++ b/pmd-cataloger/build.gradle.kts
@@ -35,7 +35,8 @@ tasks.register<Copy>("installPmd") {
 }
 
 dependencies {
-  implementation("com.googlecode.json-simple:json-simple:1.1.1")
+  implementation ("com.googlecode.json-simple:json-simple:1.1.1")
+  implementation("com.google.code.gson:gson:2.3")
   testImplementation("junit", "junit", "4.12")
 }
 

--- a/pmd-cataloger/src/main/java/sfdc/sfdx/scanner/pmd/PmdRuleCataloger.java
+++ b/pmd-cataloger/src/main/java/sfdc/sfdx/scanner/pmd/PmdRuleCataloger.java
@@ -5,6 +5,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import org.w3c.dom.*;
 import sfdc.sfdx.scanner.pmd.catalog.PmdCatalogCategory;
 import sfdc.sfdx.scanner.pmd.catalog.PmdCatalogJson;
@@ -167,7 +169,8 @@ class PmdRuleCataloger {
     try (
       FileWriter file = new FileWriter(Paths.get(catDirPath.toString(), System.getProperty("catalogName")).toString());
     ) {
-      file.write(json.constructJson().toString());
+      Gson prettyGson = new GsonBuilder().setPrettyPrinting().create();
+      file.write(prettyGson.toJson(json.constructJson()));
     } catch (IOException ioe) {
       System.err.println("Failed to write JSON to file: " + ioe.getMessage());
       System.exit(ExitCode.JSON_WRITE_EXCEPTION.getCode());


### PR DESCRIPTION
Adding a new Java dependency for Gson since org.json.simple does not come with an out-of-box pretty printer and Gson has capability to work on json-simple's JSONObject.