### PR TITLE
Refactor to honor classpath rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ npm install -g scanner
 $ sfdx COMMAND
 running command...
 $ sfdx (-v|--version|version)
-scanner/0.0.0 darwin-x64 node-v12.13.0
+scanner/0.0.0 darwin-x64 node-v12.16.1
 $ sfdx --help [COMMAND]
 USAGE
   $ sfdx COMMAND
@@ -31,9 +31,8 @@ USAGE
 <!-- commands -->
 * [`sfdx scanner:rule:add -l <string> -p <array> [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-scannerruleadd--l-string--p-array---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
 * [`sfdx scanner:rule:describe -n <string> [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-scannerruledescribe--n-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
-* [`sfdx scanner:rule:list [-c <array>] [-r <array>] [-s <string>] [-l <array>] [--standard | --custom] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-scannerrulelist--c-array--r-array--s-string--l-array---standard----custom---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
-* [`sfdx scanner:run [-c <array>] [-r <array>] [-s <array> | -a <string>] [--suppress-warnings] [-f xml|csv|table | -o <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-scannerrun--c-array--r-array--s-array---a-string---suppress-warnings--f-xmlcsvtable---o-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
-* [`sfdx scanner:scan [-R <string>] [-d <string>] [-r <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-scannerscan--r-string--d-string--r-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
+* [`sfdx scanner:rule:list [-c <array>] [-r <array>] [-l <array>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-scannerrulelist--c-array--r-array--l-array---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
+* [`sfdx scanner:run [-c <array>] [-r <array>] [-s <array> | undefined] [-f xml|csv|table | -o <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-scannerrun--c-array--r-array--s-array--undefined--f-xmlcsvtable---o-string---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
 * [`sfdx scanner:scannerCommand [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-scannerscannercommand---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
 
 ## `sfdx scanner:rule:add -l <string> -p <array> [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
@@ -105,14 +104,14 @@ EXAMPLES
 
 _See code: [lib/commands/scanner/rule/describe.js](https://github.com/forcedotcom/sfdx-scanner/blob/v0.0.0/lib/commands/scanner/rule/describe.js)_
 
-## `sfdx scanner:rule:list [-c <array>] [-r <array>] [-s <string>] [-l <array>] [--standard | --custom] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
+## `sfdx scanner:rule:list [-c <array>] [-r <array>] [-l <array>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
 [Description of 'list' command]
 
 ```
 USAGE
-  $ sfdx scanner:rule:list [-c <array>] [-r <array>] [-s <string>] [-l <array>] [--standard | --custom] [--json] 
-  [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
+  $ sfdx scanner:rule:list [-c <array>] [-r <array>] [-l <array>] [--json] [--loglevel 
+  trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
 
 OPTIONS
   -c, --category=category                                                           [Description of 'category'
@@ -123,18 +122,10 @@ OPTIONS
 
   -r, --ruleset=ruleset                                                             [Description of 'ruleset' parameter]
 
-  -s, --severity=severity                                                           [Description of 'severity'
-                                                                                    parameter]
-
-  --custom                                                                          [Description of 'custom' parameter]
-
   --json                                                                            format output as json
 
   --loglevel=(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)  [default: warn] logging level for
                                                                                     this command invocation
-
-  --standard                                                                        [Description of 'standard'
-                                                                                    parameter]
 
 EXAMPLES
   $ sfdx hello:org --targetusername myOrg@example.com --targetdevhubusername devhub@org.com
@@ -147,18 +138,16 @@ EXAMPLES
 
 _See code: [lib/commands/scanner/rule/list.js](https://github.com/forcedotcom/sfdx-scanner/blob/v0.0.0/lib/commands/scanner/rule/list.js)_
 
-## `sfdx scanner:run [-c <array>] [-r <array>] [-s <array> | -a <string>] [--suppress-warnings] [-f xml|csv|table | -o <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
+## `sfdx scanner:run [-c <array>] [-r <array>] [-s <array> | undefined] [-f xml|csv|table | -o <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
 [Description of 'run' command]
 
 ```
 USAGE
-  $ sfdx scanner:run [-c <array>] [-r <array>] [-s <array> | -a <string>] [--suppress-warnings] [-f xml|csv|table | -o 
-  <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
+  $ sfdx scanner:run [-c <array>] [-r <array>] [-s <array> | undefined] [-f xml|csv|table | -o <string>] [--json] 
+  [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
 
 OPTIONS
-  -a, --org=org                                                                     [Description of 'org' parameter]
-
   -c, --category=category                                                           [Description of 'category'
                                                                                     parameter]
 
@@ -175,9 +164,6 @@ OPTIONS
   --loglevel=(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)  [default: warn] logging level for
                                                                                     this command invocation
 
-  --suppress-warnings                                                               [Description of 'suppress-warnings'
-                                                                                    parameter]
-
 EXAMPLE
   $ sfdx hello:org --targetusername myOrg@example.com --targetdevhubusername devhub@org.com
      Hello world! This is org: MyOrg and I will be around until Tue Mar 20 2018!
@@ -185,34 +171,6 @@ EXAMPLE
 ```
 
 _See code: [lib/commands/scanner/run.js](https://github.com/forcedotcom/sfdx-scanner/blob/v0.0.0/lib/commands/scanner/run.js)_
-
-## `sfdx scanner:scan [-R <string>] [-d <string>] [-r <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
-
-scan local code for violations of rules
-
-```
-USAGE
-  $ sfdx scanner:scan [-R <string>] [-d <string>] [-r <string>] [--json] [--loglevel 
-  trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
-
-OPTIONS
-  -R, --ruleset=ruleset                                                             ruleset to use for scanning
-  -d, --filepath=filepath                                                           file path to examine
-  -r, --report=report                                                               file to save output report
-  --json                                                                            format output as json
-
-  --loglevel=(trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL)  [default: warn] logging level for
-                                                                                    this command invocation
-
-EXAMPLE
-  $ sfdx scanner:scan --ruleset "/my/ruleset/file/location" --filepath "/my/code/files/to/be/scanned"
-           (todo: add sample output here)
-
-           $ sfdx scanner:scan -R "/my/ruleset/file/location" -d "/my/code/files/to/be/scanned"
-           (todo: add sample output here)
-```
-
-_See code: [lib/commands/scanner/scan.js](https://github.com/forcedotcom/sfdx-scanner/blob/v0.0.0/lib/commands/scanner/scan.js)_
 
 ## `sfdx scanner:scannerCommand [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 

--- a/messages/add.json
+++ b/messages/add.json
@@ -2,13 +2,14 @@
   "commandDescription": "Add custom rules to use while scanning. Rules should have been compiled and tested separately. Users can refer to PMD’s documentation on information and examples to write your own custom rules: https://pmd.github.io/latest/pmd_userdocs_extending_writing_pmd_rules.html",
   "flags": {
     "languageDescription": "Programming language for which custom rules are added.",
-    "pathDescription": "Comma-separated list to paths that lead to custom rule definitions. These paths could be one or more of:\n1. Jar file with compiled rule classes and one or more Rule definition XML file(s)\n2. Directory to multiple jar files, each with compiled rule classes. Rule definition XML file(s) could be part of the jar files or directly placed under the directory\n3. Directory with package-structured rule classes and Rule definition XML file(s) at some level\n\nTo distinguish Rulesets XML vs Category XML:\n1. Ensure that rulesets XML have “rulesets” in the directory path\n2. XMLs that do not have “rulesets” in the directory path would be handled as Category XML by default"  
+    "pathDescription": "Comma-separated list to paths that lead to custom rule definitions. These paths could be one or more of:\n1. Jar file with compiled rule classes and one or more Rule definition XML file(s)\n2. Directory to multiple jar files, each with compiled rule classes. Rule definition XML file(s) could be part of the jar files or directly placed under the directory\n3. Directory with package-structured rule classes and Rule definition XML file(s) at some level\n\nTo distinguish Rulesets XML vs Category XML:\n1. Ensure that rulesets XML have “rulesets” in the directory path\n2. XMLs that do not have “rulesets” in the directory path would be handled as Category XML by default"
   },
   "validations": {
     "languageCannotBeEmpty": "Language cannot be empty",
     "pathCannotBeEmpty": "Path cannot be empty"
   },
   "errors": {
+    "invalidFilePath": "Failed to find any file or directory with path: %s",
     "readCustomRulePathFileFailed": "Failed to read custom rule path file: %s",
     "writeCustomRulePathFileFailed": "Failed to write to custom rule path file: %s"
   }

--- a/src/commands/scanner/rule/add.ts
+++ b/src/commands/scanner/rule/add.ts
@@ -39,7 +39,6 @@ export default class Add extends SfdxCommand {
   };
 
   public async run(): Promise<AnyJson> {
-
     this.validateFlags();
 
     const language = this.flags.language;
@@ -50,12 +49,10 @@ export default class Add extends SfdxCommand {
 
     // Add to Custom Classpath registry
     const manager = new CustomRulePathManager();
-    await manager.addPathsForLanguage(language, path);
-
+    const classpathEntries = await manager.addPathsForLanguage(language, path);
     this.ux.log(`Successfully added rules for ${language}.`);
-    this.ux.log(`${path.length} Path(s) added: ${path}`);
-
-    return { success: true, language: language, path: path };
+    this.ux.log(`${classpathEntries.length} Path(s) added: ${classpathEntries}`);
+    return { success: true, language, path };
   }
 
   private validateFlags(): void {

--- a/src/commands/scanner/rule/add.ts
+++ b/src/commands/scanner/rule/add.ts
@@ -52,7 +52,7 @@ export default class Add extends SfdxCommand {
     const classpathEntries = await manager.addPathsForLanguage(language, path);
     this.ux.log(`Successfully added rules for ${language}.`);
     this.ux.log(`${classpathEntries.length} Path(s) added: ${classpathEntries}`);
-    return { success: true, language, path };
+    return { success: true, language, path: classpathEntries };
   }
 
   private validateFlags(): void {

--- a/src/lib/CustomRulePathManager.ts
+++ b/src/lib/CustomRulePathManager.ts
@@ -146,7 +146,12 @@ export class CustomRulePathManager {
   private async expandClasspaths(paths: string[]): Promise<string[]> {
     const classpathEntries: string[] = [];
     for (const p of paths) {
-      const stats = await this.fileHandler.stats(p);
+      let stats;
+      try {
+        stats = await this.fileHandler.stats(p);
+      } catch (e) {
+        throw SfdxError.create('scanner', 'add', 'errors.invalidFilePath', [p]);
+      }
       if (stats.isFile()) {
         if (p.endsWith(".jar")) {
           // Simple filename check for .jar is enough.

--- a/src/lib/FileHandler.ts
+++ b/src/lib/FileHandler.ts
@@ -1,20 +1,29 @@
 import fs = require('fs');
+import {Stats} from 'fs';
 
 /**
- * Handles all File and IO operations. 
+ * Handles all File and IO operations.
  * Mock this class to override file change behavior from unit tests.
  */
 export class FileHandler {
 
-    async readFile(filename: string): Promise<string> {
-        return await fs.promises.readFile(filename, 'utf-8');
+    stats(filename: string): Promise<Stats> {
+        return fs.promises.stat(filename);
     }
 
-    async mkdirIfNotExists(dir: string): Promise<void> {
-        await fs.promises.mkdir(dir, { recursive: true });
+    readDir(filename: string): Promise<string[]> {
+      return fs.promises.readdir(filename);
     }
 
-    async writeFile(filename: string, fileContent: string): Promise<void> {
-        await fs.promises.writeFile(filename, fileContent);
+    readFile(filename: string): Promise<string> {
+        return fs.promises.readFile(filename, 'utf-8');
+    }
+
+    mkdirIfNotExists(dir: string): Promise<void> {
+        return fs.promises.mkdir(dir, { recursive: true });
+    }
+
+    writeFile(filename: string, fileContent: string): Promise<void> {
+        return fs.promises.writeFile(filename, fileContent);
     }
 }

--- a/test/commands/scanner/rule/add.test.ts
+++ b/test/commands/scanner/rule/add.test.ts
@@ -28,11 +28,11 @@ describe('scanner:rule:add', () => {
 
       // Use two dirs, with one jar file in each.
       const tmpDir1 = fs.mkdtempSync(path.join(os.tmpdir(), 'foo-'));
-      let tmpFile1 = path.join(tmpDir1, 'bar.jar');
+      const tmpFile1 = path.join(tmpDir1, 'bar.jar');
       fs.writeFileSync(tmpFile1, "There is no spoon");
 
       const tmpDir2 = fs.mkdtempSync(path.join(os.tmpdir(), 'bar-'));
-      let tmpFile2 = path.join(tmpDir2, 'foo.jar');
+      const tmpFile2 = path.join(tmpDir2, 'foo.jar');
       fs.writeFileSync(tmpFile2, "Spoon is no there");
 
       // Now pass the first dir and the second file.
@@ -46,8 +46,6 @@ describe('scanner:rule:add', () => {
         .stderr()
         .command(['scanner:rule:add', '--language', myLanguage, '--path', myPath.join(','), '--json'])
         .it('should run successfully and add entries to custom classpath json', ctx => {
-          expect(ctx.stderr).to.be.empty;
-
           const outputJson = JSON.parse(ctx.stdout);
           const result = outputJson.result;
           expect(result).to.have.property('success')

--- a/test/commands/scanner/rule/add.test.ts
+++ b/test/commands/scanner/rule/add.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@salesforce/command/lib/test';
 import { Messages } from '@salesforce/core';
+import * as os from 'os';
 import { SFDX_SCANNER_PATH } from '../../../../src/Constants';
 import fs = require('fs');
 import path = require('path');
@@ -24,14 +25,29 @@ describe('scanner:rule:add', () => {
       }
 
       const myLanguage = 'apex';
-      const myPath = ['/some/local/path', 'some/other/path'];
 
+      // Use two dirs, with one jar file in each.
+      const tmpDir1 = fs.mkdtempSync(path.join(os.tmpdir(), 'foo-'));
+      let tmpFile1 = path.join(tmpDir1, 'bar.jar');
+      fs.writeFileSync(tmpFile1, "There is no spoon");
+
+      const tmpDir2 = fs.mkdtempSync(path.join(os.tmpdir(), 'bar-'));
+      let tmpFile2 = path.join(tmpDir2, 'foo.jar');
+      fs.writeFileSync(tmpFile2, "Spoon is no there");
+
+      // Now pass the first dir and the second file.
+      const myPath = [tmpDir1, tmpFile2];
+
+      // Result should be three entries: dir 1, file 1, and file 2
+      const expectedPath = [tmpDir1, tmpFile1, tmpFile2];
       test
         .env({PMD_CATALOG_NAME: CATALOG_OVERRIDE, CUSTOM_PATH_FILE: CUSTOM_PATH_OVERRIDE})
         .stdout()
         .stderr()
         .command(['scanner:rule:add', '--language', myLanguage, '--path', myPath.join(','), '--json'])
         .it('should run successfully and add entries to custom classpath json', ctx => {
+          expect(ctx.stderr).to.be.empty;
+
           const outputJson = JSON.parse(ctx.stdout);
           const result = outputJson.result;
           expect(result).to.have.property('success')
@@ -41,8 +57,8 @@ describe('scanner:rule:add', () => {
             .and.equals(myLanguage);
 
           expect(result).to.have.property('path')
-            .and.have.lengthOf(myPath.length)
-            .and.deep.equals(myPath);
+            .and.have.lengthOf(expectedPath.length)
+            .and.deep.equals(expectedPath);
         });
     });
   });


### PR DESCRIPTION
Each path can be a jar file or a directory.  If directory, include self along with any child jar files (not recursively)