### PR TITLE
IOC part 2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,8 @@
 plugins {
-  java
+	java
+	id("com.github.hierynomus.license") version "0.15.0"
 }
 
 subprojects {
-  version = "1.0"
+	version = "1.0"
 }

--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
 		"@salesforce/core": "^2.1.6",
 		"find-java-home": "^1.1.0",
 		"globby": "^11.0.0",
-		"inversify": "^5.0.1",
 		"normalize-path": "^3.0.0",
 		"reflect-metadata": "^0.1.13",
 		"ts-node": "^8",
 		"tslib": "^1",
+		"tsyringe": "^4.1.0",
 		"typescript": "^3.8.2",
 		"untildify": "^4.0.0",
 		"xml-js": "^1.6.11"

--- a/pmd-cataloger/src/test/java/sfdc/sfdx/scanner/pmd/catalog/PmdCatalogJsonTest.java
+++ b/pmd-cataloger/src/test/java/sfdc/sfdx/scanner/pmd/catalog/PmdCatalogJsonTest.java
@@ -33,11 +33,12 @@ public class PmdCatalogJsonTest {
 		final JSONObject jsonObject = catalogJson.constructJson();
 
 		// Verify
-		final String expectedRulesetJson = String.format("{\"%s\":[\"%s\"]}", RULE_NAME, RULE_PATH);
-		assertEquals(expectedRulesetJson, jsonObject.get(PmdCatalogJson.JSON_RULESETS).toString());
+		//[{"paths":["rule path"],"name":"rule name"}]
+		final String expectedRulesetJson = String.format("[{\"paths\":[\"%s\"],\"name\":\"%s\"}]", RULE_PATH, RULE_NAME);
+		assertEquals(jsonObject.get(PmdCatalogJson.JSON_RULESETS).toString(), expectedRulesetJson);
 
-		final String expectedCategoryJson = String.format("{\"%s\":[\"%s\"]}", CATEGORY_NAME, CATEGORY_PATH);
-		assertEquals(expectedCategoryJson, jsonObject.get(PmdCatalogJson.JSON_CATEGORIES).toString());
+		final String expectedCategoryJson = String.format("[{\"paths\":[\"%s\"],\"name\":\"%s\"}]", CATEGORY_PATH, CATEGORY_NAME);
+		assertEquals(jsonObject.get(PmdCatalogJson.JSON_CATEGORIES).toString(), expectedCategoryJson);
 
 		// Rules json has its own test where we verify the Json contents. Here, we only confirm that it exists
 		assertTrue("JSON should contain 'rules' element", jsonObject.containsKey(PmdCatalogJson.JSON_RULES));

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -3,5 +3,6 @@ import path = require('path');
 
 export const SFDX_SCANNER_PATH = path.join(os.homedir(), '.sfdx-scanner');
 export const PMD_CATALOG = 'PmdCatalog.json';
+export const CATALOG_JSON = 'Catalog.json';
 export const CUSTOM_PATHS = 'CustomPaths.json';
 export const CONFIG = 'Config.json';

--- a/src/commands/scanner/rule/add.ts
+++ b/src/commands/scanner/rule/add.ts
@@ -1,7 +1,7 @@
 import {flags, SfdxCommand} from '@salesforce/command';
 import {Messages, SfdxError} from '@salesforce/core';
 import {AnyJson} from '@salesforce/ts-types';
-import {CustomRulePathManager} from '../../../lib/CustomRulePathManager';
+import {Controller} from '../../../ioc.config';
 import path = require('path');
 import untildify = require('untildify');
 
@@ -48,7 +48,7 @@ export default class Add extends SfdxCommand {
 		this.logger.trace(`Rule path: ${paths}`);
 
 		// Add to Custom Classpath registry
-		const manager = await CustomRulePathManager.create();
+		const manager = await Controller.createRulePathManager();
 		const classpathEntries = await manager.addPathsForLanguage(language, paths);
 		this.ux.log(`Successfully added rules for ${language}.`);
 		this.ux.log(`${classpathEntries.length} Path(s) added: ${classpathEntries}`);

--- a/src/commands/scanner/rule/describe.ts
+++ b/src/commands/scanner/rule/describe.ts
@@ -39,7 +39,7 @@ export default class Describe extends ScannerCommand {
 		const ruleFilters = this.buildRuleFilters();
 		// It's possible for this line to throw an error, but that's fine because the error will be an SfdxError that we can
 		// allow to boil over.
-		const ruleManager = await Controller.createManager();
+		const ruleManager = await Controller.createRuleManager();
 		const rules = await ruleManager.getRulesMatchingCriteria(ruleFilters);
 		if (rules.length === 0) {
 			// If we couldn't find any rules that fit the criteria, we'll let the user know. We'll use .warn() instead of .log()

--- a/src/commands/scanner/rule/describe.ts
+++ b/src/commands/scanner/rule/describe.ts
@@ -1,7 +1,7 @@
 import {flags} from '@salesforce/command';
 import {Messages} from '@salesforce/core';
 import {AnyJson} from '@salesforce/ts-types';
-import {RuleManager} from '../../../lib/RuleManager';
+import {Controller} from '../../../ioc.config';
 import {Rule} from '../../../types';
 import {ScannerCommand} from '../scannerCommand';
 
@@ -39,7 +39,7 @@ export default class Describe extends ScannerCommand {
 		const ruleFilters = this.buildRuleFilters();
 		// It's possible for this line to throw an error, but that's fine because the error will be an SfdxError that we can
 		// allow to boil over.
-		const ruleManager = await RuleManager.create();
+		const ruleManager = await Controller.createManager();
 		const rules = await ruleManager.getRulesMatchingCriteria(ruleFilters);
 		if (rules.length === 0) {
 			// If we couldn't find any rules that fit the criteria, we'll let the user know. We'll use .warn() instead of .log()

--- a/src/commands/scanner/rule/list.ts
+++ b/src/commands/scanner/rule/list.ts
@@ -1,6 +1,6 @@
 import {flags} from '@salesforce/command';
 import {Messages} from '@salesforce/core';
-import {RuleManager} from '../../../lib/RuleManager';
+import {Controller} from '../../../ioc.config';
 import {Rule} from '../../../types';
 import {ScannerCommand} from '../scannerCommand';
 
@@ -10,7 +10,7 @@ Messages.importMessagesDirectory(__dirname);
 // Load the specific messages for this file. Messages from @salesforce/command, @salesforce/core,
 // or any library that is using the messages framework can also be loaded this way.
 const messages = Messages.loadMessages('@salesforce/sfdx-scanner', 'list');
-const columns = ['name', 'languages', 'categories', 'rulesets'];
+const columns = ['name', 'languages', 'categories', 'rulesets', 'engine'];
 
 export default class List extends ScannerCommand {
 	// These determine what's displayed when the --help/-h flag is supplied.
@@ -64,9 +64,9 @@ export default class List extends ScannerCommand {
 
 	public async run(): Promise<Rule[]> {
 		const ruleFilters = this.buildRuleFilters();
-		const ruleManager = await RuleManager.create();
 		// It's possible for this line to throw an error, but that's fine because the error will be an SfdxError that we can
 		// allow to boil over.
+		const ruleManager = await Controller.createManager();
 		const rules = await ruleManager.getRulesMatchingCriteria(ruleFilters);
 		const formattedRules = this.formatRulesForDisplay(rules);
 		this.ux.table(formattedRules, columns);

--- a/src/commands/scanner/rule/list.ts
+++ b/src/commands/scanner/rule/list.ts
@@ -66,7 +66,7 @@ export default class List extends ScannerCommand {
 		const ruleFilters = this.buildRuleFilters();
 		// It's possible for this line to throw an error, but that's fine because the error will be an SfdxError that we can
 		// allow to boil over.
-		const ruleManager = await Controller.createManager();
+		const ruleManager = await Controller.createRuleManager();
 		const rules = await ruleManager.getRulesMatchingCriteria(ruleFilters);
 		const formattedRules = this.formatRulesForDisplay(rules);
 		this.ux.table(formattedRules, columns);

--- a/src/commands/scanner/rule/remove.ts
+++ b/src/commands/scanner/rule/remove.ts
@@ -1,10 +1,10 @@
 import {flags} from '@salesforce/command';
 import {Messages, SfdxError} from '@salesforce/core';
 import {AnyJson} from '@salesforce/ts-types';
+import {Controller} from '../../../ioc.config';
+import {FilterType, RuleFilter} from '../../../lib/RuleFilter';
 import {ScannerCommand} from '../scannerCommand';
-import {RULE_FILTER_TYPE, RuleFilter, RuleManager} from '../../../lib/RuleManager';
 import {Rule} from '../../../types';
-import {CustomRulePathManager} from '../../../lib/CustomRulePathManager';
 import path = require('path');
 import untildify = require('untildify');
 
@@ -52,7 +52,7 @@ export default class Remove extends ScannerCommand {
 		this.logger.trace(`Rule path: ${paths}`);
 
 		// Step 3: Get all rule entries matching the criteria they provided.
-		const crpm = await CustomRulePathManager.create();
+		const crpm = await Controller.createRulePathManager();
 		const deletablePaths: string[] = paths ? await crpm.getMatchingPaths(paths) : await crpm.getAllPaths();
 
 		// Step 4: If there aren't any matching paths, we need to react appropriately.
@@ -81,10 +81,10 @@ export default class Remove extends ScannerCommand {
 		if (!this.flags.force) {
 			// Step 6a: We'll want to create filter criteria.
 			const filters: RuleFilter[] = [];
-			filters.push(new RuleFilter(RULE_FILTER_TYPE.SOURCEPACKAGE, deletablePaths));
+			filters.push(new RuleFilter(FilterType.SOURCEPACKAGE, deletablePaths));
 
 			// Step 6b: We'll want to retrieve the matching rules.
-			const rm = await RuleManager.create();
+			const rm = await Controller.createManager();
 			const matchingRules: Rule[] = await rm.getRulesMatchingCriteria(filters);
 
 			// Step 6c: Ask the user to confirm that they actually want to delete the rules in question.

--- a/src/commands/scanner/rule/remove.ts
+++ b/src/commands/scanner/rule/remove.ts
@@ -84,7 +84,7 @@ export default class Remove extends ScannerCommand {
 			filters.push(new RuleFilter(FilterType.SOURCEPACKAGE, deletablePaths));
 
 			// Step 6b: We'll want to retrieve the matching rules.
-			const rm = await Controller.createManager();
+			const rm = await Controller.createRuleManager();
 			const matchingRules: Rule[] = await rm.getRulesMatchingCriteria(filters);
 
 			// Step 6c: Ask the user to confirm that they actually want to delete the rules in question.

--- a/src/commands/scanner/run.ts
+++ b/src/commands/scanner/run.ts
@@ -1,7 +1,8 @@
 import {flags} from '@salesforce/command';
 import {Messages, SfdxError} from '@salesforce/core';
 import {AnyJson} from '@salesforce/ts-types';
-import {OUTPUT_FORMAT, RuleManager} from '../../lib/RuleManager';
+import {Controller} from '../../ioc.config';
+import {OUTPUT_FORMAT} from '../../lib/RuleManager';
 import {ScannerCommand} from './scannerCommand';
 import fs = require('fs');
 import globby = require('globby');
@@ -105,7 +106,7 @@ export default class Run extends ScannerCommand {
 		// Else, default to table format.  We can't use the default attribute of the flag here because we need to differentiate
 		// between 'table' being defaulted and 'table' being explicitly chosen by the user.
 		const format: OUTPUT_FORMAT = this.flags.format || (this.flags.outfile ? this.deriveFormatFromOutfile() : OUTPUT_FORMAT.TABLE);
-		const ruleManager = await RuleManager.create();
+		const ruleManager = await Controller.createManager();
 		// It's possible for this line to throw an error, but that's fine because the error will be an SfdxError that we can
 		// allow to boil over.
 		const output = await ruleManager.runRulesMatchingCriteria(filters, target, format);

--- a/src/commands/scanner/run.ts
+++ b/src/commands/scanner/run.ts
@@ -106,7 +106,7 @@ export default class Run extends ScannerCommand {
 		// Else, default to table format.  We can't use the default attribute of the flag here because we need to differentiate
 		// between 'table' being defaulted and 'table' being explicitly chosen by the user.
 		const format: OUTPUT_FORMAT = this.flags.format || (this.flags.outfile ? this.deriveFormatFromOutfile() : OUTPUT_FORMAT.TABLE);
-		const ruleManager = await Controller.createManager();
+		const ruleManager = await Controller.createRuleManager();
 		// It's possible for this line to throw an error, but that's fine because the error will be an SfdxError that we can
 		// allow to boil over.
 		const output = await ruleManager.runRulesMatchingCriteria(filters, target, format);

--- a/src/commands/scanner/scannerCommand.ts
+++ b/src/commands/scanner/scannerCommand.ts
@@ -1,5 +1,5 @@
 import {SfdxCommand} from '@salesforce/command';
-import {RuleFilter, RULE_FILTER_TYPE} from '../../lib/RuleManager';
+import {FilterType, RuleFilter} from '../../lib/RuleFilter';
 import {uxEvents} from '../../lib/ScannerEvents';
 
 export abstract class ScannerCommand extends SfdxCommand {
@@ -8,23 +8,23 @@ export abstract class ScannerCommand extends SfdxCommand {
 		const filters: RuleFilter[] = [];
 		// Create a filter for any provided categories.
 		if ((this.flags.category || []).length > 0) {
-			filters.push(new RuleFilter(RULE_FILTER_TYPE.CATEGORY, this.flags.category));
+			filters.push(new RuleFilter(FilterType.CATEGORY, this.flags.category));
 		}
 
 		// Create a filter for any provided rulesets.
 		if ((this.flags.ruleset || []).length > 0) {
-			filters.push(new RuleFilter(RULE_FILTER_TYPE.RULESET, this.flags.ruleset));
+			filters.push(new RuleFilter(FilterType.RULESET, this.flags.ruleset));
 		}
 
 		// Create a filter for any provided languages.
 		if ((this.flags.language || []).length > 0) {
-			filters.push(new RuleFilter(RULE_FILTER_TYPE.LANGUAGE, this.flags.language));
+			filters.push(new RuleFilter(FilterType.LANGUAGE, this.flags.language));
 		}
 
 		// Create a filter for provided rule names.
 		// NOTE: Only a single rule name can be provided. It will be treated as a singleton list.
 		if (this.flags.rulename) {
-			filters.push(new RuleFilter(RULE_FILTER_TYPE.RULENAME, [this.flags.rulename]));
+			filters.push(new RuleFilter(FilterType.RULENAME, [this.flags.rulename]));
 		}
 
 		return filters;

--- a/src/ioc.config.ts
+++ b/src/ioc.config.ts
@@ -1,12 +1,52 @@
-import { Container as IOC} from "inversify";
 import "reflect-metadata";
 
+import {container} from "tsyringe";
+import {CustomRulePathManager} from './lib/CustomRulePathManager';
+import {DefaultManager} from './lib/DefaultManager';
+import {ESLintEngine} from './lib/eslint/ESLintEngine';
+import {PmdEngine} from './lib/pmd/PmdEngine';
+import {RuleManager} from './lib/RuleManager';
+import {RulePathManager} from './lib/RulePathManager';
+import LocalCatalog from './lib/services/LocalCatalog';
+
 export const Services = {
-	RuleEngine: Symbol("RuleEngine")
+	RuleManager: "RuleManager",
+	RuleEngine: "RuleEngine",
+	RuleCatalog: "RuleCatalog",
+	RulePathManager: "RulePathManager"
 };
 
-import {PmdEngine} from './lib/pmd/PmdEngine';
-import {RuleEngine} from './lib/services/RuleEngine';
+container.register(Services.RuleManager, {
+	useClass: DefaultManager
+});
+container.register(Services.RuleEngine, {
+	useClass: PmdEngine
+});
+container.register(Services.RuleEngine, {
+	useClass: ESLintEngine
+});
+container.register(Services.RuleCatalog, {
+	useClass: LocalCatalog
+});
+container.register(Services.RulePathManager, {
+	useClass: CustomRulePathManager
+});
 
-export const Container = new IOC();
-Container.bind<RuleEngine>(Services.RuleEngine).to(PmdEngine);
+export const Controller = {
+	container,
+	createManager: async (): Promise<RuleManager> => {
+		try {
+			const manager = container.resolve<RuleManager>(Services.RuleManager);
+			await manager.init();
+			return manager;
+		} catch (e) {
+			console.log(e.stack);
+		}
+	},
+
+	createRulePathManager: async (): Promise<RulePathManager> => {
+		const manager = container.resolve<RulePathManager>(Services.RulePathManager);
+		await manager.init();
+		return manager;
+	}
+};

--- a/src/ioc.config.ts
+++ b/src/ioc.config.ts
@@ -2,7 +2,7 @@ import "reflect-metadata";
 
 import {container} from "tsyringe";
 import {CustomRulePathManager} from './lib/CustomRulePathManager';
-import {DefaultManager} from './lib/DefaultManager';
+import {DefaultRuleManager} from './lib/DefaultRuleManager';
 import {ESLintEngine} from './lib/eslint/ESLintEngine';
 import {PmdEngine} from './lib/pmd/PmdEngine';
 import {RuleManager} from './lib/RuleManager';
@@ -17,7 +17,7 @@ export const Services = {
 };
 
 container.register(Services.RuleManager, {
-	useClass: DefaultManager
+	useClass: DefaultRuleManager
 });
 container.register(Services.RuleEngine, {
 	useClass: PmdEngine
@@ -34,7 +34,7 @@ container.register(Services.RulePathManager, {
 
 export const Controller = {
 	container,
-	createManager: async (): Promise<RuleManager> => {
+	createRuleManager: async (): Promise<RuleManager> => {
 		try {
 			const manager = container.resolve<RuleManager>(Services.RuleManager);
 			await manager.init();

--- a/src/lib/CustomRulePathManager.ts
+++ b/src/lib/CustomRulePathManager.ts
@@ -26,8 +26,9 @@ export class CustomRulePathManager implements RulePathManager {
 	}
 
 	async init(): Promise<void> {
-		if (this.initialized)
+		if (this.initialized) {
 			return;
+		}
 
 		await Promise.all(this.engines.map(e => e.init()));
 		this.pathsByLanguageByEngine = new Map();

--- a/src/lib/DefaultManager.ts
+++ b/src/lib/DefaultManager.ts
@@ -1,0 +1,64 @@
+import {Logger, SfdxError} from '@salesforce/core';
+import {inject, injectable, injectAll} from 'tsyringe';
+import {NamedPaths, Rule} from '../types';
+import {RuleFilter} from './RuleFilter';
+import {OUTPUT_FORMAT, RuleManager} from './RuleManager';
+import {RuleResultRecombinator} from './RuleResultRecombinator';
+import {RuleCatalog} from './services/RuleCatalog';
+import {RuleEngine} from './services/RuleEngine';
+
+@injectable()
+export class DefaultManager implements RuleManager {
+	private logger: Logger;
+
+	// noinspection JSMismatchedCollectionQueryUpdate
+	private readonly engines: RuleEngine[];
+	private readonly catalog: RuleCatalog;
+	private initialized: boolean;
+
+	constructor(
+		@injectAll("RuleEngine") engines?: RuleEngine[],
+		@inject("RuleCatalog") catalog?: RuleCatalog
+	) {
+		this.engines = engines;
+		this.catalog = catalog;
+	}
+
+	async init(): Promise<void> {
+		if (this.initialized) return;
+
+		await Promise.all(this.engines.map(e => e.init()));
+		await this.catalog.init();
+		this.logger = await Logger.child('DefaultManager');
+
+		this.initialized = true;
+	}
+
+	async getRulesMatchingCriteria(filters: RuleFilter[]): Promise<Rule[]> {
+		return this.catalog.getRulesMatchingFilters(filters);
+	}
+
+	async runRulesMatchingCriteria(filters: RuleFilter[], target: string[] | string, format: OUTPUT_FORMAT): Promise<string> {
+		// If target is a string, it means it's an alias for an org, instead of a bunch of local file paths. We can't handle
+		// running rules against an org yet, so we'll just throw an error for now.
+		if (typeof target === 'string') {
+			throw new SfdxError('Running rules against orgs is not yet supported');
+		}
+
+		// Convert our filters into paths that we can feed to the engines. If we didn't find any paths, we're done.
+		const paths: NamedPaths[] = await this.catalog.getNamedPathsMatchingFilters(filters);
+		if (paths == null || paths.length === 0) {
+			this.logger.trace('No Rule paths found. Nothing to execute.');
+			return '';
+		}
+
+		const ps = this.engines.map(e => e.run(paths, target));
+		const [results] = await Promise.all(ps);
+		this.logger.trace(`Received rule violations: ${results}`);
+
+		// Once all of the rules finish running, we'll need to combine their results into a single set of the desired type,
+		// which we can then return.
+		this.logger.trace(`Recombining results into requested format ${format}`);
+		return RuleResultRecombinator.recombineAndReformatResults([results], format);
+	}
+}

--- a/src/lib/DefaultRuleManager.ts
+++ b/src/lib/DefaultRuleManager.ts
@@ -1,6 +1,6 @@
 import {Logger, SfdxError} from '@salesforce/core';
 import {inject, injectable, injectAll} from 'tsyringe';
-import {NamedPaths, Rule} from '../types';
+import {PathGroup, Rule} from '../types';
 import {RuleFilter} from './RuleFilter';
 import {OUTPUT_FORMAT, RuleManager} from './RuleManager';
 import {RuleResultRecombinator} from './RuleResultRecombinator';
@@ -8,7 +8,7 @@ import {RuleCatalog} from './services/RuleCatalog';
 import {RuleEngine} from './services/RuleEngine';
 
 @injectable()
-export class DefaultManager implements RuleManager {
+export class DefaultRuleManager implements RuleManager {
 	private logger: Logger;
 
 	// noinspection JSMismatchedCollectionQueryUpdate
@@ -25,7 +25,9 @@ export class DefaultManager implements RuleManager {
 	}
 
 	async init(): Promise<void> {
-		if (this.initialized) return;
+		if (this.initialized) {
+			return;
+		}
 
 		await Promise.all(this.engines.map(e => e.init()));
 		await this.catalog.init();
@@ -46,7 +48,7 @@ export class DefaultManager implements RuleManager {
 		}
 
 		// Convert our filters into paths that we can feed to the engines. If we didn't find any paths, we're done.
-		const paths: NamedPaths[] = await this.catalog.getNamedPathsMatchingFilters(filters);
+		const paths: PathGroup[] = await this.catalog.getNamedPathsMatchingFilters(filters);
 		if (paths == null || paths.length === 0) {
 			this.logger.trace('No Rule paths found. Nothing to execute.');
 			return '';

--- a/src/lib/JreSetupManager.ts
+++ b/src/lib/JreSetupManager.ts
@@ -31,7 +31,9 @@ class JreSetupManager extends AsyncCreatable {
 	private initialized: boolean;
 
 	protected async init(): Promise<void> {
-		if (this.initialized) return;
+		if (this.initialized) {
+			return;
+		}
 
 		this.logger = await Logger.child('verifyJRE');
 		this.config = await Config.create({});

--- a/src/lib/JreSetupManager.ts
+++ b/src/lib/JreSetupManager.ts
@@ -28,11 +28,16 @@ class JreSetupManager extends AsyncCreatable {
 	private logger!: Logger;
 	private config!: Config;
 	private dependencies: JreSetupManagerDependencies;
+	private initialized: boolean;
 
 	protected async init(): Promise<void> {
+		if (this.initialized) return;
+
 		this.logger = await Logger.child('verifyJRE');
 		this.config = await Config.create({});
 		this.dependencies = new JreSetupManagerDependencies();
+
+		this.initialized = true;
 	}
 
 	async verifyJreSetup(): Promise<string> {

--- a/src/lib/RuleFilter.ts
+++ b/src/lib/RuleFilter.ts
@@ -1,0 +1,17 @@
+export enum FilterType {
+	RULENAME,
+	CATEGORY,
+	RULESET,
+	LANGUAGE,
+	SOURCEPACKAGE
+}
+
+export class RuleFilter {
+    readonly filterType: FilterType;
+    readonly filterValues: ReadonlyArray<string>;
+
+    constructor(filterType: FilterType, filterValues: string[]) {
+        this.filterType = filterType;
+        this.filterValues = filterValues;
+    }
+}

--- a/src/lib/RuleManager.ts
+++ b/src/lib/RuleManager.ts
@@ -1,18 +1,5 @@
-import {Logger, SfdxError} from '@salesforce/core';
-import {multiInject} from 'inversify';
-import {Container, Services} from '../ioc.config';
 import {Rule} from '../types';
-import {RuleResultRecombinator} from './RuleResultRecombinator';
-import {RuleEngine} from './services/RuleEngine';
-import * as PrettyPrinter from './util/PrettyPrinter';
-
-export enum RULE_FILTER_TYPE {
-	RULENAME,
-	CATEGORY,
-	RULESET,
-	LANGUAGE,
-	SOURCEPACKAGE
-}
+import {RuleFilter} from './RuleFilter';
 
 export enum OUTPUT_FORMAT {
 	XML = 'xml',
@@ -21,122 +8,10 @@ export enum OUTPUT_FORMAT {
 	TABLE = 'table'
 }
 
-export class RuleFilter {
-	readonly filterType: RULE_FILTER_TYPE;
-	readonly filterValues: ReadonlyArray<string>;
+export interface RuleManager {
+	init(): Promise<void>;
 
-	constructor(filterType: RULE_FILTER_TYPE, filterValues: string[]) {
-		this.filterType = filterType;
-		this.filterValues = filterValues;
-	}
-}
+	getRulesMatchingCriteria(filters: RuleFilter[]): Promise<Rule[]>;
 
-export class RuleManager {
-	public static async create(): Promise<RuleManager> {
-		const engines = Container.getAll<RuleEngine>(Services.RuleEngine);
-		const manager = new RuleManager(engines);
-		await manager.init();
-		return manager;
-	}
-
-	private logger: Logger;
-	private readonly engines: RuleEngine[] = [];
-
-
-	constructor(@multiInject("RuleEngine") engines: RuleEngine[]) {
-		this.engines = engines;
-	}
-
-	protected async init(): Promise<void> {
-		this.logger = await Logger.child('RuleManager');
-		for (const e of this.engines) {
-			await e.init();
-		}
-	}
-
-	public async getRulesMatchingCriteria(filters: RuleFilter[]): Promise<Rule[]> {
-		this.logger.trace(`Fetching rules that match the criteria ${PrettyPrinter.stringifyRuleFilters(filters)}`);
-
-		try {
-			const allRules = await this.getAllRules();
-			const rulesThatMatchCriteria = allRules.filter(rule => this.ruleSatisfiesFilterConstraints(rule, filters));
-			this.logger.trace(`Rules that match the criteria: ${PrettyPrinter.stringifyRules(rulesThatMatchCriteria)}`);
-			return rulesThatMatchCriteria;
-		} catch (e) {
-			throw new SfdxError(e.message || e);
-		}
-	}
-
-	public async runRulesMatchingCriteria(filters: RuleFilter[], target: string[] | string, format: OUTPUT_FORMAT): Promise<string> {
-		// If target is a string, it means it's an alias for an org, instead of a bunch of local file paths. We can't handle
-		// running rules against an org yet, so we'll just throw an error for now.
-		if (typeof target === 'string') {
-			throw new SfdxError('Running rules against orgs is not yet supported');
-		}
-		const ps = this.engines.map(e => e.run(filters, target));
-		const [results] = await Promise.all(ps);
-		this.logger.trace(`Received rule violations: ${results}`);
-
-		// Once all of the rules finish running, we'll need to combine their results into a single set of the desired type,
-		// which we can then return.
-		this.logger.trace(`Recombining results into requested format ${format}`);
-		return RuleResultRecombinator.recombineAndReformatResults([results], format);
-	}
-
-	private async getAllRules(): Promise<Rule[]> {
-		this.logger.trace('Getting all rules.');
-
-		const ps = this.engines.map(e => e.getAll());
-		const [rules]: Rule[][] = await Promise.all(ps);
-		return [...rules];
-	}
-
-	private ruleSatisfiesFilterConstraints(rule: Rule, filters: RuleFilter[]): boolean {
-		// If no filters were provided, then the rule is vacuously acceptable and we can just return true.
-		if (filters == null || filters.length === 0) {
-			return true;
-		}
-
-		// Otherwise, we'll iterate over all provided criteria and make sure that the rule satisfies them.
-		for (const filter of filters) {
-			const filterType = filter.filterType;
-			const filterValues = filter.filterValues;
-
-			// Which property of the rule we're testing against depends on this filter's type.
-			let ruleValues = null;
-			switch (filterType) {
-				case RULE_FILTER_TYPE.CATEGORY:
-					ruleValues = rule.categories;
-					break;
-				case RULE_FILTER_TYPE.RULESET:
-					ruleValues = rule.rulesets;
-					break;
-				case RULE_FILTER_TYPE.LANGUAGE:
-					ruleValues = rule.languages;
-					break;
-				case RULE_FILTER_TYPE.RULENAME:
-					// Rules only have one name, so we'll just turn that name into a singleton list so we can compare names the
-					// same way we compare everything else.
-					ruleValues = [rule.name];
-					break;
-				case RULE_FILTER_TYPE.SOURCEPACKAGE:
-					// Rules also only have one source package, so we'll turn it into a singleton list just like we do with 'name'.
-					ruleValues = [rule.sourcepackage];
-					break;
-			}
-
-			// For each filter, one of the values it specifies as acceptable must be present in the rule's corresponding list.
-			// e.g., if the user specified one or more categories, the rule must be a member of at least one of those categories.
-			if (filterValues.length > 0 && !this.listContentsOverlap(filterValues, ruleValues)) {
-				return false;
-			}
-		}
-		// If we're at this point, it's because we looped through all of the filter criteria without finding a single one that
-		// wasn't satisfied, which means the rule is good.
-		return true;
-	}
-
-	private listContentsOverlap<T>(list1: ReadonlyArray<T>, list2: T[]): boolean {
-		return list1.some(x => list2.includes(x));
-	}
+	runRulesMatchingCriteria(filters: RuleFilter[], target: string[] | string, format: OUTPUT_FORMAT): Promise<string>;
 }

--- a/src/lib/RulePathManager.ts
+++ b/src/lib/RulePathManager.ts
@@ -1,0 +1,14 @@
+export interface RulePathManager {
+	init(): Promise<void>;
+
+	addPathsForLanguage(language: string, paths: string[]): Promise<string[]>;
+
+	getAllPaths(): Promise<string[]>;
+
+	getMatchingPaths(paths: string[]): Promise<string[]>;
+
+	removePaths(paths: string[]): Promise<string[]>;
+
+	getRulePathEntries(engine: string): Promise<Map<string, Set<string>>>;
+}
+

--- a/src/lib/RuleResultRecombinator.ts
+++ b/src/lib/RuleResultRecombinator.ts
@@ -99,7 +99,8 @@ export class RuleResultRecombinator {
 			const violations = fileElement.elements;
 			for (const violation of violations) {
 				const attrs = violation.attributes;
-				// The error message for the violation is a 'text' Element below it.
+				// The error message for the violation is a 'text' Element below it. And since we are creating
+				// CSVs, make sure we escape any commas in our violation messages.  Just replace with semi-colon.
 				const msg = violation.elements[0].text.trim().replace(",", ";");
 				const row = [++problemCount, fileName, attrs.priority, attrs.beginline, msg, attrs.ruleset, attrs.rule, engine];
 				results += '"' + row.join('","') + '"\n';

--- a/src/lib/eslint/ESLintEngine.ts
+++ b/src/lib/eslint/ESLintEngine.ts
@@ -1,5 +1,5 @@
 import {Logger, SfdxError} from '@salesforce/core';
-import {Catalog, NamedPaths, Rule} from '../../types';
+import {Catalog, PathGroup, Rule} from '../../types';
 import {RuleEngine} from '../services/RuleEngine';
 
 export class ESLintEngine implements RuleEngine {
@@ -18,7 +18,9 @@ export class ESLintEngine implements RuleEngine {
 	}
 
 	public async init(): Promise<void> {
-		if (this.initialized) return;
+		if (this.initialized) {
+			return;
+		}
 
 		this.logger = await Logger.child(this.getName());
 
@@ -35,7 +37,7 @@ export class ESLintEngine implements RuleEngine {
 		return Promise.resolve([]);
 	}
 
-	public async run(paths: NamedPaths[], target: string[]): Promise<string> {
+	public async run(paths: PathGroup[], target: string[]): Promise<string> {
 		this.logger.trace(`About to run eslint rules. Target count: ${target.length}, filter count: ${paths.length}`);
 		try {
 			/*

--- a/src/lib/pmd/OutputProcessor.ts
+++ b/src/lib/pmd/OutputProcessor.ts
@@ -18,7 +18,9 @@ export class OutputProcessor extends AsyncCreatable {
 	private initialized: boolean;
 
 	protected async init(): Promise<void> {
-		if (this.initialized) return;
+		if (this.initialized) {
+			return;
+		}
 
 		this.logger = await Logger.child('OutputProcessor');
 		this.messageLogger = await Logger.child('MessageLog');

--- a/src/lib/pmd/OutputProcessor.ts
+++ b/src/lib/pmd/OutputProcessor.ts
@@ -1,21 +1,12 @@
-import {Logger, Messages, LoggerLevel} from '@salesforce/core';
+import {Logger, LoggerLevel, Messages} from '@salesforce/core';
 import {AsyncCreatable} from '@salesforce/kit';
+import {RuleEvent} from '../../types';
 import {uxEvents} from '../ScannerEvents';
 
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/sfdx-scanner', 'EventKeyTemplates');
 const genericMessageKey = 'error.external.genericErrorMessage';
-
-export type PmdCatalogEvent = {
-	messageKey: string;
-	args: string[];
-	type: string;
-	internalLog: string;
-	handler: string;
-	verbose: boolean;
-	time: number;
-};
 
 /**
  * Helps with processing output from PmdCatalog java module and converting messages into usable events
@@ -24,12 +15,17 @@ export class OutputProcessor extends AsyncCreatable {
 
 	private logger!: Logger;
 	private messageLogger!: Logger;
+	private initialized: boolean;
 
 	protected async init(): Promise<void> {
+		if (this.initialized) return;
+
 		this.logger = await Logger.child('OutputProcessor');
 		this.messageLogger = await Logger.child('MessageLog');
 		// this.logger.setLevel(LoggerLevel.TRACE);
 		this.messageLogger.setLevel(LoggerLevel.TRACE);
+
+		this.initialized = true;
 	}
 
 	// We want to find any events that were dumped into stdout or stderr and turn them back into events that can be thrown.
@@ -42,14 +38,14 @@ export class OutputProcessor extends AsyncCreatable {
 			return;
 		}
 
-		const outEvents: PmdCatalogEvent[] = this.getEventsFromString(out);
+		const outEvents: RuleEvent[] = this.getEventsFromString(out);
 		this.logger.trace(`Total count of events found: ${outEvents.length}`);
 
 		this.emitEvents(outEvents);
 	}
 
 	// TODO: consider moving all message creation logic to a separate place and making this method private
-	public emitEvents(outEvents: PmdCatalogEvent[]): void {
+	public emitEvents(outEvents: RuleEvent[]): void {
 		this.logger.trace('About to order and emit');
 		// If list is empty, we can just be done now.
 		if (outEvents.length == 0) {
@@ -75,8 +71,8 @@ export class OutputProcessor extends AsyncCreatable {
 		uxEvents.emit(eventType, messages.getMessage(messageKey, args));
 	}
 
-	private getEventsFromString(str: string): PmdCatalogEvent[] {
-		const events: PmdCatalogEvent[] = [];
+	private getEventsFromString(str: string): RuleEvent[] {
+		const events: RuleEvent[] = [];
 
 		const regex = /SFDX-START(.*)SFDX-END/g;
 		const headerLength = 'SFDX-START'.length;
@@ -93,7 +89,7 @@ export class OutputProcessor extends AsyncCreatable {
 		return events;
 	}
 
-	private logEvent(event: PmdCatalogEvent): void {
+	private logEvent(event: RuleEvent): void {
 		const message = `Event: messageKey = ${event.messageKey}, args = ${event.args}, type = ${event.type}, handler = ${event.handler}, verbose = ${event.verbose}, time = ${event.time}, internalLog = ${event.internalLog}`;
 		this.messageLogger.info(message);
 	}

--- a/src/lib/pmd/PmdCatalogWrapper.ts
+++ b/src/lib/pmd/PmdCatalogWrapper.ts
@@ -23,7 +23,9 @@ export class PmdCatalogWrapper extends PmdSupport {
 	private initialized: boolean;
 
 	protected async init(): Promise<void> {
-		if (this.initialized) return;
+		if (this.initialized) {
+			return;
+		}
 
 		this.outputProcessor = await OutputProcessor.create({});
 		this.logger = await Logger.child('PmdCatalogWrapper');

--- a/src/lib/pmd/PmdEngine.ts
+++ b/src/lib/pmd/PmdEngine.ts
@@ -1,5 +1,5 @@
 import {Logger, SfdxError} from '@salesforce/core';
-import {Rule, Catalog, NamedPaths} from '../../types';
+import {Rule, Catalog, PathGroup} from '../../types';
 import {RuleEngine} from '../services/RuleEngine';
 import {PmdCatalogWrapper} from './PmdCatalogWrapper';
 import PmdWrapper from './PmdWrapper';
@@ -21,7 +21,9 @@ export class PmdEngine implements RuleEngine {
 	}
 
 	public async init(): Promise<void> {
-		if (this.initialized) return;
+		if (this.initialized) {
+			return;
+		}
 
 		this.pmdCatalogWrapper = await PmdCatalogWrapper.create({});
 		this.logger = await Logger.child(this.getName());
@@ -40,7 +42,7 @@ export class PmdEngine implements RuleEngine {
 		return catalog.rules;
 	}
 
-	public async run(paths: NamedPaths[], target: string[]): Promise<string> {
+	public async run(paths: PathGroup[], target: string[]): Promise<string> {
 		this.logger.trace(`About to run PMD rules. Targets: ${target.length}, named paths: ${paths.length}`);
 		try {
 			// TODO: Weird translation to next layer. target=path and path=rule path. Consider renaming

--- a/src/lib/pmd/PmdSupport.ts
+++ b/src/lib/pmd/PmdSupport.ts
@@ -1,9 +1,9 @@
 import childProcess = require('child_process');
-import {ChildProcessWithoutNullStreams} from 'child_process';
-import {AsyncCreatable} from '@salesforce/kit';
-import {CustomRulePathManager} from '../CustomRulePathManager';
-import {PmdEngine} from './PmdEngine';
 import path = require('path');
+import {AsyncCreatable} from '@salesforce/kit';
+import {ChildProcessWithoutNullStreams} from 'child_process';
+import {Controller} from '../../ioc.config';
+import {PmdEngine} from './PmdEngine';
 
 export const PMD_VERSION = '6.22.0';
 // Here, current dir __dirname = <base_dir>/sfdx-scanner/src/lib/pmd
@@ -55,7 +55,7 @@ export abstract class PmdSupport extends AsyncCreatable {
 	}
 
 	protected async getRulePathEntries(): Promise<Map<string, Set<string>>> {
-		const customRulePathManager = await CustomRulePathManager.create();
+		const customRulePathManager = await Controller.createRulePathManager();
 		return await customRulePathManager.getRulePathEntries(PmdEngine.NAME);
 	}
 }

--- a/src/lib/pmd/PmdWrapper.ts
+++ b/src/lib/pmd/PmdWrapper.ts
@@ -26,9 +26,14 @@ export default class PmdWrapper extends PmdSupport {
 	reportFormat: Format;
 	reportFile: string;
 	logger: Logger; // TODO: Add relevant trace log lines
+	private initialized: boolean;
 
 	protected async init(): Promise<void> {
+		if (this.initialized) return;
+
 		this.logger = await Logger.child('PmdWrapper');
+
+		this.initialized = true;
 	}
 
 	public static async execute(path: string, rules: string, reportFormat?: Format, reportFile?: string): Promise<[boolean, string]> {

--- a/src/lib/pmd/PmdWrapper.ts
+++ b/src/lib/pmd/PmdWrapper.ts
@@ -29,7 +29,9 @@ export default class PmdWrapper extends PmdSupport {
 	private initialized: boolean;
 
 	protected async init(): Promise<void> {
-		if (this.initialized) return;
+		if (this.initialized) {
+			return;
+		}
 
 		this.logger = await Logger.child('PmdWrapper');
 

--- a/src/lib/services/LocalCatalog.ts
+++ b/src/lib/services/LocalCatalog.ts
@@ -1,0 +1,212 @@
+import {Logger, SfdxError} from '@salesforce/core';
+import * as path from 'path';
+import {injectable, injectAll} from 'tsyringe';
+import {CATALOG_JSON, SFDX_SCANNER_PATH} from '../../Constants';
+import {Catalog, NamedPaths, Rule, RuleEvent} from '../../types';
+import {OutputProcessor} from '../pmd/OutputProcessor';
+import {FilterType, RuleFilter} from '../RuleFilter';
+import {FileHandler} from '../util/FileHandler';
+import * as PrettyPrinter from '../util/PrettyPrinter';
+import {RuleCatalog} from './RuleCatalog';
+import {RuleEngine} from './RuleEngine';
+
+
+@injectable()
+export default class LocalCatalog implements RuleCatalog {
+
+	private logger: Logger;
+	private outputProcessor: OutputProcessor;
+	private catalog: Catalog;
+
+	private readonly engines: RuleEngine[];
+	private initialized: boolean;
+
+	constructor(@injectAll("RuleEngine") engines?: RuleEngine[]) {
+		this.engines = engines;
+	}
+
+	async init(): Promise<void> {
+		if (this.initialized) return;
+
+		await Promise.all(this.engines.map(e => e.init()));
+		this.logger = await Logger.child("LocalCatalog"); // TODO should be an injected service
+		this.outputProcessor = await OutputProcessor.create({}); // TODO should be an injected service
+		this.catalog = await this.getCatalog();
+
+		this.initialized = true;
+	}
+
+	/**
+	 * Accepts a set of filter criteria, and returns the paths of all categories and rulesets matching those criteria.
+	 * @param {RuleFilter[]} filters
+	 */
+	public async getNamedPathsMatchingFilters(filters: RuleFilter[]): Promise<NamedPaths[]> {
+		this.logger.trace(`Getting paths that match filters ${PrettyPrinter.stringifyRuleFilters(filters)}`);
+
+		// If we weren't given any filters, that should be treated as implicitly including all rules. Since PMD defines its
+		// rules in category files, we should just return all paths corresponding to a category.
+		if (!filters || filters.length === 0) {
+			return this.getAllCategoryPaths();
+		}
+		// If we actually do have filters, we'll want to iterate over all of them and see which ones
+		// correspond to a path in the catalog.
+		// Since categories and rulesets are both just NamedPaths, we can put both types of
+		// path into a single array and return that.
+		const foundPaths: NamedPaths[] = [];
+		for (const filter of filters) {
+			// For now, we only care about filters that act on rulesets and categories.
+			const type = filter.filterType;
+			if (type === FilterType.CATEGORY || type === FilterType.RULESET) {
+				// We only want to evaluate category filters against category names, and ruleset filters against ruleset names.
+				const namedPaths: NamedPaths[] = type === FilterType.CATEGORY ? this.catalog.categories : this.catalog.rulesets;
+				for (const value of filter.filterValues) {
+					// If there's a matching category/ruleset for the specified filter, we'll need to add all the
+					// corresponding paths to our list.
+					const np = namedPaths.find(np => np.name === value);
+					foundPaths.push(np);
+				}
+			}
+		}
+		return foundPaths;
+	}
+
+	async getRulesMatchingFilters(filters: RuleFilter[]): Promise<Rule[]> {
+		this.logger.trace(`Fetching rules that match the criteria ${PrettyPrinter.stringifyRuleFilters(filters)}`);
+
+		try {
+			const rulesThatMatchCriteria = this.catalog.rules.filter(rule => this.ruleSatisfiesFilterConstraints(rule, filters));
+			this.logger.trace(`Rules that match the criteria: ${PrettyPrinter.stringifyRules(rulesThatMatchCriteria)}`);
+			return rulesThatMatchCriteria;
+		} catch (e) {
+			throw new SfdxError(e.message || e);
+		}
+	}
+
+	private getAllCategoryPaths(): NamedPaths[] {
+		// Since this method is run when no filter criteria are provided, it might be nice to provide a level of visibility
+		// into all of the categories that were run. So before returning the category paths, loop through them
+		// and emit events for each path.
+
+		const events: RuleEvent[] = [];
+		this.catalog.categories.forEach(np => {
+			// For each path, build an event indicating that the path was implicitly included.
+			for (const p of np.paths) {
+				events.push({
+					messageKey: 'info.pmdJarImplicitlyRun',
+					args: [np.name, p],
+					type: 'INFO',
+					handler: 'UX',
+					verbose: true,
+					time: Date.now()
+				});
+			}
+		});
+
+		this.outputProcessor.emitEvents(events);
+		return this.catalog.categories;
+	}
+
+	private static getCatalogName(): string {
+		// For test mocking purposes, we allow for env variables to override the default catalog name.
+		return process.env.CATALOG_JSON || CATALOG_JSON;
+	}
+
+	private static getCatalogPath(): string {
+		return path.join(SFDX_SCANNER_PATH, LocalCatalog.getCatalogName());
+	}
+
+	private static async readCatalogJson(): Promise<Catalog> {
+		const rawCatalog = await new FileHandler().readFile(LocalCatalog.getCatalogPath());
+		return JSON.parse(rawCatalog);
+	}
+
+	private static async writeCatalogJson(content: Catalog): Promise<void> {
+		return new FileHandler().writeFile(LocalCatalog.getCatalogPath(), JSON.stringify(content));
+	}
+
+	private async getCatalog(): Promise<Catalog> {
+		// If we haven't read in a catalog yet, do so now.
+		if (!this.catalog) {
+			this.logger.trace(`Populating Catalog JSON.`);
+			await this.rebuildCatalogIfNecessary();
+			this.catalog = await LocalCatalog.readCatalogJson();
+		}
+		return Promise.resolve(this.catalog);
+	}
+
+	private async rebuildCatalogIfNecessary(): Promise<[boolean, string]> {
+		// First, check whether the catalog is stale. If it's not, we don't even need to do anything.
+		if (!LocalCatalog.catalogIsStale()) {
+			return new Promise<[boolean, string]>(() => [false, 'no action taken']);
+		}
+
+		return this.rebuildCatalog();
+	}
+
+	private async rebuildCatalog(): Promise<[boolean, string]> {
+		this.catalog = {rulesets:[], categories:[], rules: []};
+		for(const engine of this.engines) {
+			const catalog: Catalog = await engine.getCatalog();
+			catalog.rulesets.forEach(rs => {rs.engine = engine.getName(); this.catalog.rulesets.push(rs);});
+			catalog.categories.forEach(c => {c.engine = engine.getName(); this.catalog.categories.push(c);});
+			catalog.rules.forEach(r => {r.engine = engine.getName(); this.catalog.rules.push(r);});
+		}
+		await LocalCatalog.writeCatalogJson(this.catalog);
+		return Promise.resolve([true, 'rebuilt catalog']);
+	}
+
+	private static catalogIsStale(): boolean {
+		// TODO: Pretty soon, we'll want to add sophisticated logic to determine whether the catalog is stale. But for now,
+		//  we'll just return true so we always rebuild the catalog.
+		return true;
+	}
+
+	private ruleSatisfiesFilterConstraints(rule: Rule, filters: RuleFilter[]): boolean {
+		// If no filters were provided, then the rule is vacuously acceptable and we can just return true.
+		if (filters == null || filters.length === 0) {
+			return true;
+		}
+
+		// Otherwise, we'll iterate over all provided criteria and make sure that the rule satisfies them.
+		for (const filter of filters) {
+			const filterType = filter.filterType;
+			const filterValues = filter.filterValues;
+
+			// Which property of the rule we're testing against depends on this filter's type.
+			let ruleValues = null;
+			switch (filterType) {
+				case FilterType.CATEGORY:
+					ruleValues = rule.categories;
+					break;
+				case FilterType.RULESET:
+					ruleValues = rule.rulesets;
+					break;
+				case FilterType.LANGUAGE:
+					ruleValues = rule.languages;
+					break;
+				case FilterType.RULENAME:
+					// Rules only have one name, so we'll just turn that name into a singleton list so we can compare names the
+					// same way we compare everything else.
+					ruleValues = [rule.name];
+					break;
+				case FilterType.SOURCEPACKAGE:
+					// Rules also only have one source package, so we'll turn it into a singleton list just like we do with 'name'.
+					ruleValues = [rule.sourcepackage];
+					break;
+			}
+
+			// For each filter, one of the values it specifies as acceptable must be present in the rule's corresponding list.
+			// e.g., if the user specified one or more categories, the rule must be a member of at least one of those categories.
+			if (filterValues.length > 0 && !this.listContentsOverlap(filterValues, ruleValues)) {
+				return false;
+			}
+		}
+		// If we're at this point, it's because we looped through all of the filter criteria without finding a single one that
+		// wasn't satisfied, which means the rule is good.
+		return true;
+	}
+
+	private listContentsOverlap<T>(list1: ReadonlyArray<T>, list2: T[]): boolean {
+		return list1.some(x => list2.includes(x));
+	}
+}

--- a/src/lib/services/RuleCatalog.ts
+++ b/src/lib/services/RuleCatalog.ts
@@ -1,4 +1,4 @@
-import {NamedPaths, Rule} from '../../types';
+import {PathGroup, Rule} from '../../types';
 import {RuleFilter} from '../RuleFilter';
 
 export interface RuleCatalog {
@@ -11,7 +11,7 @@ export interface RuleCatalog {
 	 * Accepts a set of filter criteria, and returns the paths of all categories and rulesets matching those criteria.
 	 * @param {RuleFilter[]} filters
 	 */
-	getNamedPathsMatchingFilters(filters: RuleFilter[]): Promise<NamedPaths[]>;
+	getNamedPathsMatchingFilters(filters: RuleFilter[]): Promise<PathGroup[]>;
 
 	getRulesMatchingFilters(filters: RuleFilter[]): Promise<Rule[]>;
 }

--- a/src/lib/services/RuleCatalog.ts
+++ b/src/lib/services/RuleCatalog.ts
@@ -1,0 +1,17 @@
+import {NamedPaths, Rule} from '../../types';
+import {RuleFilter} from '../RuleFilter';
+
+export interface RuleCatalog {
+	/**
+	 * Asynchronous construction
+	 */
+	init(): Promise<void>;
+
+	/**
+	 * Accepts a set of filter criteria, and returns the paths of all categories and rulesets matching those criteria.
+	 * @param {RuleFilter[]} filters
+	 */
+	getNamedPathsMatchingFilters(filters: RuleFilter[]): Promise<NamedPaths[]>;
+
+	getRulesMatchingFilters(filters: RuleFilter[]): Promise<Rule[]>;
+}

--- a/src/lib/services/RuleEngine.ts
+++ b/src/lib/services/RuleEngine.ts
@@ -1,14 +1,16 @@
-import {Rule} from '../../types';
-import {RuleFilter} from '../RuleManager';
+import {Rule, Catalog, NamedPaths} from '../../types';
 
 export interface RuleEngine {
 	getName(): string;
 
+	// TODO deprecate this.  Engines don't provide rules directly.  They provide catalogs.
 	getAll(): Promise<Rule[]>;
 
-	run(filters: RuleFilter[], target: string[] | string): Promise<string>;
+	getCatalog(): Promise<Catalog>;
 
-	init(): Promise<RuleEngine>;
+	run(paths: NamedPaths[], target: string[] | string): Promise<string>;
+
+	init(): Promise<void>;
 
 	matchPath(path: string): boolean;
 }

--- a/src/lib/services/RuleEngine.ts
+++ b/src/lib/services/RuleEngine.ts
@@ -1,4 +1,4 @@
-import {Rule, Catalog, NamedPaths} from '../../types';
+import {Rule, Catalog, PathGroup} from '../../types';
 
 export interface RuleEngine {
 	getName(): string;
@@ -8,7 +8,7 @@ export interface RuleEngine {
 
 	getCatalog(): Promise<Catalog>;
 
-	run(paths: NamedPaths[], target: string[] | string): Promise<string>;
+	run(paths: PathGroup[], target: string[] | string): Promise<string>;
 
 	init(): Promise<void>;
 

--- a/src/lib/util/Config.ts
+++ b/src/lib/util/Config.ts
@@ -15,12 +15,17 @@ export class Config extends AsyncCreatable {
 	configContent!: JSON;
 	fileHandler!: FileHandler;
 	private logger!: Logger;
+	private initialized: boolean;
 
 	protected async init(): Promise<void> {
+		if (this.initialized) return;
+
 		this.fileHandler = new FileHandler();
 		this.logger = await Logger.child('Config');
 		this.logger.setLevel(LoggerLevel.TRACE);
 		await this.initializeConfig();
+
+		this.initialized = true;
 	}
 
 	public async setJavaHome(value: string): Promise<void> {

--- a/src/lib/util/Config.ts
+++ b/src/lib/util/Config.ts
@@ -18,7 +18,9 @@ export class Config extends AsyncCreatable {
 	private initialized: boolean;
 
 	protected async init(): Promise<void> {
-		if (this.initialized) return;
+		if (this.initialized) {
+			return;
+		}
 
 		this.fileHandler = new FileHandler();
 		this.logger = await Logger.child('Config');

--- a/src/lib/util/PrettyPrinter.ts
+++ b/src/lib/util/PrettyPrinter.ts
@@ -1,4 +1,4 @@
-import {RuleFilter} from '../RuleManager';
+import {RuleFilter} from '../RuleFilter';
 import {Rule} from '../../types';
 
 /**
@@ -55,7 +55,7 @@ export function stringifyRuleFilters(filters: RuleFilter[]): string {
  * @param rule Rule to stringify
  */
 export function stringifyRule(rule: Rule): string {
-	return `Rule[name: ${rule.name}, description: ${rule.description}, categories: ${rule.categories.join(',')}, rulesets: ${rule.rulesets.join(',')}, languages: ${rule.languages.join(',')}, sourcepackage: ${rule.sourcepackage}]`;
+	return `Rule[name: ${rule.name}, description: ${rule.description}, categories: ${rule.categories.join(',')}, rulesets: ${rule.rulesets.join(',')}, languages: ${rule.languages.join(',')}, engine: ${rule.engine}, sourcepackage: ${rule.sourcepackage}]`;
 }
 
 /**

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,8 +1,31 @@
-export interface Rule {
+export type Rule = {
+	engine: string;
+	sourcepackage: string;
 	name: string;
 	description: string;
-	sourcepackage: string;
 	categories: string[];
 	rulesets: string[];
 	languages: string[];
+}
+
+export type NamedPaths = {
+	engine: string;
+	name: string;
+	paths: string[];
+}
+
+export type Catalog = {
+	rules: Rule[];
+	categories: NamedPaths[];
+	rulesets: NamedPaths[];
+};
+
+export type RuleEvent = {
+	messageKey: string;
+	args: string[];
+	type: string;
+	handler: string;
+	verbose: boolean;
+	time: number;
+	internalLog?: string;
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -8,7 +8,7 @@ export type Rule = {
 	languages: string[];
 }
 
-export type NamedPaths = {
+export type PathGroup = {
 	engine: string;
 	name: string;
 	paths: string[];
@@ -16,8 +16,8 @@ export type NamedPaths = {
 
 export type Catalog = {
 	rules: Rule[];
-	categories: NamedPaths[];
-	rulesets: NamedPaths[];
+	categories: PathGroup[];
+	rulesets: PathGroup[];
 };
 
 export type RuleEvent = {

--- a/test/catalog-fixtures/DefaultPmdCatalogFixture.json
+++ b/test/catalog-fixtures/DefaultPmdCatalogFixture.json
@@ -1,1144 +1,1244 @@
 {
-	"rulesets": {
-		"Empty Code": [
-			"rulesets\/apex\/empty.xml"
-		],
-		"quickstart": [
-			"rulesets\/apex\/quickstart.xml"
-		],
-		"Basic Ecmascript": [
-			"rulesets\/ecmascript\/basic.xml"
-		],
-		"ApexUnit": [
-			"rulesets\/apex\/apexunit.xml"
-		],
-		"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex": [
-			"rulesets\/apex\/ruleset.xml"
-		],
-		"Metrics temporary ruleset": [
-			"rulesets\/apex\/metrics.xml"
-		],
-		"Security": [
-			"rulesets\/apex\/security.xml"
-		],
-		"Complexity": [
-			"rulesets\/apex\/complexity.xml"
-		],
-		"Braces": [
-			"rulesets\/ecmascript\/braces.xml",
-			"rulesets\/apex\/braces.xml"
-		],
-		"Style": [
-			"rulesets\/apex\/style.xml"
-		],
-		"Controversial Ecmascript": [
-			"rulesets\/ecmascript\/controversial.xml"
-		],
-		"Performance": [
-			"rulesets\/apex\/performance.xml"
-		],
-		"Unnecessary": [
-			"rulesets\/ecmascript\/unnecessary.xml"
-		]
-	},
-	"rules": [
-		{
-			"rulesets": [
-				"Controversial Ecmascript"
-			],
-			"languages": [
-				"javascript"
-			],
-			"name": "AvoidWithStatement",
-			"description": "Avoid using with - it's bad news",
-			"categories": [
-				"Best Practices"
-			],
-			"message": "Avoid using with - it's bad news"
-		},
-		{
-			"rulesets": [
-				"Basic Ecmascript"
-			],
-			"languages": [
-				"javascript"
-			],
-			"name": "ConsistentReturn",
-			"description": "\nECMAScript does provide for return types on functions, and therefore there is no solid rule as to their usage.\nHowever, when a function does use returns they should all have a value, or all with no value.  Mixed return\nusage is likely a bug, or at best poor style.\n        ",
-			"categories": [
-				"Best Practices"
-			],
-			"message": "A function should not mix 'return' statements with and without a result."
-		},
-		{
-			"rulesets": [
-				"Basic Ecmascript"
-			],
-			"languages": [
-				"javascript"
-			],
-			"name": "GlobalVariable",
-			"description": "\nThis rule helps to avoid using accidently global variables by simply missing the \"var\" declaration.\nGlobal variables can lead to side-effects that are hard to debug.\n        ",
-			"categories": [
-				"Best Practices"
-			],
-			"message": "Avoid using global variables"
-		},
-		{
-			"rulesets": [
-				"Basic Ecmascript"
-			],
-			"languages": [
-				"javascript"
-			],
-			"name": "ScopeForInVariable",
-			"description": "\nA for-in loop in which the variable name is not explicitly scoped to the enclosing scope with the 'var' keyword can\nrefer to a variable in an enclosing scope outside the nearest enclosing scope.  This will overwrite the\nexisting value of the variable in the outer scope when the body of the for-in is evaluated.  When the for-in loop\nhas finished, the variable will contain the last value used in the for-in, and the original value from before\nthe for-in loop will be gone.  Since the for-in variable name is most likely intended to be a temporary name, it\nis better to explicitly scope the variable name to the nearest enclosing scope with 'var'.\n        ",
-			"categories": [
-				"Best Practices"
-			],
-			"message": "The for-in loop variable ''{0}'' should be explicitly scoped with 'var' to avoid pollution."
-		},
-		{
-			"rulesets": [
-				"Basic Ecmascript"
-			],
-			"languages": [
-				"javascript"
-			],
-			"name": "UseBaseWithParseInt",
-			"description": "\nThis rule checks for usages of parseInt. While the second parameter is optional and usually defaults\nto 10 (base\/radix is 10 for a decimal number), different implementations may behave differently.\nIt also improves readability, if the base is given.\n\nSee also: [parseInt()](https:\/\/developer.mozilla.org\/en-US\/docs\/Web\/JavaScript\/Reference\/Global_Objects\/parseInt)\n        ",
-			"categories": [
-				"Best Practices"
-			],
-			"message": "Always provide a base when using parseInt() functions"
-		},
-		{
-			"rulesets": [
-				"Basic Ecmascript"
-			],
-			"languages": [
-				"javascript"
-			],
-			"name": "AvoidTrailingComma",
-			"description": "\nThis rule helps improve code portability due to differences in browser treatment of trailing commas in object or array literals.\n        ",
-			"categories": [
-				"Error Prone"
-			],
-			"message": "Avoid trailing commas in object or array literals"
-		},
-		{
-			"rulesets": [
-				"Basic Ecmascript"
-			],
-			"languages": [
-				"javascript"
-			],
-			"name": "EqualComparison",
-			"description": "\nUsing == in condition may lead to unexpected results, as the variables are automatically casted to be of the\nsame type. The === operator avoids the casting.\n        ",
-			"categories": [
-				"Error Prone"
-			],
-			"message": "Use '==='\/'!==' to compare with true\/false or Numbers"
-		},
-		{
-			"rulesets": [
-				"Basic Ecmascript"
-			],
-			"languages": [
-				"javascript"
-			],
-			"name": "InnaccurateNumericLiteral",
-			"description": "\nThe numeric literal will have a different value at runtime, which can happen if you provide too much\nprecision in a floating point number.  This may result in numeric calculations being in error.\n        ",
-			"categories": [
-				"Error Prone"
-			],
-			"message": "The numeric literal ''{0}'' will have at different value at runtime."
-		},
-		{
-			"rulesets": [
-				"Basic Ecmascript"
-			],
-			"languages": [
-				"javascript"
-			],
-			"name": "AssignmentInOperand",
-			"description": "\nAvoid assignments in operands; this can make code more complicated and harder to read.  This is sometime\nindicative of the bug where the assignment operator '=' was used instead of the equality operator '=='.\n        ",
-			"categories": [
-				"Code Style"
-			],
-			"message": "Avoid assignments in operands"
-		},
-		{
-			"rulesets": [
-				"Braces"
-			],
-			"languages": [
-				"javascript"
-			],
-			"name": "ForLoopsMustUseBraces",
-			"description": "\nAvoid using 'for' statements without using curly braces.\n        ",
-			"categories": [
-				"Code Style"
-			],
-			"message": "Avoid using 'for' statements without curly braces"
-		},
-		{
-			"rulesets": [
-				"Braces"
-			],
-			"languages": [
-				"javascript"
-			],
-			"name": "IfElseStmtsMustUseBraces",
-			"description": "\nAvoid using if..else statements without using curly braces.\n        ",
-			"categories": [
-				"Code Style"
-			],
-			"message": "Avoid using 'if...else' statements without curly braces"
-		},
-		{
-			"rulesets": [
-				"Braces"
-			],
-			"languages": [
-				"javascript"
-			],
-			"name": "IfStmtsMustUseBraces",
-			"description": "\nAvoid using if statements without using curly braces.\n        ",
-			"categories": [
-				"Code Style"
-			],
-			"message": "Avoid using if statements without curly braces"
-		},
-		{
-			"rulesets": [
-				"Unnecessary"
-			],
-			"languages": [
-				"javascript"
-			],
-			"name": "NoElseReturn",
-			"description": "\nThe else block in a if-else-construct is unnecessary if the `if` block contains a return.\nThen the content of the else block can be put outside.\n\nSee also: <http:\/\/eslint.org\/docs\/rules\/no-else-return>\n        ",
-			"categories": [
-				"Code Style"
-			],
-			"message": "The else block is unnecessary"
-		},
-		{
-			"rulesets": [
-				"Unnecessary"
-			],
-			"languages": [
-				"javascript"
-			],
-			"name": "UnnecessaryBlock",
-			"description": "\nAn unnecessary Block is present.  Such Blocks are often used in other languages to\nintroduce a new variable scope.  Blocks do not behave like this in ECMAScipt, and using them can\nbe misleading.  Considering removing this unnecessary Block.\n        ",
-			"categories": [
-				"Code Style"
-			],
-			"message": "Unnecessary block."
-		},
-		{
-			"rulesets": [
-				"Unnecessary"
-			],
-			"languages": [
-				"javascript"
-			],
-			"name": "UnnecessaryParentheses",
-			"description": "Unnecessary parentheses should be removed.",
-			"categories": [
-				"Code Style"
-			],
-			"message": "Unnecessary parentheses."
-		},
-		{
-			"rulesets": [
-				"Basic Ecmascript"
-			],
-			"languages": [
-				"javascript"
-			],
-			"name": "UnreachableCode",
-			"description": "\nA 'return', 'break', 'continue', or 'throw' statement should be the last in a block. Statements after these\nwill never execute.  This is a bug, or extremely poor style.\n        ",
-			"categories": [
-				"Code Style"
-			],
-			"message": "A ''return'', ''break'', ''continue'', or ''throw'' statement should be the last in a block."
-		},
-		{
-			"rulesets": [
-				"Braces"
-			],
-			"languages": [
-				"javascript"
-			],
-			"name": "WhileLoopsMustUseBraces",
-			"description": "\nAvoid using 'while' statements without using curly braces.\n        ",
-			"categories": [
-				"Code Style"
-			],
-			"message": "Avoid using 'while' statements without curly braces"
-		},
-		{
-			"rulesets": [],
-			"languages": [
-				"apex"
-			],
-			"name": "ApexAssertionsShouldIncludeMessage",
-			"description": "\nThe second parameter of System.assert\/third parameter of System.assertEquals\/System.assertNotEquals is a message.\nHaving a second\/third parameter provides more information and makes it easier to debug the test failure and\nimproves the readability of test output.\n        ",
-			"categories": [
-				"Best Practices"
-			],
-			"message": "Apex test assert statement should make use of the message parameter."
-		},
-		{
-			"rulesets": [
-				"ApexUnit",
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "ApexUnitTestClassShouldHaveAsserts",
-			"description": "\nApex unit tests should include at least one assertion.  This makes the tests more robust, and using assert\nwith messages provide the developer a clearer idea of what the test does.\n        ",
-			"categories": [
-				"Best Practices"
-			],
-			"message": "Apex unit tests should System.assert() or assertEquals() or assertNotEquals()"
-		},
-		{
-			"rulesets": [],
-			"languages": [
-				"apex"
-			],
-			"name": "ApexUnitTestMethodShouldHaveIsTestAnnotation",
-			"description": "\nApex test methods should have @isTest annotation.\nAs testMethod keyword is deprecated, Salesforce advices to use @isTest annotation for test class\/methods.\n        ",
-			"categories": [
-				"Best Practices"
-			],
-			"message": "Apex test methods should have @isTest annotation."
-		},
-		{
-			"rulesets": [
-				"ApexUnit",
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "ApexUnitTestShouldNotUseSeeAllDataTrue",
-			"description": "\nApex unit tests should not use @isTest(seeAllData=true) because it opens up the existing database data for unexpected modification by tests.\n        ",
-			"categories": [
-				"Best Practices"
-			],
-			"message": "Apex unit tests should not use @isTest(seeAllData = true)"
-		},
-		{
-			"rulesets": [
-				"Style",
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "AvoidGlobalModifier",
-			"description": "\nGlobal classes should be avoided (especially in managed packages) as they can never be deleted or changed in signature. Always check twice if something needs to be global.\nMany interfaces (e.g. Batch) required global modifiers in the past but don't require this anymore. Don't lock yourself in.\n        ",
-			"categories": [
-				"Best Practices"
-			],
-			"message": "Avoid using global modifier"
-		},
-		{
-			"rulesets": [
-				"Style",
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "AvoidLogicInTrigger",
-			"description": "\nAs triggers do not allow methods like regular classes they are less flexible and suited to apply good encapsulation style.\nTherefore delegate the triggers work to a regular class (often called Trigger handler class).\n\nSee more here: <https:\/\/developer.salesforce.com\/page\/Trigger_Frameworks_and_Apex_Trigger_Best_Practices>\n        ",
-			"categories": [
-				"Best Practices"
-			],
-			"message": "Avoid logic in triggers"
-		},
-		{
-			"rulesets": [
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "DebugsShouldUseLoggingLevel",
-			"description": "\nThe first parameter of System.debug, when using the signature with two parameters, is a LoggingLevel enum.\n\nHaving the Logging Level specified provides a cleaner log, and improves readability of it.\n       ",
-			"categories": [
-				"Best Practices"
-			],
-			"message": "Calls to System.debug should specify a logging level."
-		},
-		{
-			"rulesets": [
-				"Performance",
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "AvoidDmlStatementsInLoops",
-			"description": "\nAvoid DML statements inside loops to avoid hitting the DML governor limit. Instead, try to batch up the data into a list and invoke your DML once on that list of data outside the loop.\n        ",
-			"categories": [
-				"Performance"
-			],
-			"message": "Avoid DML statements inside loops"
-		},
-		{
-			"rulesets": [
-				"Performance",
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "AvoidSoqlInLoops",
-			"description": "\nNew objects created within loops should be checked to see if they can created outside them and reused.\n        ",
-			"categories": [
-				"Performance"
-			],
-			"message": "Avoid Soql queries inside loops"
-		},
-		{
-			"rulesets": [
-				"Performance",
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "AvoidSoslInLoops",
-			"description": "\nSosl calls within loops can cause governor limit exceptions.\n        ",
-			"categories": [
-				"Performance"
-			],
-			"message": "Avoid Sosl queries inside loops"
-		},
-		{
-			"rulesets": [
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart",
-				"Security"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "ApexBadCrypto",
-			"description": "\nThe rule makes sure you are using randomly generated IVs and keys for `Crypto` calls.\nHard-wiring these values greatly compromises the security of encrypted data.\n        ",
-			"categories": [
-				"Security"
-			],
-			"message": "Apex classes should use random IV\/key"
-		},
-		{
-			"rulesets": [
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart",
-				"Security"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "ApexCRUDViolation",
-			"description": "\nThe rule validates you are checking for access permissions before a SOQL\/SOSL\/DML operation.\nSince Apex runs in system mode not having proper permissions checks results in escalation of \nprivilege and may produce runtime errors. This check forces you to handle such scenarios.\n        ",
-			"categories": [
-				"Security"
-			],
-			"message": "Validate CRUD permission before SOQL\/DML operation"
-		},
-		{
-			"rulesets": [
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart",
-				"Security"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "ApexCSRF",
-			"description": "\nCheck to avoid making DML operations in Apex class constructor\/init method. This prevents\nmodification of the database just by accessing a page.\n        ",
-			"categories": [
-				"Security"
-			],
-			"message": "Avoid making DML operations in Apex class constructor\/init method"
-		},
-		{
-			"rulesets": [
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart",
-				"Security"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "ApexDangerousMethods",
-			"description": "\nChecks against calling dangerous methods.\n\nFor the time being, it reports:\n\n* Against `FinancialForce`'s `Configuration.disableTriggerCRUDSecurity()`. Disabling CRUD security\nopens the door to several attacks and requires manual validation, which is unreliable.\n* Calling `System.debug` passing sensitive data as parameter, which could lead to exposure\nof private data.\n        ",
-			"categories": [
-				"Security"
-			],
-			"message": "Calling potentially dangerous method"
-		},
-		{
-			"rulesets": [
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart",
-				"Security"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "ApexInsecureEndpoint",
-			"description": "\nChecks against accessing endpoints under plain **http**. You should always use\n**https** for security.\n        ",
-			"categories": [
-				"Security"
-			],
-			"message": "Apex callouts should use encrypted communication channels"
-		},
-		{
-			"rulesets": [
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart",
-				"Security"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "ApexOpenRedirect",
-			"description": "\nChecks against redirects to user-controlled locations. This prevents attackers from\nredirecting users to phishing sites.\n        ",
-			"categories": [
-				"Security"
-			],
-			"message": "Apex classes should safely redirect to a known location"
-		},
-		{
-			"rulesets": [
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart",
-				"Security"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "ApexSharingViolations",
-			"description": "\nDetect classes declared without explicit sharing mode if DML methods are used. This\nforces the developer to take access restrictions into account before modifying objects.\n        ",
-			"categories": [
-				"Security"
-			],
-			"message": "Apex classes should declare a sharing model if DML or SOQL\/SOSL is used"
-		},
-		{
-			"rulesets": [
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart",
-				"Security"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "ApexSOQLInjection",
-			"description": "\nDetects the usage of untrusted \/ unescaped variables in DML queries.\n        ",
-			"categories": [
-				"Security"
-			],
-			"message": "Avoid untrusted\/unescaped variables in DML query"
-		},
-		{
-			"rulesets": [
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart",
-				"Security"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "ApexSuggestUsingNamedCred",
-			"description": "\nDetects hardcoded credentials used in requests to an endpoint.\n\nYou should refrain from hardcoding credentials:\n  * They are hard to mantain by being mixed in application code\n  * Particularly hard to update them when used from different classes\n  * Granting a developer access to the codebase means granting knowledge\n     of credentials, keeping a two-level access is not possible.\n  * Using different credentials for different environments is troublesome\n     and error-prone.\n\nInstead, you should use *Named Credentials* and a callout endpoint.\n\nFor more information, you can check [this](https:\/\/developer.salesforce.com\/docs\/atlas.en-us.apexcode.meta\/apexcode\/apex_callouts_named_credentials.htm)\n        ",
-			"categories": [
-				"Security"
-			],
-			"message": "Suggest named credentials for authentication"
-		},
-		{
-			"rulesets": [
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart",
-				"Security"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "ApexXSSFromEscapeFalse",
-			"description": "\nReports on calls to `addError` with disabled escaping. The message passed to `addError`\nwill be displayed directly to the user in the UI, making it prime ground for XSS\nattacks if unescaped.\n        ",
-			"categories": [
-				"Security"
-			],
-			"message": "Apex classes should escape Strings in error messages"
-		},
-		{
-			"rulesets": [
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart",
-				"Security"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "ApexXSSFromURLParam",
-			"description": "\nMakes sure that all values obtained from URL parameters are properly escaped \/ sanitized\nto avoid XSS attacks.\n        ",
-			"categories": [
-				"Security"
-			],
-			"message": "Apex classes should escape\/sanitize Strings obtained from URL parameters"
-		},
-		{
-			"rulesets": [
-				"Style",
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "ClassNamingConventions",
-			"description": "\n            Configurable naming conventions for type declarations. This rule reports\n            type declarations which do not match the regex that applies to their\n            specific kind (e.g. enum or interface). Each regex can be configured through\n            properties.\n\n            By default this rule uses the standard Apex naming convention (Pascal case).\n        ",
-			"categories": [
-				"Code Style"
-			],
-			"message": "The {0} name ''{1}'' doesn''t match ''{2}''"
-		},
-		{
-			"rulesets": [
-				"Braces",
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "IfElseStmtsMustUseBraces",
-			"description": "\nAvoid using if..else statements without using surrounding braces. If the code formatting\nor indentation is lost then it becomes difficult to separate the code being controlled\nfrom the rest.\n        ",
-			"categories": [
-				"Code Style"
-			],
-			"message": "Avoid using 'if...else' statements without curly braces"
-		},
-		{
-			"rulesets": [
-				"Braces",
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "IfStmtsMustUseBraces",
-			"description": "\nAvoid using if statements without using braces to surround the code block. If the code\nformatting or indentation is lost then it becomes difficult to separate the code being\ncontrolled from the rest.\n        ",
-			"categories": [
-				"Code Style"
-			],
-			"message": "Avoid using if statements without curly braces"
-		},
-		{
-			"rulesets": [
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "FieldNamingConventions",
-			"description": "\n            Configurable naming conventions for field declarations. This rule reports variable declarations\n            which do not match the regex that applies to their specific kind ---e.g. constants (static final),\n            static field, final field. Each regex can be configured through properties.\n\n            By default this rule uses the standard Apex naming convention (Camel case).\n        ",
-			"categories": [
-				"Code Style"
-			],
-			"message": "The {0} name ''{1}'' doesn''t match ''{2}''"
-		},
-		{
-			"rulesets": [
-				"Braces",
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "ForLoopsMustUseBraces",
-			"description": "\nAvoid using 'for' statements without using surrounding braces. If the code formatting or\nindentation is lost then it becomes difficult to separate the code being controlled\nfrom the rest.\n        ",
-			"categories": [
-				"Code Style"
-			],
-			"message": "Avoid using 'for' statements without curly braces"
-		},
-		{
-			"rulesets": [
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "FormalParameterNamingConventions",
-			"description": "\n            Configurable naming conventions for formal parameters of methods.\n            This rule reports formal parameters which do not match the regex that applies to their\n            specific kind (e.g. method parameter, or final method parameter). Each regex can be\n            configured through properties.\n\n            By default this rule uses the standard Apex naming convention (Camel case).\n        ",
-			"categories": [
-				"Code Style"
-			],
-			"message": "The {0} name ''{1}'' doesn''t match ''{2}''"
-		},
-		{
-			"rulesets": [
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "LocalVariableNamingConventions",
-			"description": "\n            Configurable naming conventions for local variable declarations.\n            This rule reports variable declarations which do not match the regex that applies to their\n            specific kind (e.g. local variable, or final local variable). Each regex can be configured through\n            properties.\n\n            By default this rule uses the standard Apex naming convention (Camel case).\n        ",
-			"categories": [
-				"Code Style"
-			],
-			"message": "The {0} name ''{1}'' doesn''t match ''{2}''"
-		},
-		{
-			"rulesets": [
-				"Style",
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "MethodNamingConventions",
-			"description": "\n            Configurable naming conventions for method declarations. This rule reports\n            method declarations which do not match the regex that applies to their\n            specific kind (e.g. static method, or test method). Each regex can be\n            configured through properties.\n\n            By default this rule uses the standard Apex naming convention (Camel case).\n        ",
-			"categories": [
-				"Code Style"
-			],
-			"message": "The {0} name ''{1}'' doesn''t match ''{2}''"
-		},
-		{
-			"rulesets": [
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "OneDeclarationPerLine",
-			"description": "\nApex allows the use of several variables declaration of the same type on one line. However, it\ncan lead to quite messy code. This rule looks for several declarations on the same line.\n        ",
-			"categories": [
-				"Code Style"
-			],
-			"message": "Use one statement for each line, it enhances code readability."
-		},
-		{
-			"rulesets": [
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "PropertyNamingConventions",
-			"description": "\n            Configurable naming conventions for property declarations. This rule reports\n            property declarations which do not match the regex that applies to their\n            specific kind (e.g. static property, or instance property). Each regex can be\n            configured through properties.\n\n            By default this rule uses the standard Apex naming convention (Camel case).\n        ",
-			"categories": [
-				"Code Style"
-			],
-			"message": "The {0} name ''{1}'' doesn''t match ''{2}''"
-		},
-		{
-			"rulesets": [
-				"Style",
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "VariableNamingConventions",
-			"description": "\nA variable naming conventions rule - customize this to your liking.  Currently, it\nchecks for final variables that should be fully capitalized and non-final variables\nthat should not include underscores.\n\nThis rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced\nby the more general rules {% rule \"apex\/codestyle\/FieldNamingConventions\" %},\n{% rule \"apex\/codestyle\/FormalParameterNamingConventions\" %},\n{% rule \"apex\/codestyle\/LocalVariableNamingConventions\" %}, and\n{% rule \"apex\/codestyle\/PropertyNamingConventions\" %}.\n        ",
-			"categories": [
-				"Code Style"
-			],
-			"message": "{0} variable {1} should begin with {2}"
-		},
-		{
-			"rulesets": [
-				"Braces",
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "WhileLoopsMustUseBraces",
-			"description": "\nAvoid using 'while' statements without using braces to surround the code block. If the code\nformatting or indentation is lost then it becomes difficult to separate the code being\ncontrolled from the rest.\n        ",
-			"categories": [
-				"Code Style"
-			],
-			"message": "Avoid using 'while' statements without curly braces"
-		},
-		{
-			"rulesets": [
-				"Complexity",
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "AvoidDeeplyNestedIfStmts",
-			"description": "\nAvoid creating deeply nested if-then statements since they are harder to read and error-prone to maintain.\n        ",
-			"categories": [
-				"Design"
-			],
-			"message": "Deeply nested if..then statements are hard to read"
-		},
-		{
-			"rulesets": [
-				"Metrics temporary ruleset",
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "CyclomaticComplexity",
-			"description": "\nThe complexity of methods directly affects maintenance costs and readability. Concentrating too much decisional logic\nin a single method makes its behaviour hard to read and change.\n\nCyclomatic complexity assesses the complexity of a method by counting the number of decision points in a method,\nplus one for the method entry. Decision points are places where the control flow jumps to another place in the\nprogram. As such, they include all control flow statements, such as 'if', 'while', 'for', and 'case'.\n\nGenerally, numbers ranging from 1-4 denote low complexity, 5-7 denote moderate complexity, 8-10 denote\nhigh complexity, and 11+ is very high complexity. By default, this rule reports methods with a complexity >= 10.\nAdditionnally, classes with many methods of moderate complexity get reported as well once the total of their\nmethods' complexities reaches 40, even if none of the methods was directly reported.\n\nReported methods should be broken down into several smaller methods. Reported classes should probably be broken down\ninto subcomponents.\n        ",
-			"categories": [
-				"Design"
-			],
-			"message": "The {0} ''{1}'' has a{2} cyclomatic complexity of {3}."
-		},
-		{
-			"rulesets": [
-				"Complexity",
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "ExcessiveClassLength",
-			"description": "\nExcessive class file lengths are usually indications that the class may be burdened with excessive \nresponsibilities that could be provided by external classes or functions. In breaking these methods\napart the code becomes more managable and ripe for reuse.\n        ",
-			"categories": [
-				"Design"
-			],
-			"message": "Avoid really long classes."
-		},
-		{
-			"rulesets": [
-				"Complexity",
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "ExcessiveParameterList",
-			"description": "\nMethods with numerous parameters are a challenge to maintain, especially if most of them share the\nsame datatype. These situations usually denote the need for new objects to wrap the numerous parameters.\n        ",
-			"categories": [
-				"Design"
-			],
-			"message": "Avoid long parameter lists."
-		},
-		{
-			"rulesets": [
-				"Complexity",
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "ExcessivePublicCount",
-			"description": "\nClasses with large numbers of public methods and attributes require disproportionate testing efforts\nsince combinational side effects grow rapidly and increase risk. Refactoring these classes into\nsmaller ones not only increases testability and reliability but also allows new variations to be\ndeveloped easily.\n        ",
-			"categories": [
-				"Design"
-			],
-			"message": "This class has a bunch of public methods and attributes"
-		},
-		{
-			"rulesets": [
-				"Complexity",
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "NcssConstructorCount",
-			"description": "\nThis rule uses the NCSS (Non-Commenting Source Statements) algorithm to determine the number of lines\nof code for a given constructor. NCSS ignores comments, and counts actual statements. Using this algorithm,\nlines of code that are split are counted as one.\n        ",
-			"categories": [
-				"Design"
-			],
-			"message": "The constructor has an NCSS line count of {0}"
-		},
-		{
-			"rulesets": [
-				"Complexity",
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "NcssMethodCount",
-			"description": "\nThis rule uses the NCSS (Non-Commenting Source Statements) algorithm to determine the number of lines\nof code for a given method. NCSS ignores comments, and counts actual statements. Using this algorithm,\nlines of code that are split are counted as one.\n        ",
-			"categories": [
-				"Design"
-			],
-			"message": "The method ''{0}()'' has an NCSS line count of {1}"
-		},
-		{
-			"rulesets": [
-				"Complexity",
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "NcssTypeCount",
-			"description": "\nThis rule uses the NCSS (Non-Commenting Source Statements) algorithm to determine the number of lines\nof code for a given type. NCSS ignores comments, and counts actual statements. Using this algorithm,\nlines of code that are split are counted as one.\n        ",
-			"categories": [
-				"Design"
-			],
-			"message": "The type has an NCSS line count of {0}"
-		},
-		{
-			"rulesets": [
-				"Complexity",
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "StdCyclomaticComplexity",
-			"description": "\nComplexity directly affects maintenance costs is determined by the number of decision points in a method \nplus one for the method entry.  The decision points include 'if', 'while', 'for', and 'case labels' calls.  \nGenerally, numbers ranging from 1-4 denote low complexity, 5-7 denote moderate complexity, 8-10 denote\nhigh complexity, and 11+ is very high complexity.\n        ",
-			"categories": [
-				"Design"
-			],
-			"message": "The {0} ''{1}'' has a Standard Cyclomatic Complexity of {2}."
-		},
-		{
-			"rulesets": [
-				"Complexity",
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "TooManyFields",
-			"description": "\nClasses that have too many fields can become unwieldy and could be redesigned to have fewer fields,\npossibly through grouping related fields in new objects.  For example, a class with individual \ncity\/state\/zip fields could park them within a single Address field.\n        ",
-			"categories": [
-				"Design"
-			],
-			"message": "Too many fields"
-		},
-		{
-			"rulesets": [
-				"Style",
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "AvoidDirectAccessTriggerMap",
-			"description": "\nAvoid directly accessing Trigger.old and Trigger.new as it can lead to a bug. Triggers should be bulkified and iterate through the map to handle the actions for each item separately.\n        ",
-			"categories": [
-				"Error Prone"
-			],
-			"message": "Avoid directly accessing Trigger.old and Trigger.new"
-		},
-		{
-			"rulesets": [
-				"Style",
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "AvoidHardcodingId",
-			"description": "\nWhen deploying Apex code between sandbox and production environments, or installing Force.com AppExchange packages,\nit is essential to avoid hardcoding IDs in the Apex code. By doing so, if the record IDs change between environments,\nthe logic can dynamically identify the proper data to operate against and not fail.\n        ",
-			"categories": [
-				"Error Prone"
-			],
-			"message": "Hardcoding Id's is bound to break when changing environments."
-		},
-		{
-			"rulesets": [
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"Empty Code",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "EmptyCatchBlock",
-			"description": "\nEmpty Catch Block finds instances where an exception is caught, but nothing is done.  \nIn most circumstances, this swallows an exception which should either be acted on \nor reported.\n        ",
-			"categories": [
-				"Error Prone"
-			],
-			"message": "Avoid empty catch blocks"
-		},
-		{
-			"rulesets": [
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"Empty Code",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "EmptyIfStmt",
-			"description": "\nEmpty If Statement finds instances where a condition is checked but nothing is done about it.\n        ",
-			"categories": [
-				"Error Prone"
-			],
-			"message": "Avoid empty 'if' statements"
-		},
-		{
-			"rulesets": [
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"Empty Code",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "EmptyStatementBlock",
-			"description": "\nEmpty block statements serve no purpose and should be removed.\n        ",
-			"categories": [
-				"Error Prone"
-			],
-			"message": "Avoid empty block statements."
-		},
-		{
-			"rulesets": [
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"Empty Code",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "EmptyTryOrFinallyBlock",
-			"description": "\nAvoid empty try or finally blocks - what's the point?\n        ",
-			"categories": [
-				"Error Prone"
-			],
-			"message": "Avoid empty try or finally blocks"
-		},
-		{
-			"rulesets": [
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"Empty Code",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "EmptyWhileStmt",
-			"description": "\nEmpty While Statement finds all instances where a while statement does nothing.  \nIf it is a timing loop, then you should use Thread.sleep() for it; if it is\na while loop that does a lot in the exit expression, rewrite it to make it clearer.\n        ",
-			"categories": [
-				"Error Prone"
-			],
-			"message": "Avoid empty 'while' statements"
-		},
-		{
-			"rulesets": [
-				"Style",
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "MethodWithSameNameAsEnclosingClass",
-			"description": "\nNon-constructor methods should not have the same name as the enclosing class.\n        ",
-			"categories": [
-				"Error Prone"
-			],
-			"message": "Classes should not have non-constructor methods with the same name as the class"
-		},
-		{
-			"rulesets": [
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "AvoidNonExistentAnnotations",
-			"description": "\n            Apex supported non existent annotations for legacy reasons.\n            In the future, use of such non-existent annotations could result in broken apex code that will not compile.\n            This will prevent users of garbage annotations from being able to use legitimate annotations added to Apex in the future.\n            A full list of supported annotations can be found at https:\/\/developer.salesforce.com\/docs\/atlas.en-us.apexcode.meta\/apexcode\/apex_classes_annotation.htm\n        ",
-			"categories": [
-				"Error Prone"
-			],
-			"message": "Use of non existent annotations will lead to broken Apex code which will not compile in the future."
-		},
-		{
-			"rulesets": [
-				"Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
-				"quickstart"
-			],
-			"languages": [
-				"apex"
-			],
-			"name": "ApexDoc",
-			"description": "\nThis rule validates that:\n\n* ApexDoc comments are present for classes, methods, and properties that are public or global, excluding\noverrides and test classes (as well as the contents of test classes).\n* ApexDoc comments should contain @description.\n* ApexDoc comments on non-void, non-constructor methods should contain @return.\n* ApexDoc comments on void or constructor methods should not contain @return.\n* ApexDoc comments on methods with parameters should contain @param for each parameter, in the same\norder as the method signature.\n\nMethod overrides and tests are both exempted from having ApexDoc.\n        ",
-			"categories": [
-				"Documentation"
-			],
-			"message": "ApexDoc comment is missing or incorrect"
-		}
-	],
-	"categories": {
-		"Design": [
-			"category\/ecmascript\/design.xml",
-			"category\/apex\/design.xml"
-		],
-		"Multithreading": [
-			"category\/ecmascript\/multithreading.xml",
-			"category\/apex\/multithreading.xml"
-		],
-		"Documentation": [
-			"category\/ecmascript\/documentation.xml",
-			"category\/apex\/documentation.xml"
-		],
-		"Best Practices": [
-			"category\/ecmascript\/bestpractices.xml",
-			"category\/apex\/bestpractices.xml"
-		],
-		"Performance": [
-			"category\/ecmascript\/performance.xml",
-			"category\/apex\/performance.xml"
-		],
-		"Security": [
-			"category\/ecmascript\/security.xml",
-			"category\/apex\/security.xml"
-		],
-		"Code Style": [
-			"category\/ecmascript\/codestyle.xml",
-			"category\/apex\/codestyle.xml"
-		],
-		"Error Prone": [
-			"category\/ecmascript\/errorprone.xml",
-			"category\/apex\/errorprone.xml"
-		]
-	}
+  "rulesets": [
+    {
+      "paths": [
+        "rulesets/apex/empty.xml"
+      ],
+      "name": "Empty Code"
+    },
+    {
+      "paths": [
+        "rulesets/apex/quickstart.xml"
+      ],
+      "name": "quickstart"
+    },
+    {
+      "paths": [
+        "rulesets/ecmascript/basic.xml"
+      ],
+      "name": "Basic Ecmascript"
+    },
+    {
+      "paths": [
+        "rulesets/apex/apexunit.xml"
+      ],
+      "name": "ApexUnit"
+    },
+    {
+      "paths": [
+        "rulesets/apex/ruleset.xml"
+      ],
+      "name": "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex"
+    },
+    {
+      "paths": [
+        "rulesets/apex/metrics.xml"
+      ],
+      "name": "Metrics temporary ruleset"
+    },
+    {
+      "paths": [
+        "rulesets/apex/security.xml"
+      ],
+      "name": "Security"
+    },
+    {
+      "paths": [
+        "rulesets/apex/complexity.xml"
+      ],
+      "name": "Complexity"
+    },
+    {
+      "paths": [
+        "rulesets/ecmascript/braces.xml",
+        "rulesets/apex/braces.xml"
+      ],
+      "name": "Braces"
+    },
+    {
+      "paths": [
+        "rulesets/apex/style.xml"
+      ],
+      "name": "Style"
+    },
+    {
+      "paths": [
+        "rulesets/ecmascript/controversial.xml"
+      ],
+      "name": "Controversial Ecmascript"
+    },
+    {
+      "paths": [
+        "rulesets/apex/performance.xml"
+      ],
+      "name": "Performance"
+    },
+    {
+      "paths": [
+        "rulesets/ecmascript/unnecessary.xml"
+      ],
+      "name": "Unnecessary"
+    }
+  ],
+  "rules": [
+    {
+      "rulesets": [
+        "Controversial Ecmascript"
+      ],
+      "languages": [
+        "javascript"
+      ],
+      "name": "AvoidWithStatement",
+      "description": "Avoid using with - it\u0027s bad news",
+      "categories": [
+        "Best Practices"
+      ],
+      "message": "Avoid using with - it\u0027s bad news"
+    },
+    {
+      "rulesets": [
+        "Basic Ecmascript"
+      ],
+      "languages": [
+        "javascript"
+      ],
+      "name": "ConsistentReturn",
+      "description": "\nECMAScript does provide for return types on functions, and therefore there is no solid rule as to their usage.\nHowever, when a function does use returns they should all have a value, or all with no value.  Mixed return\nusage is likely a bug, or at best poor style.\n        ",
+      "categories": [
+        "Best Practices"
+      ],
+      "message": "A function should not mix \u0027return\u0027 statements with and without a result."
+    },
+    {
+      "rulesets": [
+        "Basic Ecmascript"
+      ],
+      "languages": [
+        "javascript"
+      ],
+      "name": "GlobalVariable",
+      "description": "\nThis rule helps to avoid using accidently global variables by simply missing the \"var\" declaration.\nGlobal variables can lead to side-effects that are hard to debug.\n        ",
+      "categories": [
+        "Best Practices"
+      ],
+      "message": "Avoid using global variables"
+    },
+    {
+      "rulesets": [
+        "Basic Ecmascript"
+      ],
+      "languages": [
+        "javascript"
+      ],
+      "name": "ScopeForInVariable",
+      "description": "\nA for-in loop in which the variable name is not explicitly scoped to the enclosing scope with the \u0027var\u0027 keyword can\nrefer to a variable in an enclosing scope outside the nearest enclosing scope.  This will overwrite the\nexisting value of the variable in the outer scope when the body of the for-in is evaluated.  When the for-in loop\nhas finished, the variable will contain the last value used in the for-in, and the original value from before\nthe for-in loop will be gone.  Since the for-in variable name is most likely intended to be a temporary name, it\nis better to explicitly scope the variable name to the nearest enclosing scope with \u0027var\u0027.\n        ",
+      "categories": [
+        "Best Practices"
+      ],
+      "message": "The for-in loop variable \u0027\u0027{0}\u0027\u0027 should be explicitly scoped with \u0027var\u0027 to avoid pollution."
+    },
+    {
+      "rulesets": [
+        "Basic Ecmascript"
+      ],
+      "languages": [
+        "javascript"
+      ],
+      "name": "UseBaseWithParseInt",
+      "description": "\nThis rule checks for usages of parseInt. While the second parameter is optional and usually defaults\nto 10 (base/radix is 10 for a decimal number), different implementations may behave differently.\nIt also improves readability, if the base is given.\n\nSee also: [parseInt()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt)\n        ",
+      "categories": [
+        "Best Practices"
+      ],
+      "message": "Always provide a base when using parseInt() functions"
+    },
+    {
+      "rulesets": [
+        "Basic Ecmascript"
+      ],
+      "languages": [
+        "javascript"
+      ],
+      "name": "AvoidTrailingComma",
+      "description": "\nThis rule helps improve code portability due to differences in browser treatment of trailing commas in object or array literals.\n        ",
+      "categories": [
+        "Error Prone"
+      ],
+      "message": "Avoid trailing commas in object or array literals"
+    },
+    {
+      "rulesets": [
+        "Basic Ecmascript"
+      ],
+      "languages": [
+        "javascript"
+      ],
+      "name": "EqualComparison",
+      "description": "\nUsing \u003d\u003d in condition may lead to unexpected results, as the variables are automatically casted to be of the\nsame type. The \u003d\u003d\u003d operator avoids the casting.\n        ",
+      "categories": [
+        "Error Prone"
+      ],
+      "message": "Use \u0027\u003d\u003d\u003d\u0027/\u0027!\u003d\u003d\u0027 to compare with true/false or Numbers"
+    },
+    {
+      "rulesets": [
+        "Basic Ecmascript"
+      ],
+      "languages": [
+        "javascript"
+      ],
+      "name": "InnaccurateNumericLiteral",
+      "description": "\nThe numeric literal will have a different value at runtime, which can happen if you provide too much\nprecision in a floating point number.  This may result in numeric calculations being in error.\n        ",
+      "categories": [
+        "Error Prone"
+      ],
+      "message": "The numeric literal \u0027\u0027{0}\u0027\u0027 will have at different value at runtime."
+    },
+    {
+      "rulesets": [
+        "Basic Ecmascript"
+      ],
+      "languages": [
+        "javascript"
+      ],
+      "name": "AssignmentInOperand",
+      "description": "\nAvoid assignments in operands; this can make code more complicated and harder to read.  This is sometime\nindicative of the bug where the assignment operator \u0027\u003d\u0027 was used instead of the equality operator \u0027\u003d\u003d\u0027.\n        ",
+      "categories": [
+        "Code Style"
+      ],
+      "message": "Avoid assignments in operands"
+    },
+    {
+      "rulesets": [
+        "Braces"
+      ],
+      "languages": [
+        "javascript"
+      ],
+      "name": "ForLoopsMustUseBraces",
+      "description": "\nAvoid using \u0027for\u0027 statements without using curly braces.\n        ",
+      "categories": [
+        "Code Style"
+      ],
+      "message": "Avoid using \u0027for\u0027 statements without curly braces"
+    },
+    {
+      "rulesets": [
+        "Braces"
+      ],
+      "languages": [
+        "javascript"
+      ],
+      "name": "IfElseStmtsMustUseBraces",
+      "description": "\nAvoid using if..else statements without using curly braces.\n        ",
+      "categories": [
+        "Code Style"
+      ],
+      "message": "Avoid using \u0027if...else\u0027 statements without curly braces"
+    },
+    {
+      "rulesets": [
+        "Braces"
+      ],
+      "languages": [
+        "javascript"
+      ],
+      "name": "IfStmtsMustUseBraces",
+      "description": "\nAvoid using if statements without using curly braces.\n        ",
+      "categories": [
+        "Code Style"
+      ],
+      "message": "Avoid using if statements without curly braces"
+    },
+    {
+      "rulesets": [
+        "Unnecessary"
+      ],
+      "languages": [
+        "javascript"
+      ],
+      "name": "NoElseReturn",
+      "description": "\nThe else block in a if-else-construct is unnecessary if the `if` block contains a return.\nThen the content of the else block can be put outside.\n\nSee also: \u003chttp://eslint.org/docs/rules/no-else-return\u003e\n        ",
+      "categories": [
+        "Code Style"
+      ],
+      "message": "The else block is unnecessary"
+    },
+    {
+      "rulesets": [
+        "Unnecessary"
+      ],
+      "languages": [
+        "javascript"
+      ],
+      "name": "UnnecessaryBlock",
+      "description": "\nAn unnecessary Block is present.  Such Blocks are often used in other languages to\nintroduce a new variable scope.  Blocks do not behave like this in ECMAScipt, and using them can\nbe misleading.  Considering removing this unnecessary Block.\n        ",
+      "categories": [
+        "Code Style"
+      ],
+      "message": "Unnecessary block."
+    },
+    {
+      "rulesets": [
+        "Unnecessary"
+      ],
+      "languages": [
+        "javascript"
+      ],
+      "name": "UnnecessaryParentheses",
+      "description": "Unnecessary parentheses should be removed.",
+      "categories": [
+        "Code Style"
+      ],
+      "message": "Unnecessary parentheses."
+    },
+    {
+      "rulesets": [
+        "Basic Ecmascript"
+      ],
+      "languages": [
+        "javascript"
+      ],
+      "name": "UnreachableCode",
+      "description": "\nA \u0027return\u0027, \u0027break\u0027, \u0027continue\u0027, or \u0027throw\u0027 statement should be the last in a block. Statements after these\nwill never execute.  This is a bug, or extremely poor style.\n        ",
+      "categories": [
+        "Code Style"
+      ],
+      "message": "A \u0027\u0027return\u0027\u0027, \u0027\u0027break\u0027\u0027, \u0027\u0027continue\u0027\u0027, or \u0027\u0027throw\u0027\u0027 statement should be the last in a block."
+    },
+    {
+      "rulesets": [
+        "Braces"
+      ],
+      "languages": [
+        "javascript"
+      ],
+      "name": "WhileLoopsMustUseBraces",
+      "description": "\nAvoid using \u0027while\u0027 statements without using curly braces.\n        ",
+      "categories": [
+        "Code Style"
+      ],
+      "message": "Avoid using \u0027while\u0027 statements without curly braces"
+    },
+    {
+      "rulesets": [],
+      "languages": [
+        "apex"
+      ],
+      "name": "ApexAssertionsShouldIncludeMessage",
+      "description": "\nThe second parameter of System.assert/third parameter of System.assertEquals/System.assertNotEquals is a message.\nHaving a second/third parameter provides more information and makes it easier to debug the test failure and\nimproves the readability of test output.\n        ",
+      "categories": [
+        "Best Practices"
+      ],
+      "message": "Apex test assert statement should make use of the message parameter."
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "ApexUnit",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "ApexUnitTestClassShouldHaveAsserts",
+      "description": "\nApex unit tests should include at least one assertion.  This makes the tests more robust, and using assert\nwith messages provide the developer a clearer idea of what the test does.\n        ",
+      "categories": [
+        "Best Practices"
+      ],
+      "message": "Apex unit tests should System.assert() or assertEquals() or assertNotEquals()"
+    },
+    {
+      "rulesets": [],
+      "languages": [
+        "apex"
+      ],
+      "name": "ApexUnitTestMethodShouldHaveIsTestAnnotation",
+      "description": "\nApex test methods should have @isTest annotation.\nAs testMethod keyword is deprecated, Salesforce advices to use @isTest annotation for test class/methods.\n        ",
+      "categories": [
+        "Best Practices"
+      ],
+      "message": "Apex test methods should have @isTest annotation."
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "ApexUnit",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "ApexUnitTestShouldNotUseSeeAllDataTrue",
+      "description": "\nApex unit tests should not use @isTest(seeAllData\u003dtrue) because it opens up the existing database data for unexpected modification by tests.\n        ",
+      "categories": [
+        "Best Practices"
+      ],
+      "message": "Apex unit tests should not use @isTest(seeAllData \u003d true)"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Style",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "AvoidGlobalModifier",
+      "description": "\nGlobal classes should be avoided (especially in managed packages) as they can never be deleted or changed in signature. Always check twice if something needs to be global.\nMany interfaces (e.g. Batch) required global modifiers in the past but don\u0027t require this anymore. Don\u0027t lock yourself in.\n        ",
+      "categories": [
+        "Best Practices"
+      ],
+      "message": "Avoid using global modifier"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Style",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "AvoidLogicInTrigger",
+      "description": "\nAs triggers do not allow methods like regular classes they are less flexible and suited to apply good encapsulation style.\nTherefore delegate the triggers work to a regular class (often called Trigger handler class).\n\nSee more here: \u003chttps://developer.salesforce.com/page/Trigger_Frameworks_and_Apex_Trigger_Best_Practices\u003e\n        ",
+      "categories": [
+        "Best Practices"
+      ],
+      "message": "Avoid logic in triggers"
+    },
+    {
+      "rulesets": [
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "DebugsShouldUseLoggingLevel",
+      "description": "\nThe first parameter of System.debug, when using the signature with two parameters, is a LoggingLevel enum.\n\nHaving the Logging Level specified provides a cleaner log, and improves readability of it.\n       ",
+      "categories": [
+        "Best Practices"
+      ],
+      "message": "Calls to System.debug should specify a logging level."
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "quickstart",
+        "Performance"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "AvoidDmlStatementsInLoops",
+      "description": "\nAvoid DML statements inside loops to avoid hitting the DML governor limit. Instead, try to batch up the data into a list and invoke your DML once on that list of data outside the loop.\n        ",
+      "categories": [
+        "Performance"
+      ],
+      "message": "Avoid DML statements inside loops"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "quickstart",
+        "Performance"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "AvoidSoqlInLoops",
+      "description": "\nNew objects created within loops should be checked to see if they can created outside them and reused.\n        ",
+      "categories": [
+        "Performance"
+      ],
+      "message": "Avoid Soql queries inside loops"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "quickstart",
+        "Performance"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "AvoidSoslInLoops",
+      "description": "\nSosl calls within loops can cause governor limit exceptions.\n        ",
+      "categories": [
+        "Performance"
+      ],
+      "message": "Avoid Sosl queries inside loops"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Security",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "ApexBadCrypto",
+      "description": "\nThe rule makes sure you are using randomly generated IVs and keys for `Crypto` calls.\nHard-wiring these values greatly compromises the security of encrypted data.\n        ",
+      "categories": [
+        "Security"
+      ],
+      "message": "Apex classes should use random IV/key"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Security",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "ApexCRUDViolation",
+      "description": "\nThe rule validates you are checking for access permissions before a SOQL/SOSL/DML operation.\nSince Apex runs in system mode not having proper permissions checks results in escalation of\nprivilege and may produce runtime errors. This check forces you to handle such scenarios.\n        ",
+      "categories": [
+        "Security"
+      ],
+      "message": "Validate CRUD permission before SOQL/DML operation"
+    },
+    {
+      "rulesets": [
+        "Security"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "ApexCSRF",
+      "description": "",
+      "categories": [
+        "Security"
+      ],
+      "message": ""
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Security",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "ApexDangerousMethods",
+      "description": "\nChecks against calling dangerous methods.\n\nFor the time being, it reports:\n\n* Against `FinancialForce`\u0027s `Configuration.disableTriggerCRUDSecurity()`. Disabling CRUD security\nopens the door to several attacks and requires manual validation, which is unreliable.\n* Calling `System.debug` passing sensitive data as parameter, which could lead to exposure\nof private data.\n        ",
+      "categories": [
+        "Security"
+      ],
+      "message": "Calling potentially dangerous method"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Security",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "ApexInsecureEndpoint",
+      "description": "\nChecks against accessing endpoints under plain **http**. You should always use\n**https** for security.\n        ",
+      "categories": [
+        "Security"
+      ],
+      "message": "Apex callouts should use encrypted communication channels"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Security",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "ApexOpenRedirect",
+      "description": "\nChecks against redirects to user-controlled locations. This prevents attackers from\nredirecting users to phishing sites.\n        ",
+      "categories": [
+        "Security"
+      ],
+      "message": "Apex classes should safely redirect to a known location"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Security",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "ApexSharingViolations",
+      "description": "\nDetect classes declared without explicit sharing mode if DML methods are used. This\nforces the developer to take access restrictions into account before modifying objects.\n        ",
+      "categories": [
+        "Security"
+      ],
+      "message": "Apex classes should declare a sharing model if DML or SOQL/SOSL is used"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Security",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "ApexSOQLInjection",
+      "description": "\nDetects the usage of untrusted / unescaped variables in DML queries.\n        ",
+      "categories": [
+        "Security"
+      ],
+      "message": "Avoid untrusted/unescaped variables in DML query"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Security",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "ApexSuggestUsingNamedCred",
+      "description": "\nDetects hardcoded credentials used in requests to an endpoint.\n\nYou should refrain from hardcoding credentials:\n  * They are hard to mantain by being mixed in application code\n  * Particularly hard to update them when used from different classes\n  * Granting a developer access to the codebase means granting knowledge\n     of credentials, keeping a two-level access is not possible.\n  * Using different credentials for different environments is troublesome\n     and error-prone.\n\nInstead, you should use *Named Credentials* and a callout endpoint.\n\nFor more information, you can check [this](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_callouts_named_credentials.htm)\n        ",
+      "categories": [
+        "Security"
+      ],
+      "message": "Suggest named credentials for authentication"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Security",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "ApexXSSFromEscapeFalse",
+      "description": "\nReports on calls to `addError` with disabled escaping. The message passed to `addError`\nwill be displayed directly to the user in the UI, making it prime ground for XSS\nattacks if unescaped.\n        ",
+      "categories": [
+        "Security"
+      ],
+      "message": "Apex classes should escape Strings in error messages"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Security",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "ApexXSSFromURLParam",
+      "description": "\nMakes sure that all values obtained from URL parameters are properly escaped / sanitized\nto avoid XSS attacks.\n        ",
+      "categories": [
+        "Security"
+      ],
+      "message": "Apex classes should escape/sanitize Strings obtained from URL parameters"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Style",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "ClassNamingConventions",
+      "description": "\n            Configurable naming conventions for type declarations. This rule reports\n            type declarations which do not match the regex that applies to their\n            specific kind (e.g. enum or interface). Each regex can be configured through\n            properties.\n\n            By default this rule uses the standard Apex naming convention (Pascal case).\n        ",
+      "categories": [
+        "Code Style"
+      ],
+      "message": "The {0} name \u0027\u0027{1}\u0027\u0027 doesn\u0027\u0027t match \u0027\u0027{2}\u0027\u0027"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Braces",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "IfElseStmtsMustUseBraces",
+      "description": "\nAvoid using if..else statements without using surrounding braces. If the code formatting\nor indentation is lost then it becomes difficult to separate the code being controlled\nfrom the rest.\n        ",
+      "categories": [
+        "Code Style"
+      ],
+      "message": "Avoid using \u0027if...else\u0027 statements without curly braces"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Braces",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "IfStmtsMustUseBraces",
+      "description": "\nAvoid using if statements without using braces to surround the code block. If the code\nformatting or indentation is lost then it becomes difficult to separate the code being\ncontrolled from the rest.\n        ",
+      "categories": [
+        "Code Style"
+      ],
+      "message": "Avoid using if statements without curly braces"
+    },
+    {
+      "rulesets": [
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "FieldNamingConventions",
+      "description": "\n            Configurable naming conventions for field declarations. This rule reports variable declarations\n            which do not match the regex that applies to their specific kind ---e.g. constants (static final),\n            static field, final field. Each regex can be configured through properties.\n\n            By default this rule uses the standard Apex naming convention (Camel case).\n        ",
+      "categories": [
+        "Code Style"
+      ],
+      "message": "The {0} name \u0027\u0027{1}\u0027\u0027 doesn\u0027\u0027t match \u0027\u0027{2}\u0027\u0027"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Braces",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "ForLoopsMustUseBraces",
+      "description": "\nAvoid using \u0027for\u0027 statements without using surrounding braces. If the code formatting or\nindentation is lost then it becomes difficult to separate the code being controlled\nfrom the rest.\n        ",
+      "categories": [
+        "Code Style"
+      ],
+      "message": "Avoid using \u0027for\u0027 statements without curly braces"
+    },
+    {
+      "rulesets": [
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "FormalParameterNamingConventions",
+      "description": "\n            Configurable naming conventions for formal parameters of methods.\n            This rule reports formal parameters which do not match the regex that applies to their\n            specific kind (e.g. method parameter, or final method parameter). Each regex can be\n            configured through properties.\n\n            By default this rule uses the standard Apex naming convention (Camel case).\n        ",
+      "categories": [
+        "Code Style"
+      ],
+      "message": "The {0} name \u0027\u0027{1}\u0027\u0027 doesn\u0027\u0027t match \u0027\u0027{2}\u0027\u0027"
+    },
+    {
+      "rulesets": [
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "LocalVariableNamingConventions",
+      "description": "\n            Configurable naming conventions for local variable declarations.\n            This rule reports variable declarations which do not match the regex that applies to their\n            specific kind (e.g. local variable, or final local variable). Each regex can be configured through\n            properties.\n\n            By default this rule uses the standard Apex naming convention (Camel case).\n        ",
+      "categories": [
+        "Code Style"
+      ],
+      "message": "The {0} name \u0027\u0027{1}\u0027\u0027 doesn\u0027\u0027t match \u0027\u0027{2}\u0027\u0027"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Style",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "MethodNamingConventions",
+      "description": "\n            Configurable naming conventions for method declarations. This rule reports\n            method declarations which do not match the regex that applies to their\n            specific kind (e.g. static method, or test method). Each regex can be\n            configured through properties.\n\n            By default this rule uses the standard Apex naming convention (Camel case).\n        ",
+      "categories": [
+        "Code Style"
+      ],
+      "message": "The {0} name \u0027\u0027{1}\u0027\u0027 doesn\u0027\u0027t match \u0027\u0027{2}\u0027\u0027"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "OneDeclarationPerLine",
+      "description": "\nApex allows the use of several variables declaration of the same type on one line. However, it\ncan lead to quite messy code. This rule looks for several declarations on the same line.\n        ",
+      "categories": [
+        "Code Style"
+      ],
+      "message": "Use one statement for each line, it enhances code readability."
+    },
+    {
+      "rulesets": [
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "PropertyNamingConventions",
+      "description": "\n            Configurable naming conventions for property declarations. This rule reports\n            property declarations which do not match the regex that applies to their\n            specific kind (e.g. static property, or instance property). Each regex can be\n            configured through properties.\n\n            By default this rule uses the standard Apex naming convention (Camel case).\n        ",
+      "categories": [
+        "Code Style"
+      ],
+      "message": "The {0} name \u0027\u0027{1}\u0027\u0027 doesn\u0027\u0027t match \u0027\u0027{2}\u0027\u0027"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Style"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "VariableNamingConventions",
+      "description": "\nA variable naming conventions rule - customize this to your liking.  Currently, it\nchecks for final variables that should be fully capitalized and non-final variables\nthat should not include underscores.\n\nThis rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced\nby the more general rules {% rule \"apex/codestyle/FieldNamingConventions\" %},\n{% rule \"apex/codestyle/FormalParameterNamingConventions\" %},\n{% rule \"apex/codestyle/LocalVariableNamingConventions\" %}, and\n{% rule \"apex/codestyle/PropertyNamingConventions\" %}.\n        ",
+      "categories": [
+        "Code Style"
+      ],
+      "message": "{0} variable {1} should begin with {2}"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Braces",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "WhileLoopsMustUseBraces",
+      "description": "\nAvoid using \u0027while\u0027 statements without using braces to surround the code block. If the code\nformatting or indentation is lost then it becomes difficult to separate the code being\ncontrolled from the rest.\n        ",
+      "categories": [
+        "Code Style"
+      ],
+      "message": "Avoid using \u0027while\u0027 statements without curly braces"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Complexity",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "AvoidDeeplyNestedIfStmts",
+      "description": "\nAvoid creating deeply nested if-then statements since they are harder to read and error-prone to maintain.\n        ",
+      "categories": [
+        "Design"
+      ],
+      "message": "Deeply nested if..then statements are hard to read"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Metrics temporary ruleset",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "CyclomaticComplexity",
+      "description": "\nThe complexity of methods directly affects maintenance costs and readability. Concentrating too much decisional logic\nin a single method makes its behaviour hard to read and change.\n\nCyclomatic complexity assesses the complexity of a method by counting the number of decision points in a method,\nplus one for the method entry. Decision points are places where the control flow jumps to another place in the\nprogram. As such, they include all control flow statements, such as \u0027if\u0027, \u0027while\u0027, \u0027for\u0027, and \u0027case\u0027.\n\nGenerally, numbers ranging from 1-4 denote low complexity, 5-7 denote moderate complexity, 8-10 denote\nhigh complexity, and 11+ is very high complexity. By default, this rule reports methods with a complexity \u003e\u003d 10.\nAdditionnally, classes with many methods of moderate complexity get reported as well once the total of their\nmethods\u0027 complexities reaches 40, even if none of the methods was directly reported.\n\nReported methods should be broken down into several smaller methods. Reported classes should probably be broken down\ninto subcomponents.\n        ",
+      "categories": [
+        "Design"
+      ],
+      "message": "The {0} \u0027\u0027{1}\u0027\u0027 has a{2} cyclomatic complexity of {3}."
+    },
+    {
+      "rulesets": [],
+      "languages": [
+        "apex"
+      ],
+      "name": "CognitiveComplexity",
+      "description": "\nMethods that are highly complex are difficult to read and more costly to maintain. If you include too much decisional\nlogic within a single method, you make its behavior hard to understand and more difficult to modify.\n\nCognitive complexity is a measure of how difficult it is for humans to read and understand a method. Code that contains\na break in the control flow is more complex, whereas the use of language shorthands doesn\u0027t increase the level of\ncomplexity. Nested control flows can make a method more difficult to understand, with each additional nesting of the\ncontrol flow leading to an increase in cognitive complexity.\n\nInformation about Cognitive complexity can be found in the original paper here:\nhttps://www.sonarsource.com/docs/CognitiveComplexity.pdf\n\nBy default, this rule reports methods with a complexity of 15 or more. Reported methods should be broken down into less\ncomplex components.\n        ",
+      "categories": [
+        "Design"
+      ],
+      "message": "The {0} \u0027\u0027{1}\u0027\u0027 has a{2} cognitive complexity of {3}."
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Complexity",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "ExcessiveClassLength",
+      "description": "\nExcessive class file lengths are usually indications that the class may be burdened with excessive\nresponsibilities that could be provided by external classes or functions. In breaking these methods\napart the code becomes more managable and ripe for reuse.\n        ",
+      "categories": [
+        "Design"
+      ],
+      "message": "Avoid really long classes."
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Complexity",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "ExcessiveParameterList",
+      "description": "\nMethods with numerous parameters are a challenge to maintain, especially if most of them share the\nsame datatype. These situations usually denote the need for new objects to wrap the numerous parameters.\n        ",
+      "categories": [
+        "Design"
+      ],
+      "message": "Avoid long parameter lists."
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Complexity",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "ExcessivePublicCount",
+      "description": "\nClasses with large numbers of public methods and attributes require disproportionate testing efforts\nsince combinational side effects grow rapidly and increase risk. Refactoring these classes into\nsmaller ones not only increases testability and reliability but also allows new variations to be\ndeveloped easily.\n        ",
+      "categories": [
+        "Design"
+      ],
+      "message": "This class has a bunch of public methods and attributes"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Complexity",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "NcssConstructorCount",
+      "description": "\nThis rule uses the NCSS (Non-Commenting Source Statements) algorithm to determine the number of lines\nof code for a given constructor. NCSS ignores comments, and counts actual statements. Using this algorithm,\nlines of code that are split are counted as one.\n        ",
+      "categories": [
+        "Design"
+      ],
+      "message": "The constructor has an NCSS line count of {0}"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Complexity",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "NcssMethodCount",
+      "description": "\nThis rule uses the NCSS (Non-Commenting Source Statements) algorithm to determine the number of lines\nof code for a given method. NCSS ignores comments, and counts actual statements. Using this algorithm,\nlines of code that are split are counted as one.\n        ",
+      "categories": [
+        "Design"
+      ],
+      "message": "The method \u0027\u0027{0}()\u0027\u0027 has an NCSS line count of {1}"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Complexity",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "NcssTypeCount",
+      "description": "\nThis rule uses the NCSS (Non-Commenting Source Statements) algorithm to determine the number of lines\nof code for a given type. NCSS ignores comments, and counts actual statements. Using this algorithm,\nlines of code that are split are counted as one.\n        ",
+      "categories": [
+        "Design"
+      ],
+      "message": "The type has an NCSS line count of {0}"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Complexity",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "StdCyclomaticComplexity",
+      "description": "\nComplexity directly affects maintenance costs is determined by the number of decision points in a method\nplus one for the method entry.  The decision points include \u0027if\u0027, \u0027while\u0027, \u0027for\u0027, and \u0027case labels\u0027 calls.\nGenerally, numbers ranging from 1-4 denote low complexity, 5-7 denote moderate complexity, 8-10 denote\nhigh complexity, and 11+ is very high complexity.\n        ",
+      "categories": [
+        "Design"
+      ],
+      "message": "The {0} \u0027\u0027{1}\u0027\u0027 has a Standard Cyclomatic Complexity of {2}."
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Complexity",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "TooManyFields",
+      "description": "\nClasses that have too many fields can become unwieldy and could be redesigned to have fewer fields,\npossibly through grouping related fields in new objects.  For example, a class with individual\ncity/state/zip fields could park them within a single Address field.\n        ",
+      "categories": [
+        "Design"
+      ],
+      "message": "Too many fields"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "ApexCSRF",
+      "description": "\nHaving DML operations in Apex class constructor or initializers can have unexpected side effects:\nBy just accessing a page, the DML statements would be executed and the database would be modified.\nJust querying the database is permitted.\n\nIn addition to constructors and initializers, any method called `init` is checked as well.\n\nSalesforce Apex already protects against this scenario and raises a runtime exception.\n\nNote: This rule has been moved from category \"Security\" to \"Error Prone\" with PMD 6.21.0, since\nusing DML in constructors is not a security problem, but crashes the application.\n        ",
+      "categories": [
+        "Error Prone"
+      ],
+      "message": "Avoid making DML operations in Apex class constructor or initializers"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Style",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "AvoidDirectAccessTriggerMap",
+      "description": "\nAvoid directly accessing Trigger.old and Trigger.new as it can lead to a bug. Triggers should be bulkified and iterate through the map to handle the actions for each item separately.\n        ",
+      "categories": [
+        "Error Prone"
+      ],
+      "message": "Avoid directly accessing Trigger.old and Trigger.new"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Style",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "AvoidHardcodingId",
+      "description": "\nWhen deploying Apex code between sandbox and production environments, or installing Force.com AppExchange packages,\nit is essential to avoid hardcoding IDs in the Apex code. By doing so, if the record IDs change between environments,\nthe logic can dynamically identify the proper data to operate against and not fail.\n        ",
+      "categories": [
+        "Error Prone"
+      ],
+      "message": "Hardcoding Id\u0027s is bound to break when changing environments."
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "quickstart",
+        "Empty Code"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "EmptyCatchBlock",
+      "description": "\nEmpty Catch Block finds instances where an exception is caught, but nothing is done.\nIn most circumstances, this swallows an exception which should either be acted on\nor reported.\n        ",
+      "categories": [
+        "Error Prone"
+      ],
+      "message": "Avoid empty catch blocks"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "quickstart",
+        "Empty Code"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "EmptyIfStmt",
+      "description": "\nEmpty If Statement finds instances where a condition is checked but nothing is done about it.\n        ",
+      "categories": [
+        "Error Prone"
+      ],
+      "message": "Avoid empty \u0027if\u0027 statements"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "quickstart",
+        "Empty Code"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "EmptyStatementBlock",
+      "description": "\nEmpty block statements serve no purpose and should be removed.\n        ",
+      "categories": [
+        "Error Prone"
+      ],
+      "message": "Avoid empty block statements."
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "quickstart",
+        "Empty Code"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "EmptyTryOrFinallyBlock",
+      "description": "\nAvoid empty try or finally blocks - what\u0027s the point?\n        ",
+      "categories": [
+        "Error Prone"
+      ],
+      "message": "Avoid empty try or finally blocks"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "quickstart",
+        "Empty Code"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "EmptyWhileStmt",
+      "description": "\nEmpty While Statement finds all instances where a while statement does nothing.\nIf it is a timing loop, then you should use Thread.sleep() for it; if it is\na while loop that does a lot in the exit expression, rewrite it to make it clearer.\n        ",
+      "categories": [
+        "Error Prone"
+      ],
+      "message": "Avoid empty \u0027while\u0027 statements"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "Style",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "MethodWithSameNameAsEnclosingClass",
+      "description": "\nNon-constructor methods should not have the same name as the enclosing class.\n        ",
+      "categories": [
+        "Error Prone"
+      ],
+      "message": "Classes should not have non-constructor methods with the same name as the class"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "AvoidNonExistentAnnotations",
+      "description": "\n            Apex supported non existent annotations for legacy reasons.\n            In the future, use of such non-existent annotations could result in broken apex code that will not compile.\n            This will prevent users of garbage annotations from being able to use legitimate annotations added to Apex in the future.\n            A full list of supported annotations can be found at https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_annotation.htm\n        ",
+      "categories": [
+        "Error Prone"
+      ],
+      "message": "Use of non existent annotations will lead to broken Apex code which will not compile in the future."
+    },
+    {
+      "rulesets": [],
+      "languages": [
+        "apex"
+      ],
+      "name": "TestMethodsMustBeInTestClasses",
+      "description": "\n          Test methods marked as a testMethod or annotated with @IsTest,\n          but not residing in a test class should be moved to a proper\n          class or have the @IsTest annotation added to the class.\n\n          Support for tests inside functional classes was removed in Spring-13 (API Version 27.0),\n          making classes that violate this rule fail compile-time. This rule is mostly usable when\n          dealing with legacy code.\n       ",
+      "categories": [
+        "Error Prone"
+      ],
+      "message": "Test methods must be in test classes"
+    },
+    {
+      "rulesets": [
+        "Default ruleset used by the CodeClimate Engine for Salesforce.com Apex",
+        "quickstart"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "name": "ApexDoc",
+      "description": "\nThis rule validates that:\n\n* ApexDoc comments are present for classes, methods, and properties that are public or global, excluding\noverrides and test classes (as well as the contents of test classes).\n* ApexDoc comments should contain @description.\n* ApexDoc comments on non-void, non-constructor methods should contain @return.\n* ApexDoc comments on void or constructor methods should not contain @return.\n* ApexDoc comments on methods with parameters should contain @param for each parameter, in the same\norder as the method signature.\n\nMethod overrides and tests are both exempted from having ApexDoc.\n        ",
+      "categories": [
+        "Documentation"
+      ],
+      "message": "ApexDoc comment is missing or incorrect"
+    }
+  ],
+  "categories": [
+    {
+      "paths": [
+        "category/ecmascript/design.xml",
+        "category/apex/design.xml"
+      ],
+      "name": "Design"
+    },
+    {
+      "paths": [
+        "category/ecmascript/multithreading.xml",
+        "category/apex/multithreading.xml"
+      ],
+      "name": "Multithreading"
+    },
+    {
+      "paths": [
+        "category/ecmascript/documentation.xml",
+        "category/apex/documentation.xml"
+      ],
+      "name": "Documentation"
+    },
+    {
+      "paths": [
+        "category/ecmascript/bestpractices.xml",
+        "category/apex/bestpractices.xml"
+      ],
+      "name": "Best Practices"
+    },
+    {
+      "paths": [
+        "category/ecmascript/security.xml",
+        "category/apex/security.xml"
+      ],
+      "name": "Security"
+    },
+    {
+      "paths": [
+        "category/ecmascript/performance.xml",
+        "category/apex/performance.xml"
+      ],
+      "name": "Performance"
+    },
+    {
+      "paths": [
+        "category/ecmascript/codestyle.xml",
+        "category/apex/codestyle.xml"
+      ],
+      "name": "Code Style"
+    },
+    {
+      "paths": [
+        "category/ecmascript/errorprone.xml",
+        "category/apex/errorprone.xml"
+      ],
+      "name": "Error Prone"
+    }
+  ]
 }

--- a/test/lib/CustomRulePathManager.test.ts
+++ b/test/lib/CustomRulePathManager.test.ts
@@ -1,10 +1,10 @@
 import {expect} from 'chai';
 import {Stats} from 'fs';
-import {CustomRulePathManager} from '../../src/lib/CustomRulePathManager';
+import {Controller} from '../../src/ioc.config';
 import {PmdEngine} from '../../src/lib/pmd/PmdEngine';
 import {FileHandler} from '../../src/lib/util/FileHandler';
-import Sinon = require('sinon');
 import path = require('path');
+import Sinon = require('sinon');
 
 /**
  * Unit tests to verify CustomRulePathManager
@@ -32,7 +32,7 @@ describe('CustomRulePathManager tests', () => {
 			});
 
 			it('should read CustomPaths.json to get Rule Path Entries', async () => {
-				const manager = await CustomRulePathManager.create();
+				const manager = await Controller.createRulePathManager();
 
 				// Execute test
 				const rulePathMap = await manager.getRulePathEntries(PmdEngine.NAME);
@@ -55,7 +55,7 @@ describe('CustomRulePathManager tests', () => {
 			});
 
 			it('should initialize only once', async () => {
-				const manager = await CustomRulePathManager.create();
+				const manager = await Controller.createRulePathManager();
 
 				// Execute test
 				await manager.getRulePathEntries(PmdEngine.NAME);
@@ -71,7 +71,7 @@ describe('CustomRulePathManager tests', () => {
 		it('should handle empty Rule Path file gracefully', async () => {
 			// Setup stub
 			const readStub = Sinon.stub(FileHandler.prototype, 'readFile').resolves(emptyFile);
-			const manager = await CustomRulePathManager.create();
+			const manager = await Controller.createRulePathManager();
 
 			// Execute test
 			const rulePathMap = await manager.getRulePathEntries(PmdEngine.NAME);
@@ -89,7 +89,7 @@ describe('CustomRulePathManager tests', () => {
 		// For all tests, we'll want to stub out the writeFile and mkdir methods with no-ops.
 		before(() => {
 			Sinon.stub(FileHandler.prototype, 'writeFile').resolves();
-			Sinon.stub(FileHandler.prototype, 'mkdirIfNotExists').resolves()
+			Sinon.stub(FileHandler.prototype, 'mkdirIfNotExists').resolves();
 		});
 
 		// We'll also want to stub out the readFile method, but what we'll replace it with varies by test. Regardless, we'll
@@ -120,7 +120,7 @@ describe('CustomRulePathManager tests', () => {
 
 			it('Should reflect any new entries', async () => {
 				readStub = Sinon.stub(FileHandler.prototype, 'readFile').resolves(emptyFile);
-				const manager = await CustomRulePathManager.create();
+				const manager = await Controller.createRulePathManager();
 				const language = 'javascript';
 				const paths = ['/absolute/path/to/SomeJar.jar', '/another/absolute/path/to/AnotherJar.jar'];
 
@@ -143,7 +143,7 @@ describe('CustomRulePathManager tests', () => {
 				const fileContent = '{"pmd": {"apex": ["/some/user/path/customRule.jar"]}}';
 				readStub = Sinon.stub(FileHandler.prototype, 'readFile').resolves(fileContent);
 
-				const manager = await CustomRulePathManager.create();
+				const manager = await Controller.createRulePathManager();
 				const language = 'apex';
 				const newPaths = ['/absolute/path/to/SomeJar.jar', '/different/absolute/path/to/OtherJar.jar'];
 
@@ -186,7 +186,7 @@ describe('CustomRulePathManager tests', () => {
 
 			it('Should reflect newly added entries', async () => {
 				readStub = Sinon.stub(FileHandler.prototype, 'readFile').resolves(emptyFile);
-				const manager = await CustomRulePathManager.create();
+				const manager = await Controller.createRulePathManager();
 				const language = 'javascript';
 				const paths = ['path1', 'path2'];
 
@@ -211,7 +211,7 @@ describe('CustomRulePathManager tests', () => {
 				const fileContent = '{"pmd": {"apex": ["/some/user/path/customRule.jar"]}}';
 				readStub = Sinon.stub(FileHandler.prototype, 'readFile').resolves(fileContent);
 
-				const manager = await CustomRulePathManager.create();
+				const manager = await Controller.createRulePathManager();
 				const language = 'apex';
 				const newPath = '/my/new/path';
 

--- a/test/lib/RuleManager.test.ts
+++ b/test/lib/RuleManager.test.ts
@@ -30,7 +30,7 @@ describe('RuleManager', () => {
 		});
 
 		// Declare our rule manager.
-		ruleManager = await Controller.createManager();
+		ruleManager = await Controller.createRuleManager();
 	});
 
 	describe('getRulesMatchingCriteria()', () => {

--- a/test/lib/RuleManager.test.ts
+++ b/test/lib/RuleManager.test.ts
@@ -1,12 +1,13 @@
 import {expect} from 'chai';
+import {Controller} from '../../src/ioc.config';
 import {PmdCatalogWrapper} from "../../src/lib/pmd/PmdCatalogWrapper";
-import {RULE_FILTER_TYPE, RuleFilter, RuleManager} from '../../src/lib/RuleManager';
+import {FilterType, RuleFilter} from '../../src/lib/RuleFilter';
 import fs = require('fs');
 import path = require('path');
 import Sinon = require('sinon');
 
 const PMD_CATALOG_FIXTURE_PATH = path.join('test', 'catalog-fixtures', 'DefaultPmdCatalogFixture.json');
-const PMD_FIXTURE_RULE_COUNT = 70;
+const PMD_FIXTURE_RULE_COUNT = 73;
 let ruleManager = null;
 
 describe('RuleManager', () => {
@@ -29,7 +30,7 @@ describe('RuleManager', () => {
 		});
 
 		// Declare our rule manager.
-		ruleManager = await RuleManager.create();
+		ruleManager = await Controller.createManager();
 	});
 
 	describe('getRulesMatchingCriteria()', () => {
@@ -46,7 +47,7 @@ describe('RuleManager', () => {
 		describe('Test Case: Filtering by category only', () => {
 			it('Filtering by one category returns only rules in that category', async () => {
 				// Set up our filter array.
-				const filters = [new RuleFilter(RULE_FILTER_TYPE.CATEGORY, ['Best Practices'])];
+				const filters = [new RuleFilter(FilterType.CATEGORY, ['Best Practices'])];
 
 				// Pass the filter array into the manager.
 				const matchingRules = await ruleManager.getRulesMatchingCriteria(filters);
@@ -57,20 +58,20 @@ describe('RuleManager', () => {
 
 			it('Filtering by multiple categories returns any rule in either category', async () => {
 				// Set up our filter array.
-				const filters = [new RuleFilter(RULE_FILTER_TYPE.CATEGORY, ['Best Practices', 'Design'])];
+				const filters = [new RuleFilter(FilterType.CATEGORY, ['Best Practices', 'Design'])];
 
 				// Pass the filter array into the manager.
 				const matchingRules = await ruleManager.getRulesMatchingCriteria(filters);
 
 				// Expect the right number of rules to be returned.
-				expect(matchingRules).to.have.lengthOf(22, 'Exactly 22 rules are categorized as "Best Practices" or "Design"');
+				expect(matchingRules).to.have.lengthOf(23, 'Exactly 23 rules are categorized as "Best Practices" or "Design"');
 			});
 		});
 
 		describe('Test Case: Filtering by ruleset only', () => {
 			it('Filtering by a single ruleset returns only the rules in that ruleset', async () => {
 				// Set up our filter array.
-				const filters = [new RuleFilter(RULE_FILTER_TYPE.RULESET, ['Braces'])];
+				const filters = [new RuleFilter(FilterType.RULESET, ['Braces'])];
 
 				// Pass the filter array into the manager.
 				const matchingRules = await ruleManager.getRulesMatchingCriteria(filters);
@@ -81,7 +82,7 @@ describe('RuleManager', () => {
 
 			it('Filtering by multiple rulesets returns any rule in either ruleset', async () => {
 				// Set up our filter array.
-				const filters = [new RuleFilter(RULE_FILTER_TYPE.RULESET, ['Braces', 'ApexUnit'])];
+				const filters = [new RuleFilter(FilterType.RULESET, ['Braces', 'ApexUnit'])];
 
 				// Pass the filter array into the manager.
 				const matchingRules = await ruleManager.getRulesMatchingCriteria(filters);
@@ -94,24 +95,24 @@ describe('RuleManager', () => {
 		describe('Test Case: Filtering by language', () => {
 			it('Filtering by a single language returns only rules targeting that language', async () => {
 				// Set up our filter array.
-				const filters = [new RuleFilter(RULE_FILTER_TYPE.LANGUAGE, ['apex'])];
+				const filters = [new RuleFilter(FilterType.LANGUAGE, ['apex'])];
 
 				// Pass the filter array into the manager.
 				const matchingRules = await ruleManager.getRulesMatchingCriteria(filters);
 
 				// Expect the right number of rules to be returned.
-				expect(matchingRules).to.have.lengthOf(53, 'There are 53 rules that target Apex');
+				expect(matchingRules).to.have.lengthOf(56, 'There are 56 rules that target Apex');
 			});
 
 			it('Filtering by multiple languages returns any rule targeting either language', async () => {
 				// Set up our filter array.
-				const filters = [new RuleFilter(RULE_FILTER_TYPE.LANGUAGE, ['apex', 'javascript'])];
+				const filters = [new RuleFilter(FilterType.LANGUAGE, ['apex', 'javascript'])];
 
 				// Pass the filter array into the manager.
 				const matchingRules = await ruleManager.getRulesMatchingCriteria(filters);
 
 				// Expect the right number of rules to be returned.
-				expect(matchingRules).to.have.lengthOf(70, 'There are 70 rules targeting either Apex or JS');
+				expect(matchingRules).to.have.lengthOf(73, 'There are 73 rules targeting either Apex or JS');
 			});
 		});
 
@@ -119,8 +120,8 @@ describe('RuleManager', () => {
 			it('Filtering on multiple columns at once returns only rules that satisfy ALL filters', async () => {
 				// Set up our filter array.
 				const filters = [
-					new RuleFilter(RULE_FILTER_TYPE.LANGUAGE, ['apex']),
-					new RuleFilter(RULE_FILTER_TYPE.CATEGORY, ['Best Practices'])
+					new RuleFilter(FilterType.LANGUAGE, ['apex']),
+					new RuleFilter(FilterType.CATEGORY, ['Best Practices'])
 				];
 
 				// Pass the filter array into the manager.
@@ -134,7 +135,7 @@ describe('RuleManager', () => {
 		describe('Edge Case: No rules match criteria', () => {
 			it('When no rules match the given criteria, an empty list is returned', async () => {
 				// Define our preposterous filter array.
-				const impossibleFilters = [new RuleFilter(RULE_FILTER_TYPE.CATEGORY, ['beebleborp'])];
+				const impossibleFilters = [new RuleFilter(FilterType.CATEGORY, ['beebleborp'])];
 
 				// Pass our filters into the manager.
 				const matchingRules = await ruleManager.getRulesMatchingCriteria(impossibleFilters);

--- a/test/lib/util/PrettyPrinter.test.ts
+++ b/test/lib/util/PrettyPrinter.test.ts
@@ -1,6 +1,70 @@
 import {expect} from 'chai';
+import {FilterType, RuleFilter} from '../../../src/lib/RuleFilter';
 import * as PrettyPrinter from '../../../src/lib/util/PrettyPrinter';
-import {RuleFilter, RULE_FILTER_TYPE} from '../../../src/lib/RuleManager';
+import {Rule} from '../../../src/types';
+
+
+function createRuleFilter(filterType: FilterType): {ruleFilter: RuleFilter; expectedRuleFilterString: string} {
+	const expectedRuleFilterString = `RuleFilter[filterType=${filterType}, filterValues=Rule1,Rule2]`;
+	const ruleFilter = new RuleFilter(filterType, ['Rule1', 'Rule2']);
+	return {ruleFilter, expectedRuleFilterString};
+}
+
+function createRuleFilters(): {ruleFilters: RuleFilter[]; expectedRuleFiltersString: string} {
+	const ruleFilter1 = createRuleFilter(FilterType.RULENAME);
+	const ruleFilter2 = createRuleFilter(FilterType.LANGUAGE);
+	const ruleFilters: RuleFilter[] = [ruleFilter1.ruleFilter, ruleFilter2.ruleFilter];
+	const expectedRuleFiltersString = `[${ruleFilter1.expectedRuleFilterString},${ruleFilter2.expectedRuleFilterString}]`;
+	return {ruleFilters, expectedRuleFiltersString};
+}
+
+function createRule(): {rule: Rule; expectedRuleString: string} {
+	const rule: Rule = {
+		name: "RuleName1",
+		description: "rule description",
+		categories: ["Category1", "Category2"],
+		rulesets: ["Ruleset1", "Ruleset2"],
+		languages: ["apex", "javascript"],
+		engine: "pmd",
+		sourcepackage: "/some/path/to/a/package.jar"
+	};
+	const expectedRuleString = "Rule[name: RuleName1, description: rule description, categories: Category1,Category2, rulesets: Ruleset1,Ruleset2, languages: apex,javascript, engine: pmd, sourcepackage: /some/path/to/a/package.jar]";
+	return {rule, expectedRuleString};
+}
+
+function createRules(): {rules: Rule[]; expectedRulesString: string} {
+	const rule1 = createRule();
+	const rule2 = createRule();
+	const rules = [rule1.rule, rule2.rule];
+	const expectedRulesString = `[${rule1.expectedRuleString},${rule2.expectedRuleString}]`;
+	return {rules, expectedRulesString};
+}
+
+function createSet(): {setOfString: Set<string>; expectedString: string} {
+	const setOfString = new Set<string>();
+	setOfString.add('value1');
+	setOfString.add('value2');
+	setOfString.add('value3');
+	const expectedString = '[value1,value2,value3]';
+	return {setOfString, expectedString};
+}
+
+function createMapOfSet(): {mapOfSet: Map<string, Set<string>>; expectedMapString: string} {
+	const mapOfSet = new Map<string, Set<string>>();
+	const {setOfString, expectedString} = createSet();
+	mapOfSet.set('key1', setOfString);
+	mapOfSet.set('key2', setOfString);
+	const expectedMapString = `{key1 => ${expectedString}},{key2 => ${expectedString}}`;
+	return {mapOfSet, expectedMapString};
+}
+
+function createMapOfMapOfSet(): {mapOfMapOfSet: Map<string,Map<string,Set<string>>>; expectedMapOfMapString: string} {
+	const mapOfMapOfSet = new Map<string, Map<string, Set<string>>>();
+	const {mapOfSet, expectedMapString} = createMapOfSet();
+	mapOfMapOfSet.set('topKey1', mapOfSet);
+	const expectedMapOfMapString = `{topKey1 => ${expectedMapString}}`
+	return {mapOfMapOfSet, expectedMapOfMapString};
+}
 
 describe(('PrettyPrinter tests'), () => {
 	it('should print Set<string>', () => {
@@ -19,7 +83,7 @@ describe(('PrettyPrinter tests'), () => {
 	});
 
 	it('should print a RuleFilter', () => {
-		const {ruleFilter, expectedRuleFilterString} = createRuleFilter(RULE_FILTER_TYPE.CATEGORY);
+		const {ruleFilter, expectedRuleFilterString} = createRuleFilter(FilterType.CATEGORY);
 		expect(PrettyPrinter.stringifyRuleFilter(ruleFilter)).equals(expectedRuleFilterString);
 	});
 
@@ -38,65 +102,3 @@ describe(('PrettyPrinter tests'), () => {
 		expect(PrettyPrinter.stringifyRules(rules)).equals(expectedRulesString);
 	});
 });
-
-function createRuleFilter(filterType: RULE_FILTER_TYPE) {
-	const expectedRuleFilterString = `RuleFilter[filterType=${filterType}, filterValues=Rule1,Rule2]`;
-	const ruleFilter = new RuleFilter(filterType, ['Rule1', 'Rule2']);
-	return {ruleFilter, expectedRuleFilterString};
-}
-
-function createRuleFilters() {
-	const ruleFilter1 = createRuleFilter(RULE_FILTER_TYPE.RULENAME);
-	const ruleFilter2 = createRuleFilter(RULE_FILTER_TYPE.LANGUAGE);
-	const ruleFilters: RuleFilter[] = [ruleFilter1.ruleFilter, ruleFilter2.ruleFilter];
-	const expectedRuleFiltersString = `[${ruleFilter1.expectedRuleFilterString},${ruleFilter2.expectedRuleFilterString}]`;
-	return {ruleFilters, expectedRuleFiltersString};
-}
-
-function createRule() {
-	const rule = {
-		name: 'RuleName1',
-		description: 'rule description',
-		categories: ['Category1', 'Category2'],
-		rulesets: ['Ruleset1', 'Ruleset2'],
-		languages: ['apex', 'javascript'],
-		sourcepackage: '/some/path/to/a/package.jar'
-	};
-	const expectedRuleString = 'Rule[name: RuleName1, description: rule description, categories: Category1,Category2, rulesets: Ruleset1,Ruleset2, languages: apex,javascript, sourcepackage: /some/path/to/a/package.jar]';
-	return {rule, expectedRuleString};
-}
-
-function createRules() {
-	const rule1 = createRule();
-	const rule2 = createRule();
-	const rules = [rule1.rule, rule2.rule];
-	const expectedRulesString = `[${rule1.expectedRuleString},${rule2.expectedRuleString}]`;
-	return {rules, expectedRulesString};
-}
-
-function createSet() {
-	const setOfString = new Set<string>();
-	setOfString.add('value1');
-	setOfString.add('value2');
-	setOfString.add('value3');
-	const expectedString = '[value1,value2,value3]';
-	return {setOfString, expectedString};
-}
-
-function createMapOfSet() {
-	const mapOfSet = new Map<string, Set<string>>();
-	const {setOfString, expectedString} = createSet();
-	mapOfSet.set('key1', setOfString);
-	mapOfSet.set('key2', setOfString);
-	const expectedMapString = `{key1 => ${expectedString}},{key2 => ${expectedString}}`;
-	return {mapOfSet, expectedMapString};
-}
-
-function createMapOfMapOfSet() {
-	const mapOfMapOfSet = new Map<string, Map<string, Set<string>>>();
-	const {mapOfSet, expectedMapString} = createMapOfSet();
-	mapOfMapOfSet.set('topKey1', mapOfSet);
-	const expectedMapOfMapString = `{topKey1 => ${expectedMapString}}`
-	return {mapOfMapOfSet, expectedMapOfMapString};
-}
-

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,16 @@
 {
 	"extends": "./node_modules/@salesforce/dev-config/tsconfig",
 	"compilerOptions": {
+		// Much of this is here because of Inversify.  If we swap it out in the future, remember to
+		// clean these bits up.
 		"outDir": "./lib",
 		"rootDir": "./src",
 		"allowJs": false,
-		"target": "es6",
-		"lib": ["es6", "dom"],
-		"types": ["reflect-metadata", "node", "mocha"],
-		"module": "commonjs",
-		"moduleResolution": "node",
+//		"target": "es6",
+//		"lib": ["es6", "dom"],
+//		"types": ["reflect-metadata", "node", "mocha"],
+//		"module": "commonjs",
+//		"moduleResolution": "node",
 		"experimentalDecorators": true,
 		"emitDecoratorMetadata": true
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -2104,11 +2104,6 @@ inquirer@^7.0.0:
     strip-ansi "^6.0.0"
     through "^2.3.6"
 
-inversify@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/inversify/-/inversify-5.0.1.tgz#500d709b1434896ce5a0d58915c4a4210e34fb6e"
-  integrity sha512-Ieh06s48WnEYGcqHepdsJUIJUXpwH5o5vodAX+DK2JA/gjy4EbEcQZxw+uFfzysmKjiLXGYwNG3qDZsKVMcINQ==
-
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -3987,6 +3982,13 @@ tsutils@^3.17.1:
   integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
   dependencies:
     tslib "^1.8.1"
+
+tsyringe@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/tsyringe/-/tsyringe-4.1.0.tgz#9a0c34b332dee2173b968fb739d24c4e174d3086"
+  integrity sha512-a0YXEiUNkv/Q1cvniiKd/Qv7TNa7xaFaTTekdloUmZD//aFXQ4PsGfq/cuicMLtHrOQE2QHbCAqdPfQ9wyqN0w==
+  dependencies:
+    tslib "^1.9.3"
 
 tunnel-agent@*, tunnel-agent@^0.6.0, tunnel-agent@~0.6.0:
   version "0.6.0"


### PR DESCRIPTION
IOC part 2: swapped out Inversify for a lighter weight solution called tsyringe.  Lots of changes here, but all just refactoring and cleanup.  Added missing types, introduced more interfaces, made async initialization a bit more consistent.  The ESLint engine is there, but returning no rules/categories/rulesets.  Biggest change was to restructure the catalog json, both the new Catalog.json and the existing PmdCatalog.json.  Uses arrays now instead of an object map.