### PR TITLE
@W-7736591@ Use a temporary file to pass files to PMD

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"@types/chai": "^4",
 		"@types/mocha": "^7.0.2",
 		"@types/node": "^13.11.1",
+		"@types/tmp": "^0.2.0",
 		"chai": "^4",
 		"eslint": "^6.8.0",
 		"mocha": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
 		"@types/chai": "^4",
 		"@types/mocha": "^7.0.2",
 		"@types/node": "^13.11.1",
-		"@types/tmp": "^0.2.0",
 		"chai": "^4",
 		"eslint": "^6.8.0",
 		"mocha": "^7.2.0",

--- a/src/lib/pmd/PmdWrapper.ts
+++ b/src/lib/pmd/PmdWrapper.ts
@@ -72,7 +72,7 @@ export default class PmdWrapper extends PmdSupport {
 		// NOTE: If we were going to run this command from the CLI directly, then we'd wrap the classpath in quotes, but this
 		// is intended for child_process.spawn(), which freaks out if you do that.
 		const classpath = await super.buildClasspath();
-		this.tempFile = await tmp.fileSync();
+		this.tempFile = tmp.fileSync();
 		fs.writeFileSync(this.tempFile.name, this.path);
 		const args = ['-cp', classpath.join(path.delimiter), HEAP_SIZE, MAIN_CLASS, '-filelist', this.tempFile.name,
 			'-format', this.reportFormat];

--- a/src/lib/util/FileHandler.ts
+++ b/src/lib/util/FileHandler.ts
@@ -1,5 +1,7 @@
 import fs = require('fs');
 import {Stats} from 'fs';
+import tmp = require('tmp');
+import {FileResult} from 'tmp'
 
 /**
  * Handles all File and IO operations.
@@ -71,6 +73,18 @@ export class FileHandler {
 			return fs.writeFile(filename, fileContent, (err) => {
 				if(!err) {
 					resolve();
+				} else {
+					reject(err);
+				}
+			});
+		});
+	}
+
+	tmpFile(options: object = {}): Promise<FileResult> {
+		return new Promise<FileResult>((resolve, reject) => {
+			return tmp.file(options, (err, name, fd, removeCallback) => {
+				if (!err) {
+					resolve({ name: name, fd:fd, removeCallback:removeCallback });
 				} else {
 					reject(err);
 				}

--- a/src/lib/util/FileHandler.ts
+++ b/src/lib/util/FileHandler.ts
@@ -1,7 +1,6 @@
 import fs = require('fs');
 import {Stats} from 'fs';
 import tmp = require('tmp');
-import {FileResult} from 'tmp'
 
 /**
  * Handles all File and IO operations.
@@ -80,11 +79,15 @@ export class FileHandler {
 		});
 	}
 
-	tmpFile(options: object = {}): Promise<FileResult> {
-		return new Promise<FileResult>((resolve, reject) => {
-			return tmp.file(options, (err, name, fd, removeCallback) => {
+	// Create a temp file that will automatically be cleaned up when the process exits.
+	// Returns the absolute path of the temp file
+	tmpFileWithCleanup(): Promise<string> {
+		return new Promise<string>((resolve, reject) => {
+			// Ask tmp to clean up the file on process exit
+			tmp.setGracefulCleanup();
+			return tmp.file({}, (err, name) => {
 				if (!err) {
-					resolve({ name: name, fd:fd, removeCallback:removeCallback });
+					resolve(name);
 				} else {
 					reject(err);
 				}


### PR DESCRIPTION
Write the file paths to a temporary file and pass the path fo the
temporary file to PMD.

This avoids E2BIG errors if the scan contains so many files that the
command line becomes too long.