### PR TITLE
@W-7736937@ Add Triggers to PMD glob list

### DIFF
--- a/src/lib/util/Config.ts
+++ b/src/lib/util/Config.ts
@@ -24,7 +24,7 @@ const DEFAULT_CONFIG: ConfigContent = {
 		{
 			name: "pmd",
 			targetPatterns: [
-				"**/*.cls","**/*.java","**/*.js","**/*.page","**/*.component","**/*.xml",
+				"**/*.cls","**/*.trigger","**/*.java","**/*.js","**/*.page","**/*.component","**/*.xml",
 				"!**/node_modules/**","!**/*-meta.xml"
 			],
 			supportedLanguages: ['apex', 'javascript']


### PR DESCRIPTION
PMD can analyze Apex triggers. Include them by default in the list
supported globs.