### PR TITLE
@W-7661074@ ESLint changes

### DIFF
--- a/src/lib/eslint/BaseEslintEngine.ts
+++ b/src/lib/eslint/BaseEslintEngine.ts
@@ -40,6 +40,18 @@ export interface EslintStrategy {
 export class StaticDependencies {
 	/* eslint-disable @typescript-eslint/no-explicit-any */
 	createCLIEngine(config: Record<string,any>): CLIEngine {
+		// From https://eslint.org/docs/developer-guide/nodejs-api:
+		// options.baseConfig. Configuration object, extended by all configurations used with this instance.
+		// You can use this option to define the default settings that will be used if your configuration files don't configure it.
+		config["baseConfig"] = {
+			// Include the following environment variables in order to support the objects declared in the comment
+			"env": {
+				"es6": true, // Map
+				"node": true, // process
+				"browser": true, // document
+				"webextensions": true // chrome
+			}
+		};
 		return new CLIEngine(config);
 	}
 	
@@ -148,7 +160,6 @@ export abstract class BaseEslintEngine implements RuleEngine {
 	}
 
 	async run(ruleGroups: RuleGroup[], rules: Rule[], targets: RuleTarget[]): Promise<RuleResult[]> {
-
 		// If we didn't find any paths, we're done.
 		if (!targets || targets.length === 0) {
 			this.logger.trace('No matching target files found. Nothing to execute.');

--- a/src/lib/eslint/TypescriptEslintStrategy.ts
+++ b/src/lib/eslint/TypescriptEslintStrategy.ts
@@ -39,8 +39,9 @@ const ES_PLUS_TS_CONFIG = {
 		"lib/**",
 		"node_modules/**"
 	],
-	"useEslintrc": false // TODO derive from existing eslintrc if found and desired
-
+	"useEslintrc": false, // TODO derive from existing eslintrc if found and desired
+	"resolvePluginsRelativeTo": __dirname, // Use the plugins found in the sfdx scanner installation directory
+	"cwd": __dirname // Use the parser found in the sfdx scanner installation
 };
 
 const TS_CONFIG = 'tsconfig.json';

--- a/src/lib/pmd/PmdEngine.ts
+++ b/src/lib/pmd/PmdEngine.ts
@@ -1,5 +1,4 @@
 import {Logger, SfdxError} from '@salesforce/core';
-import * as path from 'path';
 import {Element, xml2js} from 'xml-js';
 import {Controller} from '../../ioc.config';
 import {Catalog, Rule, RuleGroup, RuleResult, RuleTarget} from '../../types';
@@ -77,11 +76,7 @@ export class PmdEngine implements RuleEngine {
 		try {
 			const targetPaths: string[] = [];
 			for (const target of targets) {
-				if (target.isDirectory) {
-					targetPaths.push(...target.paths.map(p => path.join(target.target, p)));
-				} else {
-					targetPaths.push(...target.paths);
-				}
+				targetPaths.push(...target.paths);
 			}
 			if (targetPaths.length === 0) {
 				this.logger.trace('No matching pmd target files found. Nothing to execute.');

--- a/test/code-fixtures/projects/js/src/baseConfigEnv.js
+++ b/test/code-fixtures/projects/js/src/baseConfigEnv.js
@@ -1,0 +1,8 @@
+// Validate that default javascript features are supported by the eslint engine
+
+process.env.FOO;					// node
+var x = new Map();					// ex6
+if (x) {
+	console.log(document.body);		// browser
+}
+console.log(chrome.tabs);			// webextensions

--- a/test/commands/scanner/run.test.ts
+++ b/test/commands/scanner/run.test.ts
@@ -801,4 +801,18 @@ describe('scanner:run', function () {
 				});
 		});
 	});
+
+	describe('BaseConfig Environment Tests For Javascript', () => {
+		runTest
+		.stdout()
+		.stderr()
+		.command(['scanner:run',
+			'--target', path.join('test', 'code-fixtures', 'projects', 'js', 'src', 'baseConfigEnv.js'),
+			'--format', 'csv'
+		])
+		.it('The baseConfig enables the usage of default Javascript Types', ctx => {
+			// There should be no violations.
+			expect(ctx.stdout).to.contains('No rule violations found.', 'Should be no violations found in the file.');
+		});
+	});
 });


### PR DESCRIPTION
1. Resolve eslint plugins using the scanner installation directory
2. Resolve typescript parser using the scanner installation directory
3. Use absolute paths for files to scan. This is necessary since cwd is
set to support #2
4. Added default baseConfig to handle common javascript and typescript
objects