### PR TITLE
@W-7740537@ D/jbartolotta/w 7740537

### DIFF
--- a/docs/_articles/en/troubleshooting.md
+++ b/docs/_articles/en/troubleshooting.md
@@ -25,4 +25,36 @@ One possible reason is that the Java version you used to build your code is diff
 
 One possible reason is that you referenced a class in your custom rule Java code from the PMD library that's not available in version 6.22.0. Make sure that you reference only PMD features and classes that are available in version 6.22.0.
 
+### Commands display `Javascript is not currently supported by the PMD engine`.
 
+Version 6.22.0 of PMD has a [Known Issue](https://github.com/pmd/pmd/issues/2081) that causes a Java OutOfMemoryError when scanning some Javascript files. Scanning Javascript with PMD has been removed from the current version of the Salesforce CLI Scanner plug-in. We plan to restore this feature in a future version.
+
+Make the following changes to the PMD engine node in your `${HOME}/.sfdx-scanner/Config.json` file to resolve this error.
+
+1. Remove the `**/*.js` element from the PMD engine's `targetpatterns` array
+2. Remove the `javascript` element from PMD engine's `supportedLanguages` array
+
+The annotated JSON below shows you what you should remove
+```json
+{
+    "engines": [
+        {
+            "name": "pmd",
+            "targetPatterns": [
+                "**/*.cls",
+                "**/*.trigger",
+                "**/*.java",
+                "**/*.js",          // REMOVE THIS LINE
+                "**/*.page",
+                "**/*.component",
+                "**/*.xml",
+                "!**/node_modules/**",
+                "!**/*-meta.xml"
+            ],
+            "supportedLanguages": [
+                "apex",             // REMOVE THIS TRAILING COMMA
+                "javascript"        // REMOVE THIS
+            ]
+        },
+... Rest of file removed for clarity ...
+```

--- a/messages/PmdCatalogWrapper.js
+++ b/messages/PmdCatalogWrapper.js
@@ -1,0 +1,3 @@
+module.exports = {
+	"JavascriptNotSupported": "Javascript is not currently supported by the PMD engine."
+};

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -7,3 +7,9 @@ export const CUSTOM_PATHS_FILE = 'CustomPaths.json';
 export const CONFIG_FILE = 'Config.json';
 
 export const TYPESCRIPT_RULE_PREFIX = '@typescript';
+
+export const LANGUAGES = {
+    APEX: "apex",
+    JAVA: "java",
+    JAVASCRIPT: "javascript"
+};

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -8,8 +8,9 @@ export const CONFIG_FILE = 'Config.json';
 
 export const TYPESCRIPT_RULE_PREFIX = '@typescript';
 
-export const LANGUAGES = {
-    APEX: "apex",
-    JAVA: "java",
-    JAVASCRIPT: "javascript"
-};
+export enum LANGUAGE {
+	APEX = 'apex',
+	JAVA = 'java',
+	JAVASCRIPT = 'javascript',
+	PLSQL = 'plsql'
+}

--- a/src/lib/pmd/PmdCatalogWrapper.ts
+++ b/src/lib/pmd/PmdCatalogWrapper.ts
@@ -1,6 +1,6 @@
-import {Logger, Messages} from '@salesforce/core';
+import {Logger, Messages, SfdxError} from '@salesforce/core';
 import {ChildProcessWithoutNullStreams} from "child_process";
-import {SFDX_SCANNER_PATH} from '../../Constants';
+import {LANGUAGES, SFDX_SCANNER_PATH} from '../../Constants';
 import {Catalog} from '../../types';
 import {FileHandler} from '../util/FileHandler';
 import * as PrettyPrinter from '../util/PrettyPrinter';
@@ -90,7 +90,7 @@ export class PmdCatalogWrapper extends PmdSupport {
 	 * Return a map where the key is the language and the value is a set of class/jar paths.  Start with the given
 	 * default values, if provided.
 	 */
-	private async getRulePathEntries(): Promise<Map<string, Set<string>>> {
+	protected async getRulePathEntries(): Promise<Map<string, Set<string>>> {
 		const pathSetMap = new Map<string, Set<string>>();
 
 		const customPathEntries: Map<string, Set<string>> = await this.getCustomRulePathEntries();
@@ -117,6 +117,9 @@ export class PmdCatalogWrapper extends PmdSupport {
 		// Now, we'll want to add the default PMD JARs for any activated languages.
 		const supportedLanguages = await PmdLanguageManager.getSupportedLanguages();
 		supportedLanguages.forEach((language) => {
+			if (LANGUAGES.JAVASCRIPT === language) {
+				throw SfdxError.create('@salesforce/sfdx-scanner', 'PmdCatalogWrapper', 'JavascriptNotSupported');
+			}
 			const pmdJarName = PmdCatalogWrapper.derivePmdJarName(language);
 			const pathSet = pathSetMap.get(language) || new Set<string>();
 			pathSet.add(pmdJarName);

--- a/src/lib/pmd/PmdCatalogWrapper.ts
+++ b/src/lib/pmd/PmdCatalogWrapper.ts
@@ -1,6 +1,6 @@
-import {Logger, Messages, SfdxError} from '@salesforce/core';
+import {Logger, Messages} from '@salesforce/core';
 import {ChildProcessWithoutNullStreams} from "child_process";
-import {LANGUAGES, SFDX_SCANNER_PATH} from '../../Constants';
+import {SFDX_SCANNER_PATH} from '../../Constants';
 import {Catalog} from '../../types';
 import {FileHandler} from '../util/FileHandler';
 import * as PrettyPrinter from '../util/PrettyPrinter';
@@ -117,9 +117,6 @@ export class PmdCatalogWrapper extends PmdSupport {
 		// Now, we'll want to add the default PMD JARs for any activated languages.
 		const supportedLanguages = await PmdLanguageManager.getSupportedLanguages();
 		supportedLanguages.forEach((language) => {
-			if (LANGUAGES.JAVASCRIPT === language) {
-				throw SfdxError.create('@salesforce/sfdx-scanner', 'PmdCatalogWrapper', 'JavascriptNotSupported');
-			}
 			const pmdJarName = PmdCatalogWrapper.derivePmdJarName(language);
 			const pathSet = pathSetMap.get(language) || new Set<string>();
 			pathSet.add(pmdJarName);

--- a/src/lib/pmd/PmdLanguageManager.ts
+++ b/src/lib/pmd/PmdLanguageManager.ts
@@ -1,7 +1,7 @@
 import {Config} from '../util/Config';
 import {Controller} from '../../ioc.config';
 import {PmdEngine} from './PmdEngine';
-
+import {LANGUAGE} from '../../Constants'
 import {Logger, SfdxError, Messages} from '@salesforce/core';
 import {AsyncCreatable} from '@salesforce/kit';
 
@@ -58,7 +58,10 @@ class PmdLanguageManager extends AsyncCreatable {
 		for (const alias of aliases) {
 			const lang = this.resolveLanguageAlias(alias);
 			if (lang) {
-				langs.push(lang);
+				if (LANGUAGE.JAVASCRIPT === lang) {
+					throw SfdxError.create('@salesforce/sfdx-scanner', 'PmdCatalogWrapper', 'JavascriptNotSupported');
+				}
+					langs.push(lang);
 			} else {
 				this.logger.trace(`Default-supported language alias ${alias} could not be resolved.`);
 				throw SfdxError.create('@salesforce/sfdx-scanner', 'PmdLanguageManager', 'InvalidLanguageAlias', [alias]);

--- a/src/lib/util/Config.ts
+++ b/src/lib/util/Config.ts
@@ -24,10 +24,10 @@ const DEFAULT_CONFIG: ConfigContent = {
 		{
 			name: "pmd",
 			targetPatterns: [
-				"**/*.cls","**/*.trigger","**/*.java","**/*.js","**/*.page","**/*.component","**/*.xml",
+				"**/*.cls","**/*.trigger","**/*.java","**/*.page","**/*.component","**/*.xml",
 				"!**/node_modules/**","!**/*-meta.xml"
 			],
-			supportedLanguages: ['apex', 'javascript']
+			supportedLanguages: ['apex']
 		},
 		{
 			name: "eslint",

--- a/test/catalog-fixtures/DefaultCatalogFixture.json
+++ b/test/catalog-fixtures/DefaultCatalogFixture.json
@@ -17,6 +17,14 @@
 			"engine": "pmd"
 		},
 		{
+			"paths": [
+				"category/ecmascript/errorprone.xml",
+				"category/apex/errorprone.xml"
+			],
+			"name": "Error Prone",
+			"engine": "pmd"
+		},
+		{
 			"name": "Best Practices",
 			"engine": "eslint",
 			"paths": [

--- a/test/commands/scanner/rule/describe.test.ts
+++ b/test/commands/scanner/rule/describe.test.ts
@@ -80,19 +80,19 @@ describe('scanner:rule:describe', () => {
 			// Both tests will test for the presence of this warning string in the output, so we might as well format it up here.
 			const formattedWarning = messages.output.multipleMatchingRules
 				.replace('{0}', '2')
-				.replace('{1}', 'WhileLoopsMustUseBraces');
+				.replace('{1}', 'constructor-super');
 
 			describeTest
 				.stdout()
 				.stderr()
-				.command(['scanner:rule:describe', '--rulename', 'WhileLoopsMustUseBraces'])
+				.command(['scanner:rule:describe', '--rulename', 'constructor-super'])
 				.it('Displayed output matches expectations', ctx => {
 					// First, verify that the warning was printed at the start like it should have been.
 					expect(ctx.stderr).to.contain('WARNING: ' + formattedWarning, 'Warning message should be formatted correctly');
 
 					// Next, verify that there are two rule descriptions that are distinctly identified.
-					const regex = /=== Rule #1\nname:\s+WhileLoopsMustUseBraces(.*\n)*=== Rule #2\nname:\s+WhileLoopsMustUseBraces/g;
-					expect(ctx.stdout).to.match(regex, 'Output should contain two rules named WhileLoopsMustUseBraces');
+					const regex = /=== Rule #1\nname:\s+constructor-super(.*\n)*=== Rule #2\nname:\s+constructor-super/g;
+					expect(ctx.stdout).to.match(regex, 'Output should contain two rules named constructor-super');
 				});
 
 			// TODO: THIS TEST IS FAILING BECAUSE THE WARNING FOR DEFINITELYFAKERULE IS BEING INCLUDED IN THE WARNINGS HERE.

--- a/test/commands/scanner/run.test.ts
+++ b/test/commands/scanner/run.test.ts
@@ -791,7 +791,7 @@ describe('scanner:run', function () {
 				.stdout()
 				.stderr()
 				.command(['scanner:run', '--target', '**/*.js,**/*.cls', '--format', 'json'])
-				.it('Poloyglot project triggers pmd and eslint rules', ctx => {
+				.it('Polyglot project triggers pmd and eslint rules', ctx => {
 					expect(ctx.stderr).to.be.empty;
 					const results = JSON.parse(ctx.stdout.substring(ctx.stdout.indexOf("[{")));
 					// Look through all of the results and gather a set of unique engines

--- a/test/commands/scanner/run.test.ts
+++ b/test/commands/scanner/run.test.ts
@@ -782,19 +782,24 @@ describe('scanner:run', function () {
 	describe('MultiEngine', () => {
 		describe('Project: JS', () => {
 			before(() => {
-				process.chdir(path.join('test', 'code-fixtures', 'projects'))
+				process.chdir(path.join('test', 'code-fixtures', 'projects', 'app'))
 			});
 			after(() => {
-				process.chdir("../../..");
+				process.chdir("../../../..");
 			});
 			runTest
 				.stdout()
 				.stderr()
-				.command(['scanner:run', '--target', 'js', '--format', 'json'])
-				.it('JS project triggers pmd and eslint rules', ctx => {
+				.command(['scanner:run', '--target', '**/*.js,**/*.cls', '--format', 'json'])
+				.it('Poloyglot project triggers pmd and eslint rules', ctx => {
 					expect(ctx.stderr).to.be.empty;
 					const results = JSON.parse(ctx.stdout.substring(ctx.stdout.indexOf("[{")));
-					expect(results).to.be.an("array").that.has.length(2);
+					// Look through all of the results and gather a set of unique engines
+					const uniqueEngines = new Set(results.map(r => { return r.engine }));
+					expect(uniqueEngines).to.be.an("Set").that.has.length(2);
+					expect(uniqueEngines).to.contain("eslint");
+					expect(uniqueEngines).to.contain("pmd");
+					// Validate that all of the results have an expected property
 					for (const result of results) {
 						expect(result.violations[0], `Message is ${result.violations[0].message}`).to.have.property("ruleName").that.is.not.null;
 					}

--- a/test/lib/RuleManager.test.ts
+++ b/test/lib/RuleManager.test.ts
@@ -170,7 +170,7 @@ describe('RuleManager', () => {
 						results = JSON.parse(output);
 					}
 
-					expect(results).to.be.an("array").that.has.length(2);
+					expect(results).to.be.an("array").that.has.length(1);
 					for (const result of results) {
 						expect(result.violations[0], `Message is ${result.violations[0].message}`).to.have.property("ruleName").that.is.not.null;
 					}
@@ -201,7 +201,7 @@ describe('RuleManager', () => {
 					} else {
 						results = JSON.parse(output);
 					}
-					expect(results).to.be.an("array").that.has.length(6);
+					expect(results).to.be.an("array").that.has.length(8);
 					for (const result of results) {
 						expect(result.violations[0], `Message is ${result.violations[0]['message']}`).to.have.property("ruleName").that.is.not.null;
 					}
@@ -222,7 +222,7 @@ describe('RuleManager', () => {
 						results = JSON.parse(output);
 					}
 
-					expect(results).to.be.an("array").that.has.length(4);
+					expect(results, JSON.stringify(results)).to.be.an("array").that.has.length(3);
 					for (const result of results) {
 						expect(result.violations[0], `Message is ${result.violations[0]['message']}`).to.have.property("ruleName").that.is.not.null;
 					}
@@ -230,7 +230,7 @@ describe('RuleManager', () => {
 
 				it('Filtering by multiple categories runs any rule in either category', async () => {
 					// Set up our filter array.
-					const filters = [new RuleFilter(FilterType.CATEGORY, ['Best Practices', 'Design'])];
+					const filters = [new RuleFilter(FilterType.CATEGORY, ['Best Practices', 'Error Prone'])];
 
 					const output = await ruleManager.runRulesMatchingCriteria(filters, ['projects/app'], OUTPUT_FORMAT.JSON);
 					let results = null;
@@ -240,7 +240,7 @@ describe('RuleManager', () => {
 						results = JSON.parse(output);
 					}
 
-					expect(results).to.be.an("array").that.has.length(4);
+					expect(results).to.be.an("array").that.has.length(6);
 					for (const result of results) {
 						expect(result.violations[0], `Message is ${result.violations[0]['message']}`).to.have.property("ruleName").that.is.not.null;
 					}

--- a/test/lib/pmd/PmdCatalogWrapper.test.ts
+++ b/test/lib/pmd/PmdCatalogWrapper.test.ts
@@ -1,13 +1,11 @@
 import {PmdCatalogWrapper} from '../../../src/lib/pmd/PmdCatalogWrapper';
-import * as PmdLanguageManager from '../../../src/lib/pmd/PmdLanguageManager';
 import {PmdEngine} from '../../../src/lib/pmd/PmdEngine';
 import {CustomRulePathManager} from '../../../src/lib/CustomRulePathManager';
 import {Config} from '../../../src/lib/util/Config';
-import {LANGUAGES} from '../../../src/Constants';
+import {LANGUAGE} from '../../../src/Constants';
 import {expect} from 'chai';
 import Sinon = require('sinon');
 import path = require('path');
-import {fail} from 'assert';
 // In order to get access to PmdCatalogWrapper's protected methods, we're going to extend it with a test class here.
 class TestablePmdCatalogWrapper extends PmdCatalogWrapper {
 	public async buildCommandArray(): Promise<[string, string[]]> {
@@ -27,7 +25,7 @@ describe('PmdCatalogWrapper', () => {
 				before(() => {
 					Sinon.createSandbox();
 					// Spoof a config that claims that only Apex's default PMD JAR is enabled.
-					Sinon.stub(Config.prototype, 'getSupportedLanguages').withArgs(PmdEngine.NAME).resolves([LANGUAGES.APEX]);
+					Sinon.stub(Config.prototype, 'getSupportedLanguages').withArgs(PmdEngine.NAME).resolves([LANGUAGE.APEX]);
 					// Spoof a CustomPathManager that claims that a custom JAR exists for Java.
 					const customJars: Map<string, Set<string>> = new Map();
 					customJars.set('java', new Set([irrelevantPath]));
@@ -64,7 +62,7 @@ describe('PmdCatalogWrapper', () => {
 				before(() => {
 					Sinon.createSandbox();
 					// Spoof a config that claims that only Apex's default PMD JAR is enabled.
-					Sinon.stub(Config.prototype, 'getSupportedLanguages').withArgs(PmdEngine.NAME).resolves([LANGUAGES.APEX]);
+					Sinon.stub(Config.prototype, 'getSupportedLanguages').withArgs(PmdEngine.NAME).resolves([LANGUAGE.APEX]);
 					// Spoof a CustomPathManager that claims that a custom JAR exists for plsql, using a weird alias for that language.
 					const customJars: Map<string, Set<string>> = new Map();
 					customJars.set('Pl/SqL', new Set([irrelevantPath]));
@@ -95,29 +93,6 @@ describe('PmdCatalogWrapper', () => {
 					expect(params[5]).to.match(/^apex=.*pmd-apex-.*.jar$/, 'Sixth parameter is Apex-specific, with only standard JAR.');
 				});
 			});
-		});
-	});
-
-	describe('getRulePathEntries()', () => {
-		before(() => {
-			Sinon.createSandbox();
-			// Stub out the array so that it returns 'javascript'
-			Sinon.stub(PmdLanguageManager, "getSupportedLanguages").resolves([LANGUAGES.APEX, LANGUAGES.JAVASCRIPT]);
-		});
-
-		after(() => {
-			Sinon.restore();
-		});
-
-		it('Throws exception if javascript is found in supportedLanguages array', async () => {
-			const target = await TestablePmdCatalogWrapper.create({});
-
-			try {
-				await target.getRulePathEntries();
-				fail('getRulePathEntries should have thrown');
-			} catch (ex) {
-				expect(ex.message).to.equal('Javascript is not currently supported by the PMD engine.');
-			}
 		});
 	});
 });

--- a/test/lib/pmd/PmdCatalogWrapper.test.ts
+++ b/test/lib/pmd/PmdCatalogWrapper.test.ts
@@ -1,14 +1,21 @@
 import {PmdCatalogWrapper} from '../../../src/lib/pmd/PmdCatalogWrapper';
+import * as PmdLanguageManager from '../../../src/lib/pmd/PmdLanguageManager';
 import {PmdEngine} from '../../../src/lib/pmd/PmdEngine';
 import {CustomRulePathManager} from '../../../src/lib/CustomRulePathManager';
 import {Config} from '../../../src/lib/util/Config';
+import {LANGUAGES} from '../../../src/Constants';
 import {expect} from 'chai';
 import Sinon = require('sinon');
 import path = require('path');
+import {fail} from 'assert';
 // In order to get access to PmdCatalogWrapper's protected methods, we're going to extend it with a test class here.
 class TestablePmdCatalogWrapper extends PmdCatalogWrapper {
 	public async buildCommandArray(): Promise<[string, string[]]> {
 		return super.buildCommandArray();
+	}
+
+	public async getRulePathEntries(): Promise<Map<string, Set<string>>> {
+		return super.getRulePathEntries();
 	}
 }
 
@@ -20,7 +27,7 @@ describe('PmdCatalogWrapper', () => {
 				before(() => {
 					Sinon.createSandbox();
 					// Spoof a config that claims that only Apex's default PMD JAR is enabled.
-					Sinon.stub(Config.prototype, 'getSupportedLanguages').withArgs(PmdEngine.NAME).resolves(['apex']);
+					Sinon.stub(Config.prototype, 'getSupportedLanguages').withArgs(PmdEngine.NAME).resolves([LANGUAGES.APEX]);
 					// Spoof a CustomPathManager that claims that a custom JAR exists for Java.
 					const customJars: Map<string, Set<string>> = new Map();
 					customJars.set('java', new Set([irrelevantPath]));
@@ -57,7 +64,7 @@ describe('PmdCatalogWrapper', () => {
 				before(() => {
 					Sinon.createSandbox();
 					// Spoof a config that claims that only Apex's default PMD JAR is enabled.
-					Sinon.stub(Config.prototype, 'getSupportedLanguages').withArgs(PmdEngine.NAME).resolves(['apex']);
+					Sinon.stub(Config.prototype, 'getSupportedLanguages').withArgs(PmdEngine.NAME).resolves([LANGUAGES.APEX]);
 					// Spoof a CustomPathManager that claims that a custom JAR exists for plsql, using a weird alias for that language.
 					const customJars: Map<string, Set<string>> = new Map();
 					customJars.set('Pl/SqL', new Set([irrelevantPath]));
@@ -88,6 +95,29 @@ describe('PmdCatalogWrapper', () => {
 					expect(params[5]).to.match(/^apex=.*pmd-apex-.*.jar$/, 'Sixth parameter is Apex-specific, with only standard JAR.');
 				});
 			});
+		});
+	});
+
+	describe('getRulePathEntries()', () => {
+		before(() => {
+			Sinon.createSandbox();
+			// Stub out the array so that it returns 'javascript'
+			Sinon.stub(PmdLanguageManager, "getSupportedLanguages").resolves([LANGUAGES.APEX, LANGUAGES.JAVASCRIPT]);
+		});
+
+		after(() => {
+			Sinon.restore();
+		});
+
+		it('Throws exception if javascript is found in supportedLanguages array', async () => {
+			const target = await TestablePmdCatalogWrapper.create({});
+
+			try {
+				await target.getRulePathEntries();
+				fail('getRulePathEntries should have thrown');
+			} catch (ex) {
+				expect(ex.message).to.equal('Javascript is not currently supported by the PMD engine.');
+			}
 		});
 	});
 });

--- a/test/lib/pmd/PmdLanguageManager.test.ts
+++ b/test/lib/pmd/PmdLanguageManager.test.ts
@@ -1,6 +1,7 @@
 import {expect} from 'chai';
 import Sinon = require('sinon');
 import {Config} from '../../../src/lib/util/Config';
+import {LANGUAGE} from '../../../src/Constants';
 import * as PmdLanguageManager from '../../../src/lib/pmd/PmdLanguageManager';
 import {PmdEngine} from '../../../src/lib/pmd/PmdEngine';
 import messages = require('../../../messages/PmdLanguageManager');
@@ -8,7 +9,7 @@ import messages = require('../../../messages/PmdLanguageManager');
 describe('PmdLanguageManager', () => {
 	describe('getSupportedLanguages()', () => {
 		describe('When Config specifies exact language names', () => {
-			const exactFakeLangs = ['apex', 'javascript', 'java'];
+			const exactFakeLangs = [LANGUAGE.APEX, LANGUAGE.JAVA];
 
 			before(() => {
 				Sinon.createSandbox();
@@ -22,12 +23,12 @@ describe('PmdLanguageManager', () => {
 
 			it('Explicitly supported languages are returned', async () => {
 				const langs = await PmdLanguageManager.getSupportedLanguages();
-				expect(langs).to.deep.equal(['apex', 'javascript', 'java'], 'Explicitly supported languages should have been returned');
+				expect(langs).to.deep.equal([LANGUAGE.APEX, LANGUAGE.JAVA], 'Explicitly supported languages should have been returned');
 			});
 		});
 
 		describe('When Config specifies weirdly aliased language names', () => {
-			const weirdlyAliasedLangs = ['ApEx', 'EcMaScRiPt', 'JaVa', 'Pl/SqL'];
+			const weirdlyAliasedLangs = ['ApEx', 'JaVa', 'Pl/SqL'];
 
 			before(() => {
 				Sinon.createSandbox();
@@ -41,7 +42,7 @@ describe('PmdLanguageManager', () => {
 
 			it('Aliases are successfully resolved into a viable language name', async () => {
 				const langs = await PmdLanguageManager.getSupportedLanguages();
-				expect(langs).to.deep.equal(['apex', 'javascript', 'java', 'plsql'], 'Aliases to languages should have been resolved');
+				expect(langs).to.deep.equal([LANGUAGE.APEX, LANGUAGE.JAVA, LANGUAGE.PLSQL], 'Aliases to languages should have been resolved');
 			});
 		});
 
@@ -64,6 +65,29 @@ describe('PmdLanguageManager', () => {
 					expect(true).to.equal(false, 'Error should have thrown');
 				} catch (e) {
 					expect(e.message).to.include(messages.InvalidLanguageAlias.replace('%s', 'NotRealLang'));
+				}
+			});
+		});
+
+		describe('When Javascript appears in config()', () => {
+			const langsContainingJavaScript = [LANGUAGE.APEX, LANGUAGE.JAVASCRIPT];
+
+			before(() => {
+				Sinon.createSandbox();
+				// Simulate a config that specifies javascript.
+				Sinon.stub(Config.prototype, 'getSupportedLanguages').withArgs(PmdEngine.NAME).resolves(langsContainingJavaScript);
+			});
+
+			after(() => {
+				Sinon.restore();
+			});
+
+			it('Throws exception if javascript is found in supportedLanguages array', async () => {
+				try {
+					await PmdLanguageManager.getSupportedLanguages();
+					expect(true).to.equal(false, 'Error should have thrown');
+				} catch (ex) {
+					expect(ex.message).to.equal('Javascript is not currently supported by the PMD engine.');
 				}
 			});
 		});


### PR DESCRIPTION
Throw an error if the PMD engine would run javascript rules. This is
accomplished by preventing 'javascript' from appearing in the PMD
engine's supportedLanguages array.

No enforcment is done of the PMD engine's targePatterns array, removing
the value from the supportedLanguages array is enough enforcement to
prevent the user from encountering the OOM bug.