### PR TITLE
@W-776022@ Give precedence to --tsconfig flag over cwd

### DIFF
--- a/messages/TypescriptEslintStrategy.js
+++ b/messages/TypescriptEslintStrategy.js
@@ -2,6 +2,5 @@ module.exports = {
 	"FileNotIncludedByTsConfig": "'%s' does not reside in a location that is included by your %s 'include' attribute.",
 	"MissingTsConfigFromCwd": "Unable to find '%s' in current directory '%s'. Please change to a directory that contains '%s' or specify it using the --tsconfig flag",
 	"InvalidNameTsConfigFromOptions": "File '%s' specified by the --tsconfig flag must be named '%s'",
-	"NotAFileTsConfigFromOptions": "Unable to find '%s' at location '%s' specified by the 'tsconfig' option",
-	"MultipleTsConfigs": "'%s' was found in current directory at location '%s', '%s' was also specified by the --tsconfig flag. Please change to another directory or remove the --tsconfig flag."
+	"NotAFileTsConfigFromOptions": "Unable to find '%s' at location '%s' specified by the 'tsconfig' option"
 }

--- a/src/lib/eslint/TypescriptEslintStrategy.ts
+++ b/src/lib/eslint/TypescriptEslintStrategy.ts
@@ -137,16 +137,13 @@ export class TypescriptEslintStrategy implements EslintStrategy {
 	 * Throw an error if a tsconfig.json file can't be found.
 	 */
 	async findTsconfig(engineOptions: Map<string, string>): Promise<string> {
-		let foundTsConfig = await this.checkEngineOptionsForTsconfig(engineOptions);
+		const foundTsConfig = (await this.checkEngineOptionsForTsconfig(engineOptions)) || (await this.checkWorkingDirectoryForTsconfig());
 
 		if (!foundTsConfig) {
-			foundTsConfig = await this.checkWorkingDirectoryForTsconfig();
-			if (!foundTsConfig) {
-				const cwd = path.resolve();
-				// Not specified in engineOptions and not found in the current directory
-				throw SfdxError.create('@salesforce/sfdx-scanner', 'TypescriptEslintStrategy', 'MissingTsConfigFromCwd',
-					[TS_CONFIG, cwd, TS_CONFIG]);
-			}
+			const cwd = path.resolve();
+			// Not specified in engineOptions and not found in the current directory
+			throw SfdxError.create('@salesforce/sfdx-scanner', 'TypescriptEslintStrategy', 'MissingTsConfigFromCwd',
+				[TS_CONFIG, cwd, TS_CONFIG]);
 		}
 
 		this.logger.trace(`Using ${TS_CONFIG} from ${foundTsConfig}`);

--- a/test/lib/eslint/TypescriptEslintStrategy.test.ts
+++ b/test/lib/eslint/TypescriptEslintStrategy.test.ts
@@ -58,6 +58,17 @@ describe('TypescriptEslint Strategy', () => {
 				expect(fileFound).equals(engineOptionsVal);
 			});
 
+
+			it('engineOptions.tsconfig should take precedence over tsconfig.json file found in the current working directory', async () => {
+				Sinon.stub(TestTypescriptEslintStrategy.prototype, 'checkWorkingDirectoryForTsconfig').resolves(cwdVal);
+				Sinon.stub(TestTypescriptEslintStrategy.prototype, 'checkEngineOptionsForTsconfig').resolves(engineOptionsVal);
+
+				const tsStrategy = new TestTypescriptEslintStrategy();
+				await tsStrategy.init();
+				const foundTsConfig = await tsStrategy.findTsconfig(null);
+				expect(foundTsConfig).to.equal(engineOptionsVal);
+			});
+
 			it('should throw an error if tsconfig is not in current working directory and not specified by engineOptions', async () => {
 				Sinon.stub(TestTypescriptEslintStrategy.prototype, 'checkWorkingDirectoryForTsconfig').resolves(null);
 				Sinon.stub(TestTypescriptEslintStrategy.prototype, 'checkEngineOptionsForTsconfig').resolves(null);
@@ -70,20 +81,6 @@ describe('TypescriptEslint Strategy', () => {
 					fail('findTsconfig should have thrown');
 				} catch(e) {
 					expect(e.message).to.contain(`Unable to find 'tsconfig.json' in current directory '${path.resolve()}'`)
-				}
-			});
-
-			it('should throw an error if tsconfig is in working directory and is also specified as engineOption', async () => {
-				Sinon.stub(TestTypescriptEslintStrategy.prototype, 'checkWorkingDirectoryForTsconfig').resolves(cwdVal);
-				Sinon.stub(TestTypescriptEslintStrategy.prototype, 'checkEngineOptionsForTsconfig').resolves(engineOptionsVal);
-
-				const tsStrategy = new TestTypescriptEslintStrategy();
-				await tsStrategy.init();
-				try {
-					await tsStrategy.findTsconfig(null);
-					fail("findTsconfig should have thrown");
-				} catch(e) {
-					expect(e.message).to.contain(`'tsconfig.json' was found in current directory at location '${cwdVal}', '${engineOptionsVal}' was also specified by the --tsconfig flag.`);
 				}
 			});
 		});


### PR DESCRIPTION
The previous implementation would thrown an error if a tsconfig.json
file was found in the current working directory and the --tsconfig flag
was specified on the command line.

Allow this situation, giving precedence to the value provided to --tsconfig.