### PR TITLE
@W-7907050@ Move ScannerCommand class to lib directory

### DIFF
--- a/src/commands/scanner/rule/describe.ts
+++ b/src/commands/scanner/rule/describe.ts
@@ -3,7 +3,7 @@ import {Messages} from '@salesforce/core';
 import {AnyJson} from '@salesforce/ts-types';
 import {Controller} from '../../../ioc.config';
 import {Rule} from '../../../types';
-import {ScannerCommand} from '../scannerCommand';
+import {ScannerCommand} from '../../../lib/ScannerCommand';
 
 // Initialize Messages with the current plugin directory
 Messages.importMessagesDirectory(__dirname);

--- a/src/commands/scanner/rule/list.ts
+++ b/src/commands/scanner/rule/list.ts
@@ -2,7 +2,7 @@ import {flags} from '@salesforce/command';
 import {Messages} from '@salesforce/core';
 import {Controller} from '../../../ioc.config';
 import {Rule} from '../../../types';
-import {ScannerCommand} from '../scannerCommand';
+import {ScannerCommand} from '../../../lib/ScannerCommand';
 
 // Initialize Messages with the current plugin directory
 Messages.importMessagesDirectory(__dirname);

--- a/src/commands/scanner/rule/remove.ts
+++ b/src/commands/scanner/rule/remove.ts
@@ -3,7 +3,7 @@ import {Messages, SfdxError} from '@salesforce/core';
 import {AnyJson} from '@salesforce/ts-types';
 import {Controller} from '../../../ioc.config';
 import {FilterType, RuleFilter} from '../../../lib/RuleFilter';
-import {ScannerCommand} from '../scannerCommand';
+import {ScannerCommand} from '../../../lib/ScannerCommand';
 import {Rule} from '../../../types';
 import path = require('path');
 import untildify = require('untildify');

--- a/src/commands/scanner/run.ts
+++ b/src/commands/scanner/run.ts
@@ -4,7 +4,7 @@ import {AnyJson} from '@salesforce/ts-types';
 import {LooseObject} from '../../types';
 import {Controller} from '../../ioc.config';
 import {OUTPUT_FORMAT} from '../../lib/RuleManager';
-import {ScannerCommand} from './scannerCommand';
+import {ScannerCommand} from '../../lib/ScannerCommand';
 import {TYPESCRIPT_ENGINE_OPTIONS} from '../../lib/eslint/TypescriptEslintStrategy';
 import fs = require('fs');
 import untildify = require('untildify');

--- a/src/lib/ScannerCommand.ts
+++ b/src/lib/ScannerCommand.ts
@@ -1,6 +1,6 @@
 import {SfdxCommand} from '@salesforce/command';
-import {FilterType, RuleFilter} from '../../lib/RuleFilter';
-import {uxEvents} from '../../lib/ScannerEvents';
+import {FilterType, RuleFilter} from './RuleFilter';
+import {uxEvents} from './ScannerEvents';
 
 export abstract class ScannerCommand extends SfdxCommand {
 


### PR DESCRIPTION
Oclif was detecting this abstract class as a command, which caused it to
show up in help commands. Move the file to the lib directory in order to avoid this issue.

Upper cased file since it contains a class.