### PR TITLE
@W-7957489@ Fix some corner cases for the HTML report

### DIFF
--- a/html-templates/simple.mustache
+++ b/html-templates/simple.mustache
@@ -260,17 +260,19 @@
 					{ data: 'ruleName',
 					    // Convert the ruleName to a hyperlink that displays the rule information
 						'render': function(data, type, row, meta){
-							if(type === 'display'){
+							if(data && type === 'display'){
 								data = '<a href="' + row.url + '" target="__blank">' + data + '</a>';
 							}
 							return data;
 						}
 					},
 					{ data: 'message' },
-					{ data: 'line', className: 'scannerLocation' },
-					{ data: 'column', className: 'scannerLocation' },
-					{ data: 'endLine', className: 'scannerLocation' },
-					{ data: 'endColumn', className: 'scannerLocation' },
+					// 'defaultContent' provides information to the Datatables code in cases where the row
+					// corresponds to something non file location specific. i.e. a tsconfig.json error
+					{ data: 'line', className: 'scannerLocation', defaultContent: ''},
+					{ data: 'column', className: 'scannerLocation', defaultContent: ''},
+					{ data: 'endLine', className: 'scannerLocation', defaultContent: ''},
+					{ data: 'endColumn', className: 'scannerLocation', defaultContent: ''}
 				],
 				'rowCallback': function(row, data, index) {
 					var severity = data['severity'];


### PR DESCRIPTION
Some violations don't contain line or column information. Display these
as empty cells.

Some violations don't have an url parameter. Display these as empty
cells.