### PR TITLE
@W-8058863@ R/jbartolotta/w 8058863

### DIFF
--- a/src/commands/scanner/rule/add.ts
+++ b/src/commands/scanner/rule/add.ts
@@ -59,7 +59,8 @@ export default class Add extends SfdxCommand {
 		if (this.flags.language.length === 0) {
 			throw SfdxError.create('@salesforce/sfdx-scanner', 'add', 'validations.languageCannotBeEmpty', []);
 		}
-		if (this.flags.path.includes('')) {
+		// --path '' results in different values depending on the OS. On Windows it is [], on *nix it is [""]
+		if (this.flags.path && (!this.flags.path.length || this.flags.path.includes(''))) {
 			throw SfdxError.create('@salesforce/sfdx-scanner', 'add', 'validations.pathCannotBeEmpty', []);
 		}
 	}

--- a/src/commands/scanner/rule/remove.ts
+++ b/src/commands/scanner/rule/remove.ts
@@ -103,7 +103,8 @@ export default class Remove extends ScannerCommand {
 	}
 
 	private validateFlags(): void {
-		if (this.flags.path != null && this.flags.path.includes('')) {
+		// --path '' results in different values depending on the OS. On Windows it is [], on *nix it is [""]
+		if (this.flags.path && (!this.flags.path.length || this.flags.path.includes(''))) {
 			throw SfdxError.create('@salesforce/sfdx-scanner', 'remove', 'validations.pathCannotBeEmpty', []);
 		}
 	}

--- a/test/commands/scanner/rule/remove.test.ts
+++ b/test/commands/scanner/rule/remove.test.ts
@@ -14,11 +14,11 @@ const SFDX_SCANNER_PATH = Controller.getSfdxScannerPath();
 
 // NOTE: The relative paths are relative to the root of the project instead of to the location of this file,
 // because the root is the working directory during test evaluation.
-const parentFolderForJars = path.resolve('./test/test-jars/apex');
-const pathToApexJar1 = path.resolve('./test/test-jars/apex/testjar1.jar');
-const pathToApexJar2 = path.resolve('./test/test-jars/apex/testjar2.jar');
-const pathToApexJar3 = path.resolve('./test/test-jars/apex/testjar3.jar');
-const pathToApexJar4 = path.resolve('./test/test-jars/apex/testjar4.jar');
+const parentFolderForJars = path.resolve('test', 'test-jars', 'apex');
+const pathToApexJar1 = path.resolve('test', 'test-jars', 'apex', 'testjar1.jar');
+const pathToApexJar2 = path.resolve('test', 'test-jars', 'apex', 'testjar2.jar');
+const pathToApexJar3 = path.resolve('test', 'test-jars', 'apex', 'testjar3.jar');
+const pathToApexJar4 = path.resolve('test', 'test-jars', 'apex', 'testjar4.jar');
 // For our tests, we'll include three Apex JARs.
 const customPathDescriptor = {
 	'pmd': {

--- a/test/commands/scanner/run.test.ts
+++ b/test/commands/scanner/run.test.ts
@@ -88,8 +88,8 @@ describe('scanner:run', function () {
 						results.shift();
 						// Verify that each set of violations corresponds to the expected file.
 						expect(results.length).to.equal(2, 'Only two files should have violated the rules');
-						expect(results[0]).to.match(/file="test\/code-fixtures\/apex\/AccountServiceTests.cls"/);
-						expect(results[1]).to.match(/file="test\/code-fixtures\/apex\/InstallProcessorTests.cls"/);
+						expect(results[0]).to.match(/file="test(\/|\\)code-fixtures(\/|\\)apex(\/|\\)AccountServiceTests.cls"/);
+						expect(results[1]).to.match(/file="test(\/|\\)code-fixtures(\/|\\)apex(\/|\\)InstallProcessorTests.cls"/);
 
 						// Now, split each file's violations by the <violation> tag so we can inspect individual violations.
 						const acctServiceViolations = results[0].split('<violation');
@@ -127,8 +127,8 @@ describe('scanner:run', function () {
 						results.shift();
 						// Verify that each set of violations corresponds to the expected file.
 						expect(results.length).to.equal(2, 'Only two files should have violated the rules');
-						expect(results[0]).to.match(/file="test\/code-fixtures\/apex\/AccountServiceTests.cls"/);
-						expect(results[1]).to.match(/file="test\/code-fixtures\/apex\/InstallProcessorTests.cls"/);
+						expect(results[0]).to.match(/file="test(\/|\\)code-fixtures(\/|\\)apex(\/|\\)AccountServiceTests.cls"/);
+						expect(results[1]).to.match(/file="test(\/|\\)code-fixtures(\/|\\)apex(\/|\\)InstallProcessorTests.cls"/);
 
 						// Now, split each file's violations by the <violation> tag so we can inspect individual violations.
 						const acctServiceViolations = results[0].split('<violation');
@@ -681,8 +681,8 @@ describe('scanner:run', function () {
 						results.shift();
 						// Verify that each set of violations corresponds to the expected file.
 						expect(results.length).to.equal(2, 'Only two files should have violated the rules');
-						expect(results[0]).to.match(/file="test\/code-fixtures\/apex\/AccountServiceTests.cls"/);
-						expect(results[1]).to.match(/file="test\/code-fixtures\/apex\/InstallProcessorTests.cls"/);
+						expect(results[0]).to.match(/file="test(\/|\\)code-fixtures(\/|\\)apex(\/|\\)AccountServiceTests.cls"/);
+						expect(results[1]).to.match(/file="test(\/|\\)code-fixtures(\/|\\)apex(\/|\\)InstallProcessorTests.cls"/);
 
 						// Now, split each file's violations by the <violation> tag so we can inspect individual violations.
 						const acctServiceViolations = results[0].split('<violation');

--- a/test/lib/CustomRulePathManager.test.ts
+++ b/test/lib/CustomRulePathManager.test.ts
@@ -224,7 +224,7 @@ describe('CustomRulePathManager tests', () => {
 				try {
 					const manager = await Controller.createRulePathManager();
 					const language = 'apex';
-					const newPath = '/my/new/path';
+					const newPath = path.resolve('my', 'new', 'path');
 
 					// Execute test
 					const originalRulePathMap = await manager.getRulePathEntries(PmdEngine.NAME);

--- a/test/lib/eslint/TypescriptEslintStrategy.test.ts
+++ b/test/lib/eslint/TypescriptEslintStrategy.test.ts
@@ -8,6 +8,7 @@ import {OUTPUT_FORMAT, RuleManager} from '../../../src/lib/RuleManager';
 import LocalCatalog from '../../../src/lib/services/LocalCatalog';
 import fs = require('fs');
 import { fail } from 'assert';
+import {RuleResult, RuleViolation} from '../../../src/types';
 
 const CATALOG_FIXTURE_PATH = path.join('test', 'catalog-fixtures', 'DefaultCatalogFixture.json');
 const CATALOG_FIXTURE_RULE_COUNT = 15;
@@ -203,8 +204,17 @@ describe('TypescriptEslint Strategy', () => {
 
 			it('The typescript engine should convert the eslint error to something more user friendly', async () => {
 				const {results} = await ruleManager.runRulesMatchingCriteria([], ['invalid-ts'], OUTPUT_FORMAT.JSON, EMPTY_ENGINE_OPTIONS);
-				expect(results).to.contain("test/code-fixtures/projects/invalid-ts/src/notSpecifiedInTsConfig.ts' does not reside in a location that is included by your tsconfig.json 'include' attribute.");
-				expect(results).to.not.contain('Parsing error: \\"parserOptions.project\\" has been set');
+				// Parse the json in order to make the string match easier.
+				// There should be a single violation with a single message
+				const ruleResults: RuleResult[] = JSON.parse(results.toString());
+				expect(ruleResults).to.have.lengthOf(1);
+				const ruleResult: RuleResult = ruleResults[0];
+				expect(ruleResult.violations).to.have.lengthOf(1);
+				const violation: RuleViolation = ruleResult.violations[0];
+				const message = violation.message;
+				const thePath = path.join('test', 'code-fixtures', 'projects', 'invalid-ts', 'src', 'notSpecifiedInTsConfig.ts');
+				expect(message).to.contain(`${thePath}' does not reside in a location that is included by your tsconfig.json 'include' attribute.`);
+				expect(message).to.not.contain('Parsing error: \\"parserOptions.project\\" has been set');
 			});
 		});
 	});

--- a/test/lib/pmd/PmdCatalogWrapper.test.ts
+++ b/test/lib/pmd/PmdCatalogWrapper.test.ts
@@ -37,11 +37,12 @@ describe('PmdCatalogWrapper', () => {
 				});
 
 				it('uses the correct common parameter values', async () => {
+					const thePath = path.join('dist', 'pmd-cataloger', 'lib');
 					const expectedParamList = [
 						`-DcatalogHome=`,
 						'-DcatalogName=PmdCatalog.json',
 						'-cp',
-						'dist/pmd-cataloger/lib',
+						thePath,
 						'sfdc.sfdx.scanner.pmd.Main'];
 
 					const target = await TestablePmdCatalogWrapper.create({});


### PR DESCRIPTION
Fix issues where tests assumed that the path separator is a `/`.

Fix differences in how an empty parameter is represented on windows vs. linux(see comments).