### PR TITLE
@W-8089974@ Trim category filters

### DIFF
--- a/src/lib/RuleFilter.ts
+++ b/src/lib/RuleFilter.ts
@@ -13,6 +13,6 @@ export class RuleFilter {
 
     constructor(filterType: FilterType, filterValues: string[]) {
         this.filterType = filterType;
-        this.filterValues = filterValues;
+        this.filterValues = filterValues.map(v => v.trim());
     }
 }


### PR DESCRIPTION
To fix a minor but confusing UX bug.  If you specify --category "Hey, You, Guys" you will get three categories: ["Hey", " You", " Guys"].

The first one is valid but the other two are ignored.  Took me a few tries before I realized what was going wrong.