### PR TITLE
@W-8095993@ Increment transitive bl dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
 		"word-wrap": "^1.2.3",
 		"xml-js": "^1.6.11"
 	},
+	"resolutions": {
+		"bl": "^4.0.3"
+	},
 	"devDependencies": {
 		"@istanbuljs/nyc-config-typescript": "^1.0.1",
 		"@oclif/dev-cli": "^1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -981,10 +981,10 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
   integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
 
-bl@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.2.tgz#52b71e9088515d0606d9dd9cc7aa48dc1f98e73a"
-  integrity sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==
+bl@^4.0.1, bl@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.3.tgz#12d6287adc29080e22a705e5764b2a9522cdc489"
+  integrity sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==
   dependencies:
     buffer "^5.5.0"
     inherits "^2.0.4"


### PR DESCRIPTION
This was originally reported by dependabot in PR 186, but it only updated
yarn.lock. This type of update has the potential to be overwritten.

More information on selective dependency resolutions can be found here
https://classic.yarnpkg.com/en/docs/selective-version-resolutions/