### PR TITLE
@W-8111353@ Switch path of init hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
 			"@oclif/plugin-help"
 		],
 		"hooks": {
-			"init": "./src/lib/hooks/init"
+			"init": "./lib/lib/hooks/init"
 		}
 	},
 	"repository": "forcedotcom/sfdx-scanner",


### PR DESCRIPTION
Change the root of the path from src to lib. src does not exist when the
plugin is published to npm.

oclif finds the hook during development even if it is declared
to exist in lib/lib, but only exists in src/lib.