### PR TITLE
@W-8118474@ Fix filter by Category regression

### DIFF
--- a/src/lib/eslint/JavascriptEslintStrategy.ts
+++ b/src/lib/eslint/JavascriptEslintStrategy.ts
@@ -4,9 +4,7 @@ import {RuleViolation} from '../../types';
 import { Logger } from '@salesforce/core';
 
 const ES_CONFIG = {
-	"baseConfig": {
-		"extends": ["eslint:recommended"]
-	},
+	"extends": ["eslint:recommended"],
 	"parserOptions": {
 		"sourceType": "module",
 		"ecmaVersion": 2018,

--- a/src/lib/eslint/TypescriptEslintStrategy.ts
+++ b/src/lib/eslint/TypescriptEslintStrategy.ts
@@ -17,13 +17,11 @@ export enum TYPESCRIPT_ENGINE_OPTIONS {
 
 const ES_PLUS_TS_CONFIG = {
 	"parser": "@typescript-eslint/parser",
-	"baseConfig": {
-		"extends": [
-			"eslint:recommended",
-			"plugin:@typescript-eslint/recommended",
-			"plugin:@typescript-eslint/eslint-recommended"
-		]
-	},
+	"extends": [
+		"eslint:recommended",
+		"plugin:@typescript-eslint/recommended",
+		"plugin:@typescript-eslint/eslint-recommended"
+	],
 	"parserOptions": {
 		"sourceType": "module",
 		"ecmaVersion": 2018,

--- a/test/code-fixtures/projects/ts/src/simpleYetWrong.ts
+++ b/test/code-fixtures/projects/ts/src/simpleYetWrong.ts
@@ -1,5 +1,6 @@
 const ONE = 1;
 const THREE = 3;
+const UNUSED = 4;
 
 function boofTime(): number {
 	return new Date().getTime() % THREE;

--- a/test/commands/scanner/run.test.ts
+++ b/test/commands/scanner/run.test.ts
@@ -567,6 +567,79 @@ describe('scanner:run', function () {
 				});
 		});
 
+		describe('Eslint Javascript Engine --category flag', () => {
+			const category = 'Stylistic Issues';
+			setupCommandTest
+				.command(['scanner:run',
+					'--target', path.join('test', 'code-fixtures', 'projects', 'app', 'force-app', 'main', 'default', 'aura', 'dom_parser', 'dom_parserController.js'),
+					'--format', 'json',
+					'--engine', 'eslint',
+					'--category', category
+				])
+				.it('Only correct categories are returned', ctx => {
+					const output = JSON.parse(ctx.stdout);
+					expect(output.length).to.equal(1, 'Should only be violations from one engine');
+					expect(output[0].engine).to.equal('eslint');
+					expect(output[0].violations, JSON.stringify(output[0].violations)).to.be.lengthOf(55);
+
+					// Make sure only violations are returned for the requested category
+					for (const v of output[0].violations) {
+						expect(v.category, JSON.stringify(v)).to.equal(category);
+					}
+				});
+
+		});
+
+		describe('Eslint Typescript Engine --category flag', () => {
+			const category = 'Possible Errors';
+			setupCommandTest
+				.command(['scanner:run',
+					'--target', path.join('test', 'code-fixtures', 'projects', 'ts', 'src', 'simpleYetWrong.ts'),
+					'--tsconfig', path.join('test', 'code-fixtures', 'projects', 'tsconfig.json'),
+					'--format', 'json',
+					'--engine', 'eslint-typescript',
+					'--category', category
+				])
+				.it('Only correct categories are returned', ctx => {
+					const output = JSON.parse(ctx.stdout);
+					expect(output.length).to.equal(1, 'Should only be violations from one engine');
+					expect(output[0].engine).to.equal('eslint-typescript');
+					expect(output[0].violations, JSON.stringify(output[0].violations)).to.be.lengthOf(2);
+
+					// Make sure only violations are returned for the requested category
+					for (const v of output[0].violations) {
+						expect(v.category, JSON.stringify(v)).to.equal(category);
+					}
+				});
+
+		});
+
+		describe('PMD Engine --category flag', () => {
+			const category = 'Code Style';
+			setupCommandTest
+				.command(['scanner:run',
+					'--target', path.join('test', 'code-fixtures', 'apex'),
+					'--format', 'json',
+					'--engine', 'pmd',
+					'--category', category
+				])
+				.it('Only correct categories are returned', ctx => {
+					const output = JSON.parse(ctx.stdout);
+					expect(output.length).to.equal(1, 'Should only be violations from one engine');
+					expect(output[0].engine).to.equal('pmd');
+					expect(output[0].violations, JSON.stringify(output[0].violations)).to.be.lengthOf(2);
+
+					// Make sure only violations are returned for the requested category
+					for (const v of output[0].violations) {
+						expect(v.category, JSON.stringify(v)).to.equal(category);
+					}
+				});
+
+		});
+
+		// TODO: eslint-lwc --category. This has a known issue
+		// TODO: this test has become more of an integration test, than just testing the run command. break it up to make it more manageable, maybe based on engine or flags.
+
 		describe('--engine flag', () => {
 			setupCommandTest
 				.command(['scanner:run',


### PR DESCRIPTION
This restores the JavascriptEslintStrategy and TypescriptEslintStrategy configs to their 2.1 values. While these values aren't correct, they are safe.

Using the extends attribute in the config will use the default rule settings for the rules that are extended. We must explicitly turn off any rules that are in the extended rule set if we don't want them to show up in the results.

The correct fix for the Javascript, LWC, and Typescript engines will go out in another release.

It is a known issue that the eslint-lwc engine won't filter by Category correctly.