### PR TITLE
@W-8121424@ Fix filter by category for extended configs

### DIFF
--- a/src/lib/eslint/JavascriptEslintStrategy.ts
+++ b/src/lib/eslint/JavascriptEslintStrategy.ts
@@ -4,7 +4,9 @@ import {RuleViolation} from '../../types';
 import { Logger } from '@salesforce/core';
 
 const ES_CONFIG = {
-	"extends": ["eslint:recommended"],
+	"baseConfig": {
+		"extends": ["eslint:recommended"]
+	},
 	"parserOptions": {
 		"sourceType": "module",
 		"ecmaVersion": 2018,

--- a/src/lib/eslint/TypescriptEslintStrategy.ts
+++ b/src/lib/eslint/TypescriptEslintStrategy.ts
@@ -17,11 +17,13 @@ export enum TYPESCRIPT_ENGINE_OPTIONS {
 
 const ES_PLUS_TS_CONFIG = {
 	"parser": "@typescript-eslint/parser",
-	"extends": [
-		"eslint:recommended",
-		"plugin:@typescript-eslint/recommended",
-		"plugin:@typescript-eslint/eslint-recommended"
-	],
+	"baseConfig": {
+		"extends": [
+			"eslint:recommended",
+			"plugin:@typescript-eslint/recommended",
+			"plugin:@typescript-eslint/eslint-recommended"
+		]
+	},
 	"parserOptions": {
 		"sourceType": "module",
 		"ecmaVersion": 2018,

--- a/src/lib/eslint/TypescriptEslintStrategy.ts
+++ b/src/lib/eslint/TypescriptEslintStrategy.ts
@@ -19,7 +19,6 @@ const ES_PLUS_TS_CONFIG = {
 	"parser": "@typescript-eslint/parser",
 	"baseConfig": {
 		"extends": [
-			"eslint:recommended",
 			"plugin:@typescript-eslint/recommended",
 			"plugin:@typescript-eslint/eslint-recommended"
 		]

--- a/src/lib/services/LocalCatalog.ts
+++ b/src/lib/services/LocalCatalog.ts
@@ -130,7 +130,7 @@ export default class LocalCatalog implements RuleCatalog {
 			await this.rebuildCatalogIfNecessary();
 			this.catalog = await this.readCatalogJson();
 		}
-		return Promise.resolve(this.catalog);
+		return this.catalog;
 	}
 
 	private async rebuildCatalogIfNecessary(): Promise<[boolean, string]> {

--- a/src/lib/services/LocalCatalog.ts
+++ b/src/lib/services/LocalCatalog.ts
@@ -136,7 +136,7 @@ export default class LocalCatalog implements RuleCatalog {
 	private async rebuildCatalogIfNecessary(): Promise<[boolean, string]> {
 		// First, check whether the catalog is stale. If it's not, we don't even need to do anything.
 		if (!LocalCatalog.catalogIsStale()) {
-			return new Promise<[boolean, string]>(() => [false, 'no action taken']);
+			return [false, 'no action taken'];
 		}
 
 		return this.rebuildCatalog();
@@ -154,7 +154,7 @@ export default class LocalCatalog implements RuleCatalog {
 			catalog.rules.push(...engineCatalog.rules);
 		}
 		await this.writeCatalogJson(this.catalog);
-		return Promise.resolve([true, 'rebuilt catalog']);
+		return [true, 'rebuilt catalog'];
 	}
 
 	private static catalogIsStale(): boolean {

--- a/test/commands/scanner/run.test.ts
+++ b/test/commands/scanner/run.test.ts
@@ -590,6 +590,29 @@ describe('scanner:run', function () {
 
 		});
 
+		describe('Eslint Javascript Engine --category flag', () => {
+			const category = 'Best Practices';
+			setupCommandTest
+				.command(['scanner:run',
+					'--target', path.join('test', 'code-fixtures', 'projects', 'app', 'force-app', 'main', 'default', 'aura', 'dom_parser', 'dom_parserController.js'),
+					'--format', 'json',
+					'--engine', 'eslint-lwc',
+					'--category', category
+				])
+				.it('Only correct categories are returned', ctx => {
+					const output = JSON.parse(ctx.stdout);
+					expect(output.length).to.equal(1, 'Should only be violations from one engine');
+					expect(output[0].engine).to.equal('eslint-lwc');
+					expect(output[0].violations, JSON.stringify(output[0].violations)).to.be.lengthOf(13);
+
+					// Make sure only violations are returned for the requested category
+					for (const v of output[0].violations) {
+						expect(v.category, JSON.stringify(v)).to.equal(category);
+					}
+				});
+
+		});
+
 		describe('Eslint Typescript Engine --category flag', () => {
 			const category = 'Possible Errors';
 			setupCommandTest
@@ -637,7 +660,6 @@ describe('scanner:run', function () {
 
 		});
 
-		// TODO: eslint-lwc --category. This has a known issue
 		// TODO: this test has become more of an integration test, than just testing the run command. break it up to make it more manageable, maybe based on engine or flags.
 
 		describe('--engine flag', () => {

--- a/test/lib/eslint/BaseEslintEngine.test.ts
+++ b/test/lib/eslint/BaseEslintEngine.test.ts
@@ -68,7 +68,7 @@ describe('Tests for BaseEslintEngine', () => {
 				Mockito.verify(StaticDependenciesMock.resolveTargetPath(target.target)).called();
 
 				// verify config
-				const capturedConfig = Mockito.capture(StaticDependenciesMock.createCLIEngine).first();
+				const capturedConfig = Mockito.capture(StaticDependenciesMock.createCLIEngine).second();
 				expect(capturedConfig[0]).instanceOf(Object);
 				const config = <Object>capturedConfig[0];
 				expect(config['cwd']).equals(target.target);
@@ -83,6 +83,7 @@ describe('Tests for BaseEslintEngine', () => {
 
 			it('should not execute when rules are empty', async () => {
 				// instantiate abstract engine
+				Mockito.when(MockStrategy.getLanguages()).thenReturn(['language']);
 				const mockStrategy = Mockito.instance(MockStrategy);
 				const engine = await createDummyEngine(mockStrategy);
 
@@ -95,24 +96,6 @@ describe('Tests for BaseEslintEngine', () => {
 
 				expect(results).to.be.empty;
 			});
-
-			it('should not execute when no rules are relevant', async () => {
-				const differentEngine = 'differentEngineName';
-				const irrelevantRule = getDummyRule(differentEngine);
-
-				const mockStrategy = Mockito.instance(MockStrategy);
-				const engine = await createDummyEngine(mockStrategy);
-
-				const results = await engine.run(
-					[getDummyRuleGroup()],
-					[irrelevantRule],
-					[getDummyTarget(true)],
-					EMPTY_ENGINE_OPTIONS
-				);
-
-				expect(results).to.be.empty;
-			});
-
 		});
 
 		describe('Rule mapping', () => {

--- a/test/lib/eslint/BaseEslintEngine.test.ts
+++ b/test/lib/eslint/BaseEslintEngine.test.ts
@@ -83,7 +83,6 @@ describe('Tests for BaseEslintEngine', () => {
 
 			it('should not execute when rules are empty', async () => {
 				// instantiate abstract engine
-				Mockito.when(MockStrategy.getLanguages()).thenReturn(['language']);
 				const mockStrategy = Mockito.instance(MockStrategy);
 				const engine = await createDummyEngine(mockStrategy);
 


### PR DESCRIPTION
Eslint engines run rules specified in the "rules" attribute plus all "recommended" rules that are enabled by extending a configuration. See recommended (boolean) is whether the "extends": "eslint:recommended" property in a configuration file enables the rule https://eslint.org/docs/developer-guide/working-with-rules

This change explicitly sets all "recommended" rules to "off", before enabling any other rules that the engine has been instructed to run.

Changed BaseEslintEngine to cache the catalog since it is now accessed multiple times.

Removed error checking from BaseEslintEngine that ensures all rules match the engine. This is the caller's responsibility and already done in DefaultRuleManager.