### PR TITLE
@W-8101850@ Display a warning when targets don't match

### DIFF
--- a/messages/DefaultRuleManager.js
+++ b/messages/DefaultRuleManager.js
@@ -1,0 +1,6 @@
+module.exports = {
+	"warning": {
+		"targetSkipped": "Target: '%s' was not processed by any engines.",
+		"targetsSkipped": "Targets: '%s' were not processed by any engines."
+	}
+}

--- a/test/lib/RuleManager.test.ts
+++ b/test/lib/RuleManager.test.ts
@@ -7,6 +7,7 @@ import fs = require('fs');
 import path = require('path');
 import Sinon = require('sinon');
 import * as TestOverrides from '../test-related-lib/TestOverrides';
+import {uxEvents} from '../../src/lib/ScannerEvents';
 
 TestOverrides.initializeTestSetup();
 
@@ -18,6 +19,17 @@ let ruleManager: RuleManager = null;
 const EMPTY_ENGINE_OPTIONS = new Map<string, string>();
 
 describe('RuleManager', () => {
+	let uxSpy;
+
+	beforeEach(() => {
+		Sinon.createSandbox();
+		uxSpy = Sinon.spy(uxEvents, 'emit');
+	});
+
+	afterEach(() => {
+		Sinon.restore();
+	});
+
 	before(async () => {
 		// Make sure all catalogs exist where they're supposed to.
 		if (!fs.existsSync(CATALOG_FIXTURE_PATH)) {
@@ -175,7 +187,7 @@ describe('RuleManager', () => {
 				process.chdir(path.join('test', 'code-fixtures', 'projects'));
 			});
 			after(() => {
-				process.chdir("../..");
+				process.chdir("../../..");
 			});
 			describe('Test Case: Run without filters', () => {
 				it('JS project files', async () => {
@@ -225,6 +237,23 @@ describe('RuleManager', () => {
 						expect(res.violations[0], `Message is ${res.violations[0]['message']}`).to.have.property("ruleName").that.is.not.null;
 					}
 				});
+
+				it('All targets match', async () => {
+					const validTargets = ['js/**/*.js', '!**/negative-filter-does-not-exist/**'];
+					// Set up our filter array.
+					const categories = ['Possible Errors'];
+					const filters = [new RuleFilter(FilterType.CATEGORY, categories)];
+
+					const {results} = await ruleManager.runRulesMatchingCriteria(filters, validTargets, OUTPUT_FORMAT.JSON, EMPTY_ENGINE_OPTIONS);
+					let parsedRes = null;
+					if (typeof results !== "string") {
+						expect(false, `Invalid output: ${results}`);
+					} else {
+						parsedRes = JSON.parse(results);
+					}
+					expect(parsedRes).to.be.an("array").that.has.length(1);
+					Sinon.assert.callCount(uxSpy, 0);
+				});
 			});
 
 			describe('Test Case: Run by category', () => {
@@ -272,7 +301,7 @@ describe('RuleManager', () => {
 				});
 			});
 
-			describe('Edge Case: No rules match criteria', () => {
+			describe('Edge Cases', () => {
 				it('When no rules match the given criteria, an empty string is returned', async () => {
 					// Define our preposterous filter array.
 					const filters = [new RuleFilter(FilterType.CATEGORY, ['beebleborp'])];
@@ -280,6 +309,51 @@ describe('RuleManager', () => {
 					const {results} = await ruleManager.runRulesMatchingCriteria(filters, ['app'], OUTPUT_FORMAT.JSON, EMPTY_ENGINE_OPTIONS);
 					expect(typeof results).to.equal('string', `Output ${results} should have been a string`);
 					expect(results).to.equal('', `Output ${results} should have been an empty string`);
+				});
+
+				it('Single target does not match', async () => {
+					const invalidTarget = ['does-not-exist.js'];
+					// Set up our filter array.
+					const categories = ['Best Practices', 'Error Prone'];
+					const filters = [new RuleFilter(FilterType.CATEGORY, categories)];
+
+					const {results} = await ruleManager.runRulesMatchingCriteria(filters, invalidTarget, OUTPUT_FORMAT.JSON, EMPTY_ENGINE_OPTIONS);
+
+					expect(results).to.equal('');
+					Sinon.assert.callCount(uxSpy, 1);
+					Sinon.assert.calledWith(uxSpy, 'warning-always', `Target: '${invalidTarget.join(', ')}' was not processed by any engines.`);
+				});
+
+				it('Multiple targets do not match', async () => {
+					const invalidTargets = ['does-not-exist-1.js', 'does-not-exist-2.js'];
+					// Set up our filter array.
+					const categories = ['Best Practices', 'Error Prone'];
+					const filters = [new RuleFilter(FilterType.CATEGORY, categories)];
+
+					const {results} = await ruleManager.runRulesMatchingCriteria(filters, invalidTargets, OUTPUT_FORMAT.JSON, EMPTY_ENGINE_OPTIONS);
+
+					expect(results).to.equal('');
+					Sinon.assert.callCount(uxSpy, 1);
+					Sinon.assert.calledWith(uxSpy, 'warning-always', `Targets: '${invalidTargets.join(', ')}' were not processed by any engines.`);
+				});
+
+				it('Some targets do not match', async () => {
+					const invalidTargets = ['does-not-exist-1.js', 'does-not-exist-2.js', '**/non-existent/**/*.js'];
+					const validTargets = ['js/**/*.js', '!**/negative-filter-does-not-exist/**'];
+					// Set up our filter array.
+					const categories = ['Possible Errors'];
+					const filters = [new RuleFilter(FilterType.CATEGORY, categories)];
+
+					const {results} = await ruleManager.runRulesMatchingCriteria(filters, [...invalidTargets, ...validTargets], OUTPUT_FORMAT.JSON, EMPTY_ENGINE_OPTIONS);
+					let parsedRes = null;
+					if (typeof results !== "string") {
+						expect(false, `Invalid output: ${results}`);
+					} else {
+						parsedRes = JSON.parse(results);
+					}
+					expect(parsedRes).to.be.an("array").that.has.length(1);
+					Sinon.assert.callCount(uxSpy, 1);
+					Sinon.assert.calledWith(uxSpy, 'warning-always', `Targets: '${invalidTargets.join(', ')}' were not processed by any engines.`);
 				});
 			});
 		});

--- a/test/lib/RuleManager.test.ts
+++ b/test/lib/RuleManager.test.ts
@@ -239,7 +239,7 @@ describe('RuleManager', () => {
 				});
 
 				it('All targets match', async () => {
-					const validTargets = ['js/**/*.js', '!**/negative-filter-does-not-exist/**'];
+					const validTargets = ['js/**/*.js', 'app/force-app/main/default/classes', '!**/negative-filter-does-not-exist/**'];
 					// Set up our filter array.
 					const categories = ['Possible Errors'];
 					const filters = [new RuleFilter(FilterType.CATEGORY, categories)];
@@ -311,7 +311,7 @@ describe('RuleManager', () => {
 					expect(results).to.equal('', `Output ${results} should have been an empty string`);
 				});
 
-				it('Single target does not match', async () => {
+				it('Single target file does not match', async () => {
 					const invalidTarget = ['does-not-exist.js'];
 					// Set up our filter array.
 					const categories = ['Best Practices', 'Error Prone'];
@@ -324,8 +324,22 @@ describe('RuleManager', () => {
 					Sinon.assert.calledWith(uxSpy, 'warning-always', `Target: '${invalidTarget.join(', ')}' was not processed by any engines.`);
 				});
 
+
+				it('Single target directory does not match', async () => {
+					const invalidTarget = ['app/force-app/main/default/no-such-directory'];
+					// Set up our filter array.
+					const categories = ['Best Practices', 'Error Prone'];
+					const filters = [new RuleFilter(FilterType.CATEGORY, categories)];
+
+					const {results} = await ruleManager.runRulesMatchingCriteria(filters, invalidTarget, OUTPUT_FORMAT.JSON, EMPTY_ENGINE_OPTIONS);
+
+					expect(results).to.equal('');
+					Sinon.assert.callCount(uxSpy, 1);
+					Sinon.assert.calledWith(uxSpy, 'warning-always', `Target: '${invalidTarget.join(', ')}' was not processed by any engines.`);
+				});
+
 				it('Multiple targets do not match', async () => {
-					const invalidTargets = ['does-not-exist-1.js', 'does-not-exist-2.js'];
+					const invalidTargets = ['does-not-exist-1.js', 'does-not-exist-2.js', 'app/force-app/main/default/no-such-directory'];
 					// Set up our filter array.
 					const categories = ['Best Practices', 'Error Prone'];
 					const filters = [new RuleFilter(FilterType.CATEGORY, categories)];
@@ -338,7 +352,7 @@ describe('RuleManager', () => {
 				});
 
 				it('Some targets do not match', async () => {
-					const invalidTargets = ['does-not-exist-1.js', 'does-not-exist-2.js', '**/non-existent/**/*.js'];
+					const invalidTargets = ['does-not-exist-1.js', 'does-not-exist-2.js', '**/non-existent/**/*.js', 'app/force-app/main/default/no-such-directory'];
 					const validTargets = ['js/**/*.js', '!**/negative-filter-does-not-exist/**'];
 					// Set up our filter array.
 					const categories = ['Possible Errors'];


### PR DESCRIPTION
Display a warning if the user specifies a target that is ignored by all
engines. This could be because the file doesn't exist or none of the
engines are configured to scan the file type.