### PR TITLE
@W-8318596@ Temporarily pin node-stream-zip version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"globby": "^11.0.0",
 		"html-escaper": "^3.0.0",
 		"mustache": "^4.0.1",
-		"node-stream-zip": "^1.11.3",
+		"node-stream-zip": "1.11.3",
 		"normalize-path": "^3.0.0",
 		"picomatch": "^2.2.2",
 		"reflect-metadata": "^0.1.13",


### PR DESCRIPTION
The current version is failing with the following exception.

> @salesforce/sfdx-scanner@2.4.0 prepack /home/circleci/repo
> rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme

node_modules/node-stream-zip/node_stream_zip.d.ts:122:1 - error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.

122 class StreamZip {
    ~~~~~