### PR TITLE
@W-8266225@ Changes to allow custom config for PMD and Eslint

### DIFF
--- a/messages/CustomEslintEngine.js
+++ b/messages/CustomEslintEngine.js
@@ -1,0 +1,4 @@
+module.exports = {
+	"ConfigFileDoesNotExist": "Eslint config file (%s) does not exist.",
+	"InvalidJson": "Error while reading JSON in Eslint config (%s): %s",
+}

--- a/messages/EventKeyTemplates.js
+++ b/messages/EventKeyTemplates.js
@@ -4,8 +4,9 @@ module.exports = {
 		"jarAndXmlProcessed": "XML files collected from JAR [%s]: %s",
 		"usingEngineConfigFile": "Using engine configuration file at %s",
 		"generalInternalLog": "Log from Java: %s",
-		"customEslintHeadsUp": "About to run Eslint with custom config in %s. Please make sure your current directory has all the required NPM dependencies or you have added the 'cwd' property in your config to point to a directory that has all the dependencies installed.",
-		"customPmdHeadsUp": "About to run PMD with custom config in %s. Please make sure that any custom rule references have already been added to the plugin through scanner:rule:add command."	},
+		"customEslintHeadsUp": "About to run Eslint with custom config in %s. Please make sure your current directory has all the required NPM dependencies.",
+		"customPmdHeadsUp": "About to run PMD with custom config in %s. Please make sure that any custom rule references have already been added to the plugin through scanner:rule:add command."	
+	},
 	"warning": {
 		"invalidCategorySkipped": "Cataloger skipped invalid PMD Category file '%s'.",
 		"invalidRulesetSkipped": "Cataloger skipped invalid PMD Ruleset file '%s'.",

--- a/messages/EventKeyTemplates.js
+++ b/messages/EventKeyTemplates.js
@@ -3,8 +3,9 @@ module.exports = {
 		"categoryImplicitlyRun": "Implicitly including %s rules from category '%s'",
 		"jarAndXmlProcessed": "XML files collected from JAR [%s]: %s",
 		"usingEngineConfigFile": "Using engine configuration file at %s",
-		"generalInternalLog": "Log from Java: %s"
-	},
+		"generalInternalLog": "Log from Java: %s",
+		"customEslintHeadsUp": "About to run Eslint with custom config in %s. Please make sure your current directory has all the required NPM dependencies or you have added the 'cwd' property in your config to point to a directory that has all the dependencies installed.",
+		"customPmdHeadsUp": "About to run PMD with custom config in %s. Please make sure that any custom rule references have already been added to the plugin through scanner:rule:add command."	},
 	"warning": {
 		"invalidCategorySkipped": "Cataloger skipped invalid PMD Category file '%s'.",
 		"invalidRulesetSkipped": "Cataloger skipped invalid PMD Ruleset file '%s'.",

--- a/messages/PmdEngine.js
+++ b/messages/PmdEngine.js
@@ -1,0 +1,3 @@
+module.exports = {
+	"ConfigNotFound": "PMD Config file (%s) is not found."
+};

--- a/messages/run.js
+++ b/messages/run.js
@@ -5,15 +5,10 @@ module.exports = {
 	You can choose the format of output and decide between printing the results directly
 	or as contents of a file that you provide with --outfile flag.`,
 	"flags": {
-		"rulenameDescription": "[description of 'rulename' parameter]",                   // TODO: Change this once the flag is implemented.
 		"categoryDescription": "categor(ies) of rules to run",
 		"categoryDescriptionLong": "One or more categories of rules to run. Multiple values can be specified as a comma-separated list.",
 		"rulesetDescription": "[deprecated] ruleset(s) of rules to run",
 		"rulesetDescriptionLong": "[Deprecated] One or more rulesets to run. Multiple values can be specified as a comma-separated list.",
-		"severityDescription": "[description of 'severity' parameter]",                   // TODO: Change this once the flag is implemented.
-		"excluderuleDescription": "[description of 'exclude-rule' parameter]",            // TODO: Change this once the flag is implemented.
-		"orgDescription": "[description of 'org' parameter]",                             // TODO: Change this once the flag is implemented.
-		"suppresswarningsDescription": "[description of 'suppress-warnings' parameter]",  // TODO: Change this once the flag is implemented.
 		"targetDescription": "location of source code",
 		"targetDescriptionLong": "Source code location. May use glob patterns. Multiple values can be specified as a comma-separated list",
 		"formatDescription": "format of results",
@@ -28,7 +23,11 @@ module.exports = {
 		"vceDescription": "throws an error when violations are detected",
 		"vceDescriptionLong": "Throws an error when violations are detected. Exit code is the most severe violation.",
 		'engineDescription': "engine(s) to run",
-		'engineDescriptionLong': "One or more engines to run. Multiple values can be specified as a comma-separated list."
+		'engineDescriptionLong': "One or more engines to run. Multiple values can be specified as a comma-separated list.",
+		'eslintConfig': 'location of eslintrc config to customize eslint engine',
+		'eslintConfigLong': 'Location of eslintrc to customize eslint engine',
+		'pmdConfig': 'location of PMD rule reference XML file to customize rule selection',
+		'pmdConfigLong': 'Location of PMD rule reference XML file to customize rule selection'
 	},
 	"validations": {
 		"mustTargetSomething": "Please specify a codebase using --target.", // TODO: Once --org is implemented, rewrite this message.

--- a/messages/run.js
+++ b/messages/run.js
@@ -24,23 +24,25 @@ module.exports = {
 		"vceDescriptionLong": "Throws an error when violations are detected. Exit code is the most severe violation.",
 		'engineDescription': "engine(s) to run",
 		'engineDescriptionLong': "One or more engines to run. Multiple values can be specified as a comma-separated list.",
-		'eslintConfig': 'location of eslintrc config to customize eslint engine',
-		'eslintConfigLong': 'Location of eslintrc to customize eslint engine',
-		'pmdConfig': 'location of PMD rule reference XML file to customize rule selection',
-		'pmdConfigLong': 'Location of PMD rule reference XML file to customize rule selection'
+		'eslintConfigDescription': 'location of eslintrc config to customize eslint engine',
+		'eslintConfigDescriptionLong': 'Location of eslintrc to customize eslint engine',
+		'pmdConfigDescription': 'location of PMD rule reference XML file to customize rule selection',
+		'pmdConfigDescriptionLong': 'Location of PMD rule reference XML file to customize rule selection'
 	},
 	"validations": {
 		"mustTargetSomething": "Please specify a codebase using --target.", // TODO: Once --org is implemented, rewrite this message.
 		"outfileFormatMismatch": "Your chosen format %s does not appear to match your output file type of %s.",
 		"outfileMustBeValid": "--outfile must be a well-formed filepath.",
-		"outfileMustBeSupportedType": "--outfile must be of a supported type. Current options are .xml and .csv."
+		"outfileMustBeSupportedType": "--outfile must be of a supported type. Current options are .xml and .csv.",
+		"tsConfigEslintConfigExclusive": "Please provide tsconfig path within the eslint config file under 'parseOptions.project'."
 	},
 	"output": {
 		"noViolationsDetected": "No rule violations found.",
 		"invalidEnvJson": "--env parameter must be a well-formed JSON.",
 		"writtenToOutFile": "Rule violations have been written to %s.",
 		"sevDetectionSummary": "Detected rule violations of severity %s or lower.",
-		"pleaseSeeAbove": "Please see the logs above."
+		"pleaseSeeAbove": "Please see the logs above.",
+		"filtersIgnoredCustom": "Rule filters will be ignored for custom config runs. Please modify your config file to reflect the filtering you need."
 	},
 	"rulesetDeprecation": "'ruleset' command parameter is deprecated. Please use 'category' instead",
 	"examples": `Invoking without specifying any rules causes all rules to be run.

--- a/messages/run.js
+++ b/messages/run.js
@@ -34,7 +34,7 @@ module.exports = {
 		"outfileFormatMismatch": "Your chosen format %s does not appear to match your output file type of %s.",
 		"outfileMustBeValid": "--outfile must be a well-formed filepath.",
 		"outfileMustBeSupportedType": "--outfile must be of a supported type. Current options are .xml and .csv.",
-		"tsConfigEslintConfigExclusive": "Please provide tsconfig path within the eslint config file under 'parseOptions.project'."
+		"tsConfigEslintConfigExclusive": "You cannot specify --tsconfig flag if you have specified --eslintconfig flag. Please provide tsconfig path within the eslint config file under 'parseOptions.project'."
 	},
 	"output": {
 		"noViolationsDetected": "No rule violations found.",
@@ -42,7 +42,7 @@ module.exports = {
 		"writtenToOutFile": "Rule violations have been written to %s.",
 		"sevDetectionSummary": "Detected rule violations of severity %s or lower.",
 		"pleaseSeeAbove": "Please see the logs above.",
-		"filtersIgnoredCustom": "Rule filters will be ignored for custom config runs. Please modify your config file to reflect the filtering you need."
+		"filtersIgnoredCustom": "Rule filters will be ignored by engines that are run with custom config (using --pmdconfig or --eslintconfig flags). Please modify your config file to reflect the filtering you need."
 	},
 	"rulesetDeprecation": "'ruleset' command parameter is deprecated. Please use 'category' instead",
 	"examples": `Invoking without specifying any rules causes all rules to be run.

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -18,6 +18,7 @@ export const PMD_CATALOG_FILE = 'PmdCatalog.json';
 
 export enum ENGINE {
 	PMD = 'pmd',
+	PMD_CUSTOM = 'pmd-custom',
 	ESLINT = 'eslint',
 	ESLINT_LWC = 'eslint-lwc',
 	ESLINT_TYPESCRIPT = 'eslint-typescript',

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -21,6 +21,7 @@ export enum ENGINE {
 	ESLINT = 'eslint',
 	ESLINT_LWC = 'eslint-lwc',
 	ESLINT_TYPESCRIPT = 'eslint-typescript',
+	ESLINT_CUSTOM = 'eslint-custom',
 	RETIRE_JS = 'retire-js'
 }
 
@@ -42,3 +43,8 @@ export const Services = {
 };
 
 export const INTERNAL_ERROR_CODE = 500;
+
+export enum CUSTOM_CONFIG {
+	EslintConfig = "EslintConfig",
+	PmdConfig = "PmdConfig"
+}

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -26,11 +26,18 @@ export enum ENGINE {
 	RETIRE_JS = 'retire-js'
 }
 
+/**
+ * Main engine types that have more than one variation
+ */
 export const EngineFlavor = {
 	PMD: 'pmd',
 	ESLINT: 'eslint'
 }
 
+/**
+ * These are the filter values that Users can filter by when using
+ * --engine flag
+ */
 export const AllowedEngineFilters = [ 
 	ENGINE.ESLINT, 
 	ENGINE.ESLINT_LWC, 

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -26,6 +26,20 @@ export enum ENGINE {
 	RETIRE_JS = 'retire-js'
 }
 
+export const EngineFlavor = {
+	PMD: 'pmd',
+	ESLINT: 'eslint'
+}
+
+export const AllowedEngineFilters = [ 
+	ENGINE.ESLINT, 
+	ENGINE.ESLINT_LWC, 
+	ENGINE.ESLINT_TYPESCRIPT, 
+	ENGINE.PMD,
+	ENGINE.RETIRE_JS
+]
+
+
 export enum LANGUAGE {
 	APEX = 'apex',
 	JAVA = 'java',

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -29,7 +29,7 @@ export enum ENGINE {
 /**
  * Main engine types that have more than one variation
  */
-export const EngineFlavor = {
+export const EngineBase = {
 	PMD: 'pmd',
 	ESLINT: 'eslint'
 }

--- a/src/Controller.ts
+++ b/src/Controller.ts
@@ -53,12 +53,25 @@ export const Controller = {
 		return engines;
 	},
 
-	getFilteredEngines: async (filteredNames: string[]): Promise<RuleEngine[]> => {
+	getUserFacingEngines: async (): Promise<RuleEngine[]> => {
 		const allEngines: RuleEngine[] = await Controller.getAllEngines();
-		const engines = allEngines.filter(e => filteredNames.includes(e.getName()));
+		const engines: RuleEngine[] = [];
+
+		for (const engine of allEngines) {
+			if (!engine.isCustomConfigBased()) {
+				engines.push(engine);
+			}
+		}
+
+		return engines;
+	},
+
+	getFilteredEngines: async (filteredNames: string[]): Promise<RuleEngine[]> => {
+		const userFacingEngines: RuleEngine[] = await Controller.getUserFacingEngines();
+		const engines = userFacingEngines.filter(e => filteredNames.includes(e.getName()));
 
 		if (engines.length == 0) {
-			throw SfdxError.create('@salesforce/sfdx-scanner', 'Controller', 'NoFilteredEnginesFound', [filteredNames.join(','), enginesToString(allEngines)]);
+			throw SfdxError.create('@salesforce/sfdx-scanner', 'Controller', 'NoFilteredEnginesFound', [filteredNames.join(','), enginesToString(userFacingEngines)]);
 		}
 
 		return engines;

--- a/src/commands/scanner/rule/list.ts
+++ b/src/commands/scanner/rule/list.ts
@@ -3,7 +3,7 @@ import {Messages} from '@salesforce/core';
 import {Controller} from '../../../Controller';
 import {Rule} from '../../../types';
 import {ScannerCommand} from '../../../lib/ScannerCommand';
-import {ENGINE} from '../../../Constants';
+import {AllowedEngineFilters} from '../../../Constants';
 
 
 // Initialize Messages with the current plugin directory
@@ -57,7 +57,7 @@ export default class List extends ScannerCommand {
 			char: 'e',
 			description: messages.getMessage('flags.engineDescription'),
 			longDescription: messages.getMessage('flags.engineDescriptionLong'),
-			options: [ENGINE.ESLINT, ENGINE.ESLINT_LWC, ENGINE.ESLINT_TYPESCRIPT, ENGINE.PMD, ENGINE.RETIRE_JS]
+			options: [...AllowedEngineFilters]
 		}),
 		// END: Flags consumed by ScannerCommand#buildRuleFilters
 		// TODO: After implementing this flag, unhide it.

--- a/src/commands/scanner/run.ts
+++ b/src/commands/scanner/run.ts
@@ -2,7 +2,7 @@ import {flags} from '@salesforce/command';
 import {Messages, SfdxError} from '@salesforce/core';
 import {AnyJson} from '@salesforce/ts-types';
 import {LooseObject, RecombinedRuleResults} from '../../types';
-import {ENGINE, INTERNAL_ERROR_CODE} from '../../Constants';
+import {AllowedEngineFilters, INTERNAL_ERROR_CODE} from '../../Constants';
 import {Controller} from '../../Controller';
 import {CUSTOM_CONFIG} from '../../Constants';
 import {OUTPUT_FORMAT} from '../../lib/RuleManager';
@@ -52,7 +52,7 @@ export default class Run extends ScannerCommand {
 			char: 'e',
 			description: messages.getMessage('flags.engineDescription'),
 			longDescription: messages.getMessage('flags.engineDescriptionLong'),
-			options: [ENGINE.ESLINT, ENGINE.ESLINT_LWC, ENGINE.ESLINT_TYPESCRIPT, ENGINE.PMD, ENGINE.RETIRE_JS]
+			options: [...AllowedEngineFilters]
 		}),
 		// END: Flags consumed by ScannerCommand#buildRuleFilters
 		// These flags are how you choose which files you're targeting.
@@ -167,7 +167,7 @@ export default class Run extends ScannerCommand {
 			options.set(CUSTOM_CONFIG.EslintConfig, eslintConfig);
 		}
 
-		// Capturing eslintconfig value, if provided
+		// Capturing pmdconfig value, if provided
 		if (this.flags.pmdconfig) {
 			const pmdConfig = normalize(untildify(this.flags.pmdconfig));
 			options.set(CUSTOM_CONFIG.PmdConfig, pmdConfig);

--- a/src/commands/scanner/run.ts
+++ b/src/commands/scanner/run.ts
@@ -80,12 +80,12 @@ export default class Run extends ScannerCommand {
 			longDescription: messages.getMessage('flags.tsconfigDescriptionLong')
 		}),
 		eslintconfig: flags.string({
-			description: messages.getMessage('flags.eslintConfig'),
-			longDescription: messages.getMessage('flags.eslintConfigLong')
+			description: messages.getMessage('flags.eslintConfigDescription'),
+			longDescription: messages.getMessage('flags.eslintConfigDescriptionLong')
 		}),
 		pmdconfig: flags.string({
-			description: messages.getMessage('flags.pmdConfig'),
-			longDescription: messages.getMessage('flags.pmdConfigLong')
+			description: messages.getMessage('flags.pmdConfigDescription'),
+			longDescription: messages.getMessage('flags.pmdConfigDescriptionLong')
 		}),
 		// TODO: This flag was implemented for W-7791882, and it's suboptimal. It leaks the abstraction and pollutes the command.
 		//   It should be replaced during the 3.0 release cycle.
@@ -179,6 +179,14 @@ export default class Run extends ScannerCommand {
 		// file, --target and --org are mutually exclusive, but they can't all be null.
 		if (!this.args.file && !this.flags.target && !this.flags.org) {
 			throw new SfdxError(messages.getMessage('validations.mustTargetSomething'), null, null, this.getInternalErrorCode());
+		}
+
+		if (this.flags.tsconfig && this.flags.eslintconfig) {
+			throw SfdxError.create('@salesforce/sfdx-scanner', 'run', 'validations.tsConfigEslintConfigExclusive', []);
+		}
+
+		if ((this.flags.pmdconfig || this.flags.eslintconfig) && (this.flags.category || this.flags.ruleset)) {
+			this.ux.log(messages.getMessage('output.filtersIgnoredCustom', []));
 		}
 
 		// Be liberal with the user, but do log an info message if they choose a file extension that does not match their format.

--- a/src/commands/scanner/run.ts
+++ b/src/commands/scanner/run.ts
@@ -4,6 +4,7 @@ import {AnyJson} from '@salesforce/ts-types';
 import {LooseObject, RecombinedRuleResults} from '../../types';
 import {ENGINE, INTERNAL_ERROR_CODE} from '../../Constants';
 import {Controller} from '../../Controller';
+import {CUSTOM_CONFIG} from '../../Constants';
 import {OUTPUT_FORMAT} from '../../lib/RuleManager';
 import {ScannerCommand} from '../../lib/ScannerCommand';
 import {TYPESCRIPT_ENGINE_OPTIONS} from '../../lib/eslint/TypescriptEslintStrategy';
@@ -47,14 +48,6 @@ export default class Run extends ScannerCommand {
 			description: messages.getMessage('flags.rulesetDescription'),
 			longDescription: messages.getMessage('flags.rulesetDescriptionLong')
 		}),
-		// TODO: After implementing this flag, unhide it.
-		rulename: flags.string({
-			char: 'n',
-			description: messages.getMessage('flags.rulenameDescription'),
-			// If you're specifying by name, it doesn't make sense to let you specify by any other means.
-			exclusive: ['category', 'ruleset', 'severity', 'exclude-rule'],
-			hidden: true
-		}),
 		engine: flags.array({
 			char: 'e',
 			description: messages.getMessage('flags.engineDescription'),
@@ -62,17 +55,6 @@ export default class Run extends ScannerCommand {
 			options: [ENGINE.ESLINT, ENGINE.ESLINT_LWC, ENGINE.ESLINT_TYPESCRIPT, ENGINE.PMD, ENGINE.RETIRE_JS]
 		}),
 		// END: Flags consumed by ScannerCommand#buildRuleFilters
-		// TODO: After implementing this flag, unhide it.
-		severity: flags.string({
-			char: 's',
-			description: messages.getMessage('flags.severityDescription'),
-			hidden: true
-		}),
-		// TODO: After implementing this flag, unhide it.
-		'exclude-rule': flags.array({
-			description: messages.getMessage('flags.excluderuleDescription'),
-			hidden: true
-		}),
 		// These flags are how you choose which files you're targeting.
 		target: flags.array({
 			char: 't',
@@ -81,20 +63,7 @@ export default class Run extends ScannerCommand {
 			// If you're specifying local files, it doesn't make much sense to let you specify anything else.
 			exclusive: ['org']
 		}),
-		// TODO: After implementing this flag, unhide it.
-		org: flags.string({
-			char: 'a',
-			description: messages.getMessage('flags.orgDescription'),
-			// If you're specifying an org, it doesn't make sense to let you specify anything else.
-			exclusive: ['target'],
-			hidden: true
-		}),
 		// These flags modify how the process runs, rather than what it consumes.
-		// TODO: After implementing this flag, unhide it.
-		'suppress-warnings': flags.boolean({
-			description: messages.getMessage('flags.suppresswarningsDescription'),
-			hidden: true
-		}),
 		format: flags.enum({
 			char: 'f',
 			description: messages.getMessage('flags.formatDescription'),
@@ -109,6 +78,14 @@ export default class Run extends ScannerCommand {
 		tsconfig: flags.string({
 			description: messages.getMessage('flags.tsconfigDescription'),
 			longDescription: messages.getMessage('flags.tsconfigDescriptionLong')
+		}),
+		eslintconfig: flags.string({
+			description: messages.getMessage('flags.eslintConfig'),
+			longDescription: messages.getMessage('flags.eslintConfigLong')
+		}),
+		pmdconfig: flags.string({
+			description: messages.getMessage('flags.pmdConfig'),
+			longDescription: messages.getMessage('flags.pmdConfigLong')
 		}),
 		// TODO: This flag was implemented for W-7791882, and it's suboptimal. It leaks the abstraction and pollutes the command.
 		//   It should be replaced during the 3.0 release cycle.
@@ -182,6 +159,18 @@ export default class Run extends ScannerCommand {
 			} catch (e) {
 				throw new SfdxError(messages.getMessage('output.invalidEnvJson'), null, null, this.getInternalErrorCode());
 			}
+		}
+
+		// Capturing eslintconfig value, if provided
+		if (this.flags.eslintconfig) {
+			const eslintConfig = normalize(untildify(this.flags.eslintconfig));
+			options.set(CUSTOM_CONFIG.EslintConfig, eslintConfig);
+		}
+
+		// Capturing eslintconfig value, if provided
+		if (this.flags.pmdconfig) {
+			const pmdConfig = normalize(untildify(this.flags.pmdconfig));
+			options.set(CUSTOM_CONFIG.PmdConfig, pmdConfig);
 		}
 		return options;
 	}

--- a/src/ioc.config.ts
+++ b/src/ioc.config.ts
@@ -6,6 +6,7 @@ import {DefaultRuleManager} from './lib/DefaultRuleManager';
 import {JavascriptEslintEngine} from './lib/eslint/EslintEngine';
 import {LWCEslintEngine} from './lib/eslint/EslintEngine';
 import {TypescriptEslintEngine} from './lib/eslint/EslintEngine';
+import {CustomEslintEngine} from './lib/eslint/CustomEslintEngine';
 import {RetireJsEngine} from './lib/retire-js/RetireJsEngine';
 import {PmdEngine} from './lib/pmd/PmdEngine';
 import LocalCatalog from './lib/services/LocalCatalog';
@@ -33,6 +34,7 @@ export function registerAll(): void {
 		container.registerSingleton(Services.RuleEngine, JavascriptEslintEngine);
 		container.registerSingleton(Services.RuleEngine, LWCEslintEngine);
 		container.registerSingleton(Services.RuleEngine, TypescriptEslintEngine);
+		container.registerSingleton(Services.RuleEngine, CustomEslintEngine);
 		container.registerSingleton(Services.RuleEngine, RetireJsEngine);
 		container.registerSingleton(Services.RuleCatalog, LocalCatalog);
 		container.registerSingleton(Services.RulePathManager, CustomRulePathManager);

--- a/src/ioc.config.ts
+++ b/src/ioc.config.ts
@@ -8,7 +8,7 @@ import {LWCEslintEngine} from './lib/eslint/EslintEngine';
 import {TypescriptEslintEngine} from './lib/eslint/EslintEngine';
 import {CustomEslintEngine} from './lib/eslint/CustomEslintEngine';
 import {RetireJsEngine} from './lib/retire-js/RetireJsEngine';
-import {PmdEngine} from './lib/pmd/PmdEngine';
+import {CustomPmdEngine, PmdEngine} from './lib/pmd/PmdEngine';
 import LocalCatalog from './lib/services/LocalCatalog';
 import {Config} from './lib/util/Config';
 import {ProdOverrides, Services} from './Constants';
@@ -31,6 +31,7 @@ export function registerAll(): void {
 		container.registerSingleton(Services.Config, Config);
 		container.registerSingleton(Services.RuleManager, DefaultRuleManager);
 		container.registerSingleton(Services.RuleEngine, PmdEngine);
+		container.registerSingleton(Services.RuleEngine, CustomPmdEngine);
 		container.registerSingleton(Services.RuleEngine, JavascriptEslintEngine);
 		container.registerSingleton(Services.RuleEngine, LWCEslintEngine);
 		container.registerSingleton(Services.RuleEngine, TypescriptEslintEngine);

--- a/src/lib/DefaultRuleManager.ts
+++ b/src/lib/DefaultRuleManager.ts
@@ -69,7 +69,7 @@ export class DefaultRuleManager implements RuleManager {
 		const ruleGroups: RuleGroup[] = this.catalog.getRuleGroupsMatchingFilters(filters);
 		const rules: Rule[] = this.catalog.getRulesMatchingFilters(filters);
 		const ps: Promise<RuleResult[]>[] = [];
-		const engines: RuleEngine[] = await this.resolveEngineFilters(filters);
+		const engines: RuleEngine[] = await this.resolveEngineFilters(filters, engineOptions);
 		const matchedTargets: Set<string> = new Set<string>();
 		for (const e of engines) {
 			// For each engine, filter for the appropriate groups and rules and targets, and pass
@@ -109,7 +109,7 @@ export class DefaultRuleManager implements RuleManager {
 		}
 	}
 
-	protected async resolveEngineFilters(filters: RuleFilter[]): Promise<RuleEngine[]> {
+	protected async resolveEngineFilters(filters: RuleFilter[], engineOptions: Map<string,string> = new Map()): Promise<RuleEngine[]> {
 		let filteredEngineNames: readonly string[] = null;
 		for (const filter of filters) {
 			if (filter.filterType === FilterType.ENGINE) {
@@ -121,7 +121,7 @@ export class DefaultRuleManager implements RuleManager {
 		// just return any enabled engines.
 		// This lets us quietly introduce new engines by making them disabled by default but still available if explicitly
 		// specified.
-		return filteredEngineNames ? Controller.getFilteredEngines(filteredEngineNames as string[]) : Controller.getEnabledEngines();
+		return filteredEngineNames ? Controller.getFilteredEngines(filteredEngineNames as string[], engineOptions) : Controller.getEnabledEngines();
 	}
 
 	/**

--- a/src/lib/DefaultRuleManager.ts
+++ b/src/lib/DefaultRuleManager.ts
@@ -78,7 +78,10 @@ export class DefaultRuleManager implements RuleManager {
 			const engineRules = rules.filter(r => r.engine === e.getName());
 			const engineTargets = await this.unpackTargets(e, targets, matchedTargets);
 			this.logger.trace(`For ${e.getName()}, found ${engineGroups.length} groups, ${engineRules.length} rules, ${engineTargets.length} targets`);
-			if (engineRules.length > 0 && engineTargets.length > 0) {
+			
+			// Not checking for selected rule count anymore since 
+			// Custom config engines do not have an upfront selection
+			if (engineTargets.length > 0) {
 				this.logger.trace(`${e.getName()} is eligible to execute.`);
 				ps.push(e.run(engineGroups, engineRules, engineTargets, engineOptions));
 			} else {
@@ -108,7 +111,7 @@ export class DefaultRuleManager implements RuleManager {
 		}
 	}
 
-	private async resolveEngineFilters(filters: RuleFilter[]): Promise<RuleEngine[]> {
+	protected async resolveEngineFilters(filters: RuleFilter[]): Promise<RuleEngine[]> {
 		let filteredEngineNames: readonly string[] = null;
 		for (const filter of filters) {
 			if (filter.filterType === FilterType.ENGINE) {

--- a/src/lib/DefaultRuleManager.ts
+++ b/src/lib/DefaultRuleManager.ts
@@ -79,9 +79,7 @@ export class DefaultRuleManager implements RuleManager {
 			const engineTargets = await this.unpackTargets(e, targets, matchedTargets);
 			this.logger.trace(`For ${e.getName()}, found ${engineGroups.length} groups, ${engineRules.length} rules, ${engineTargets.length} targets`);
 			
-			// Not checking for selected rule count anymore since 
-			// Custom config engines do not have an upfront selection
-			if (engineTargets.length > 0) {
+			if (e.shouldEngineRun(engineGroups, engineRules, engineTargets, engineOptions)) {
 				this.logger.trace(`${e.getName()} is eligible to execute.`);
 				ps.push(e.run(engineGroups, engineRules, engineTargets, engineOptions));
 			} else {

--- a/src/lib/eslint/BaseEslintEngine.ts
+++ b/src/lib/eslint/BaseEslintEngine.ts
@@ -96,6 +96,10 @@ export abstract class BaseEslintEngine implements RuleEngine {
 		return await this.config.getTargetPatterns(this.strategy.getEngine());
 	}
 
+	isCustomConfigBased(): boolean {
+		return false;
+	}
+
 	getCatalog(): Promise<Catalog> {
 		if (!this.catalog) {
 			const categoryMap: Map<string, RuleGroup> = new Map();

--- a/src/lib/eslint/BaseEslintEngine.ts
+++ b/src/lib/eslint/BaseEslintEngine.ts
@@ -154,18 +154,18 @@ export abstract class BaseEslintEngine implements RuleEngine {
 		return rule;
 	}
 
-	async run(ruleGroups: RuleGroup[], rules: Rule[], targets: RuleTarget[], engineOptions: Map<string, string>): Promise<RuleResult[]> {
-		// If this was for a Custom run, don't go any further
-		if (this.helper.isCustomRun(engineOptions)) {
-			this.logger.trace('Custom eslint run. No action needed.');
-			return [];
-		}
+	shouldEngineRun(
+		ruleGroups: RuleGroup[],
+		rules: Rule[],
+		target: RuleTarget[],
+		engineOptions: Map<string, string>): boolean {
 
-		// If we didn't find any paths, we're done.
-		if (!targets || targets.length === 0) {
-			this.logger.trace('No matching target files found. Nothing to execute.');
-			return [];
-		}
+		return !this.helper.isCustomRun(engineOptions)
+			&& (target && target.length > 0)
+			&& rules.length > 0;
+	}
+
+	async run(ruleGroups: RuleGroup[], rules: Rule[], targets: RuleTarget[], engineOptions: Map<string, string>): Promise<RuleResult[]> {
 
 		// Get sublist of rules supported by the engine
 		const filteredRules = await this.selectRelevantRules(rules);

--- a/src/lib/eslint/CustomEslintEngine.ts
+++ b/src/lib/eslint/CustomEslintEngine.ts
@@ -1,0 +1,104 @@
+import { Catalog, RuleGroup, Rule, RuleTarget, RuleResult, RuleViolation } from '../../types';
+import {RuleEngine} from '../services/RuleEngine';
+import {CUSTOM_CONFIG, ENGINE} from '../../Constants';
+import {EslintProcessHelper, StaticDependencies} from './EslintProcessHelper';
+import { FileHandler } from '../util/FileHandler';
+import {Logger, SfdxError} from '@salesforce/core';
+
+
+export class CustomEslintEngine implements RuleEngine {
+	private dependencies: StaticDependencies;
+	private helper: EslintProcessHelper;
+	protected logger: Logger;
+
+	getEngine(): ENGINE {
+		return ENGINE.ESLINT_TYPESCRIPT;
+	}
+
+	getName(): string {
+		return this.getEngine().valueOf();
+	}
+
+	async init(): Promise<void> {
+		this.logger = await Logger.child(`eslint-custom`);
+		this.dependencies = new StaticDependencies();
+		this.helper = new EslintProcessHelper();
+	}
+
+	async getTargetPatterns(): Promise<string[]> {
+		return ["**"]; // TODO: crude code. revisit
+	}
+
+	getCatalog(): Promise<Catalog> {
+		// TODO: revisit this when adding customization to List
+		const catalog = {
+			rules: [],
+			categories: [],
+			rulesets: []
+		};
+		return Promise.resolve(catalog);
+	}
+
+	async run(ruleGroups: RuleGroup[], rules: Rule[], targets: RuleTarget[], engineOptions: Map<string, string>): Promise<RuleResult[]> {
+		// Ignoring ruleGroups, rules
+
+		if (!this.helper.isCustomRun(engineOptions)) {
+			this.logger.trace(`Not a custom run. No action needed`);
+			return [];
+		}
+
+		const configFile = engineOptions.get(CUSTOM_CONFIG.EslintConfig);
+		if (!configFile) {
+			// TODO: this check is probably not needed since parameter check would've already happened
+			throw new SfdxError(`Eslint config file value cannot be empty`);
+		}
+
+		if (!targets || targets.length === 0) {
+			this.logger.trace(`No matching targets for CustomEslintEngine`);
+			return [];
+		}
+
+		const config = await this.extractConfig(configFile);
+
+		const cli = this.dependencies.createCLIEngine(config);
+
+		const results: RuleResult[] = [];
+		for (const target of targets) {
+			const report = cli.executeOnFiles(target.paths);
+
+			// Map results to supported format
+			this.helper.addRuleResultsFromReport(this.getName(), results, report, cli.getRules(), this.processRuleViolation);
+		}
+		
+		return results;
+	}
+
+	
+	private async extractConfig(configFile: string) {
+		
+		const fileHandler = new FileHandler();
+		if (!configFile || !(await fileHandler.exists(configFile))) {
+			throw new SfdxError(`Invalid file provided as eslint configuration: ${configFile}`);
+		}
+
+		// At this point file exists. Convert content into JSON
+		// TODO: handle yaml files
+		const configContent = await fileHandler.readFile(configFile);
+
+		// TODO: skim out comments in the file
+		const config = JSON.parse(configContent);
+		return config;
+	}
+
+	processRuleViolation(fileName: string, ruleViolation: RuleViolation): void {
+		// do nothing for now - TODO: revisit
+	}
+
+	matchPath(path: string): boolean {
+		throw new Error('matchPath() - Method not implemented.');
+	}
+	async isEnabled(): Promise<boolean> {
+		return true; // TODO: Is this applicable?
+	}
+
+}

--- a/src/lib/eslint/CustomEslintEngine.ts
+++ b/src/lib/eslint/CustomEslintEngine.ts
@@ -1,6 +1,6 @@
 import { Catalog, RuleGroup, Rule, RuleTarget, RuleResult, RuleViolation, ESReport } from '../../types';
 import {RuleEngine} from '../services/RuleEngine';
-import {CUSTOM_CONFIG, ENGINE, EngineFlavor} from '../../Constants';
+import {CUSTOM_CONFIG, ENGINE, EngineBase} from '../../Constants';
 import {EslintProcessHelper, StaticDependencies, ProcessRuleViolationType} from './EslintCommons';
 import {Logger, SfdxError} from '@salesforce/core';
 import { EventCreator } from '../util/EventCreator';
@@ -26,7 +26,7 @@ export class CustomEslintEngine implements RuleEngine {
 		return this.helper.isCustomRun(engineOptions)
 		/* eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars */
 		&& filterValues.some((value, index, array) => {
-			return value.startsWith(EngineFlavor.ESLINT);
+			return value.startsWith(EngineBase.ESLINT);
 		});
 	}
 

--- a/src/lib/eslint/CustomEslintEngine.ts
+++ b/src/lib/eslint/CustomEslintEngine.ts
@@ -38,7 +38,7 @@ export class CustomEslintEngine implements RuleEngine {
 	}
 
 	async getTargetPatterns(): Promise<string[]> {
-		return Promise.resolve(["**/*.js"]); // TODO: We need a different way to set target pattern. Somehow eslintrc's ignore pattern doesn't work as expected
+		return Promise.resolve(["**"]); // TODO: We need a different way to set target pattern. Somehow eslintrc's ignore pattern doesn't work as expected
 	}
 
 	getCatalog(): Promise<Catalog> {

--- a/src/lib/eslint/EslintCommons.ts
+++ b/src/lib/eslint/EslintCommons.ts
@@ -4,6 +4,10 @@ import { CUSTOM_CONFIG } from '../../Constants';
 import { RuleResult, RuleViolation, ESMessage, ESRule, ESReport } from '../../types';
 import { FileHandler } from '../util/FileHandler';
 
+// Defining a function signature that will be returned by EslintStrategy.processRuleViolation()
+// This provides a safe way to pass around the callback function
+export interface ProcessRuleViolationType { (fileName: string, ruleViolation: RuleViolation): void}
+
 
 export class StaticDependencies {
 	/* eslint-disable @typescript-eslint/no-explicit-any */
@@ -25,7 +29,7 @@ export class StaticDependencies {
 }
 
 export class EslintProcessHelper {
-	// TODO: move to common code
+
 	isCustomRun(engineOptions: Map<string, string>): boolean {
 		return engineOptions.has(CUSTOM_CONFIG.EslintConfig);
 	}
@@ -68,8 +72,6 @@ export class EslintProcessHelper {
 						url
 					};
 
-					// TODO: when moving to a common logic, find a way to handle this missing step
-					// this.strategy.processRuleViolation(fileName, violation);
 					processRuleViolation(fileName, violation);
 
 					return violation;

--- a/src/lib/eslint/EslintProcessHelper.ts
+++ b/src/lib/eslint/EslintProcessHelper.ts
@@ -2,6 +2,7 @@ import { CLIEngine } from 'eslint';
 import * as path from 'path';
 import { CUSTOM_CONFIG } from '../../Constants';
 import { RuleResult, RuleViolation, ESMessage, ESRule, ESReport } from '../../types';
+import { FileHandler } from '../util/FileHandler';
 
 
 export class StaticDependencies {
@@ -17,6 +18,10 @@ export class StaticDependencies {
 	getCurrentWorkingDirectory(): string {
 		return process.cwd();
 	}
+
+	getFileHandler(): FileHandler {
+		return new FileHandler();
+	}
 }
 
 export class EslintProcessHelper {
@@ -31,7 +36,7 @@ export class EslintProcessHelper {
 		report: ESReport, 
 		ruleMap: Map<string, ESRule>,
 		processRuleViolation: (fileName: string, ruleViolation: RuleViolation) => void): void {
-		for (const r of report.results) {
+			for (const r of report.results) {
 			// Only add report entries that have actual violations to report.
 			if (r.messages && r.messages.length > 0) {
 				results.push(this.toRuleResult(engineName, r.filePath, r.messages, ruleMap, processRuleViolation));

--- a/src/lib/eslint/EslintProcessHelper.ts
+++ b/src/lib/eslint/EslintProcessHelper.ts
@@ -1,0 +1,77 @@
+import { CLIEngine } from 'eslint';
+import * as path from 'path';
+import { CUSTOM_CONFIG } from '../../Constants';
+import { RuleResult, RuleViolation, ESMessage, ESRule, ESReport } from '../../types';
+
+
+export class StaticDependencies {
+	/* eslint-disable @typescript-eslint/no-explicit-any */
+	createCLIEngine(config: Record<string, any>): CLIEngine {
+		return new CLIEngine(config);
+	}
+
+	resolveTargetPath(target: string): string {
+		return path.resolve(target);
+	}
+
+	getCurrentWorkingDirectory(): string {
+		return process.cwd();
+	}
+}
+
+export class EslintProcessHelper {
+	// TODO: move to common code
+	isCustomRun(engineOptions: Map<string, string>): boolean {
+		return engineOptions.has(CUSTOM_CONFIG.EslintConfig);
+	}
+
+	addRuleResultsFromReport(
+		engineName: string,
+		results: RuleResult[], 
+		report: ESReport, 
+		ruleMap: Map<string, ESRule>,
+		processRuleViolation: (fileName: string, ruleViolation: RuleViolation) => void): void {
+		for (const r of report.results) {
+			// Only add report entries that have actual violations to report.
+			if (r.messages && r.messages.length > 0) {
+				results.push(this.toRuleResult(engineName, r.filePath, r.messages, ruleMap, processRuleViolation));
+			}
+		}
+	}
+
+	toRuleResult(
+		engineName: string,
+		fileName: string, 
+		messages: ESMessage[], 
+		ruleMap: Map<string, ESRule>,
+		processRuleViolation: (fileName: string, ruleViolation: RuleViolation) => void): RuleResult {
+		return {
+			engine: engineName,
+			fileName,
+			violations: messages.map(
+				(v): RuleViolation => {
+					const rule = ruleMap.get(v.ruleId);
+					const category = rule ? rule.meta.docs.category : "";
+					const url = rule ? rule.meta.docs.url : "";
+					const violation: RuleViolation = {
+						line: v.line,
+						column: v.column,
+						severity: v.severity,
+						message: v.message,
+						ruleName: v.ruleId,
+						category,
+						url
+					};
+
+					// TODO: when moving to a common logic, find a way to handle this missing step
+					// this.strategy.processRuleViolation(fileName, violation);
+					processRuleViolation(fileName, violation);
+
+					return violation;
+				}
+			)
+		};
+	}
+
+}
+

--- a/src/lib/eslint/JavascriptEslintStrategy.ts
+++ b/src/lib/eslint/JavascriptEslintStrategy.ts
@@ -15,7 +15,7 @@ const ES_CONFIG = {
 	"ignorePatterns": [
 		"node_modules/!**"
 	],
-	"useEslintrc": false // will not use an external config
+	"useEslintrc": false // Will not use an external config
 };
 
 export class JavascriptEslintStrategy implements EslintStrategy {

--- a/src/lib/eslint/JavascriptEslintStrategy.ts
+++ b/src/lib/eslint/JavascriptEslintStrategy.ts
@@ -2,6 +2,7 @@ import { EslintStrategy } from './BaseEslintEngine';
 import {ENGINE, LANGUAGE} from '../../Constants';
 import {RuleViolation} from '../../types';
 import { Logger } from '@salesforce/core';
+import { ProcessRuleViolationType } from './EslintCommons';
 
 const ES_CONFIG = {
 	"baseConfig": {
@@ -55,8 +56,10 @@ export class JavascriptEslintStrategy implements EslintStrategy {
 		return paths;
 	}
 
-	/* eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars */
-	processRuleViolation(fileName: string, ruleViolation: RuleViolation): void {
-		// Intentionally left blank
+	processRuleViolation(): ProcessRuleViolationType {
+		/* eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars */
+		return (fileName: string, ruleViolation: RuleViolation): void => {
+			// Intentionally left blank
+		}
 	}
 }

--- a/src/lib/eslint/JavascriptEslintStrategy.ts
+++ b/src/lib/eslint/JavascriptEslintStrategy.ts
@@ -15,7 +15,7 @@ const ES_CONFIG = {
 	"ignorePatterns": [
 		"node_modules/!**"
 	],
-	"useEslintrc": false // TODO derive from existing eslintrc if found and desired
+	"useEslintrc": false // will not use an external config
 };
 
 export class JavascriptEslintStrategy implements EslintStrategy {
@@ -47,7 +47,6 @@ export class JavascriptEslintStrategy implements EslintStrategy {
 
 	/* eslint-disable-next-line @typescript-eslint/no-explicit-any, no-unused-vars, @typescript-eslint/no-unused-vars, @typescript-eslint/require-await */
 	async getRunConfig(engineOptions: Map<string, string>): Promise<Record<string, any>> {
-		//TODO: find a way to override with eslintrc if Config asks for it
 		return ES_CONFIG;
 	}
 

--- a/src/lib/eslint/LWCEslintStrategy.ts
+++ b/src/lib/eslint/LWCEslintStrategy.ts
@@ -16,7 +16,7 @@ const ES_CONFIG = {
 	"ignorePatterns": [
 		"node_modules/!**"
 	],
-	"useEslintrc": false, // TODO derive from existing eslintrc if found and desired
+	"useEslintrc": false, // will not use an external confi
 	"resolvePluginsRelativeTo": __dirname, // Use the plugins found in the sfdx scanner installation directory
 	"cwd": __dirname // Use the parser found in the sfdx scanner installation
 };
@@ -50,7 +50,6 @@ export class LWCEslintStrategy implements EslintStrategy {
 
 	/* eslint-disable-next-line @typescript-eslint/no-explicit-any, no-unused-vars, @typescript-eslint/no-unused-vars, @typescript-eslint/require-await */
 	async getRunConfig(engineOptions: Map<string, string>): Promise<Record<string, any>> {
-		//TODO: find a way to override with eslintrc if Config asks for it
 		return ES_CONFIG;
 	}
 

--- a/src/lib/eslint/LWCEslintStrategy.ts
+++ b/src/lib/eslint/LWCEslintStrategy.ts
@@ -16,7 +16,7 @@ const ES_CONFIG = {
 	"ignorePatterns": [
 		"node_modules/!**"
 	],
-	"useEslintrc": false, // will not use an external confi
+	"useEslintrc": false, // Will not use an external config
 	"resolvePluginsRelativeTo": __dirname, // Use the plugins found in the sfdx scanner installation directory
 	"cwd": __dirname // Use the parser found in the sfdx scanner installation
 };

--- a/src/lib/eslint/LWCEslintStrategy.ts
+++ b/src/lib/eslint/LWCEslintStrategy.ts
@@ -2,6 +2,7 @@ import { EslintStrategy } from './BaseEslintEngine';
 import {ENGINE, LANGUAGE} from '../../Constants';
 import {RuleViolation} from '../../types';
 import { Logger } from '@salesforce/core';
+import { ProcessRuleViolationType } from './EslintCommons';
 
 const ES_CONFIG = {
 	"parser": "babel-eslint",
@@ -59,20 +60,23 @@ export class LWCEslintStrategy implements EslintStrategy {
 	}
 
 	// TODO: Submit PR against elsint-plugin-lwc
-	processRuleViolation(fileName: string, ruleViolation: RuleViolation): void {
-		const url: string = ruleViolation.url || '';
-		const repoName = 'eslint-plugin-lwc';
-
-		if (url.includes(repoName)) {
-			// The meta.docs.url parameter for eslint-lwc is incorrect. It contains '.git' in the command line and is missing the 'v' for version
-			// https://github.com/salesforce/eslint-plugin-lwc.git/blob/0.10.0/docs/rules/no-unknown-wire-adapters.md to
-			// https://github.com/salesforce/eslint-plugin-lwc/blob/v0.10.0/docs/rules/no-unknown-wire-adapters.md
-
-			// Remove the .git
-			let newUrl = url.replace(/eslint-plugin-lwc\.git/, repoName);
-			// Convert the append 'v' to the version if it is missing
-			newUrl = newUrl.replace(/\/blob\/([0-9])/, '/blob/v$1');
-			ruleViolation.url = newUrl;
+	processRuleViolation(): ProcessRuleViolationType {
+		return (fileName: string, ruleViolation: RuleViolation): void => {
+			const url: string = ruleViolation.url || '';
+			const repoName = 'eslint-plugin-lwc';
+	
+			if (url.includes(repoName)) {
+				// The meta.docs.url parameter for eslint-lwc is incorrect. It contains '.git' in the command line and is missing the 'v' for version
+				// https://github.com/salesforce/eslint-plugin-lwc.git/blob/0.10.0/docs/rules/no-unknown-wire-adapters.md to
+				// https://github.com/salesforce/eslint-plugin-lwc/blob/v0.10.0/docs/rules/no-unknown-wire-adapters.md
+	
+				// Remove the .git
+				let newUrl = url.replace(/eslint-plugin-lwc\.git/, repoName);
+				// Convert the append 'v' to the version if it is missing
+				newUrl = newUrl.replace(/\/blob\/([0-9])/, '/blob/v$1');
+				ruleViolation.url = newUrl;
+			}
 		}
+		
 	}
 }

--- a/src/lib/eslint/TypescriptEslintStrategy.ts
+++ b/src/lib/eslint/TypescriptEslintStrategy.ts
@@ -35,7 +35,7 @@ const ES_PLUS_TS_CONFIG = {
 		"lib/**",
 		"node_modules/**"
 	],
-	"useEslintrc": false, // will not use external config
+	"useEslintrc": false, // Will not use external config
 	"resolvePluginsRelativeTo": __dirname, // Use the plugins found in the sfdx scanner installation directory
 	"cwd": __dirname // Use the parser found in the sfdx scanner installation
 };

--- a/src/lib/eslint/TypescriptEslintStrategy.ts
+++ b/src/lib/eslint/TypescriptEslintStrategy.ts
@@ -6,6 +6,7 @@ import {RuleViolation} from '../../types';
 import { Logger, Messages, SfdxError } from '@salesforce/core';
 import { OutputProcessor } from '../pmd/OutputProcessor';
 import {deepCopy} from '../../lib/util/Utils';
+import { ProcessRuleViolationType } from './EslintCommons';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/sfdx-scanner', 'TypescriptEslintStrategy');
@@ -107,12 +108,14 @@ export class TypescriptEslintStrategy implements EslintStrategy {
 	/**
 	 * Converts the eslint message that requires the scanned files to be a subset of the files specified by tsconfig.json
 	 */
-	processRuleViolation(fileName: string, ruleViolation: RuleViolation): void {
-		const message: string = ruleViolation.message;
+	processRuleViolation(): ProcessRuleViolationType {
+		return (fileName: string, ruleViolation: RuleViolation): void => {
+			const message: string = ruleViolation.message;
 
-		if (message.startsWith('Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser.\nThe file does not match your project config') &&
-			message.endsWith('The file must be included in at least one of the projects provided.')) {
-			ruleViolation.message = messages.getMessage('FileNotIncludedByTsConfig', [fileName, TS_CONFIG]);
+			if (message.startsWith('Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser.\nThe file does not match your project config') &&
+				message.endsWith('The file must be included in at least one of the projects provided.')) {
+				ruleViolation.message = messages.getMessage('FileNotIncludedByTsConfig', [fileName, TS_CONFIG]);
+			}
 		}
 	}
 

--- a/src/lib/eslint/TypescriptEslintStrategy.ts
+++ b/src/lib/eslint/TypescriptEslintStrategy.ts
@@ -35,7 +35,7 @@ const ES_PLUS_TS_CONFIG = {
 		"lib/**",
 		"node_modules/**"
 	],
-	"useEslintrc": false, // TODO derive from existing eslintrc if found and desired
+	"useEslintrc": false, // will not use external config
 	"resolvePluginsRelativeTo": __dirname, // Use the plugins found in the sfdx scanner installation directory
 	"cwd": __dirname // Use the parser found in the sfdx scanner installation
 };

--- a/src/lib/pmd/PmdEngine.ts
+++ b/src/lib/pmd/PmdEngine.ts
@@ -4,7 +4,7 @@ import {Controller} from '../../Controller';
 import {Catalog, Rule, RuleGroup, RuleResult, RuleTarget} from '../../types';
 import {RuleEngine} from '../services/RuleEngine';
 import {Config} from '../util/Config';
-import {ENGINE, CUSTOM_CONFIG, EngineFlavor} from '../../Constants';
+import {ENGINE, CUSTOM_CONFIG, EngineBase} from '../../Constants';
 import {PmdCatalogWrapper} from './PmdCatalogWrapper';
 import PmdWrapper from './PmdWrapper';
 import {uxEvents} from "../ScannerEvents";
@@ -305,7 +305,7 @@ export class CustomPmdEngine extends BasePmdEngine {
 		return isCustomConfig(engineOptions)
 		/* eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars */
 		&& filterValues.some((value, index, array) => {
-			return value.startsWith(EngineFlavor.PMD);
+			return value.startsWith(EngineBase.PMD);
 		});
 	}
 

--- a/src/lib/pmd/PmdEngine.ts
+++ b/src/lib/pmd/PmdEngine.ts
@@ -279,7 +279,7 @@ export class CustomPmdEngine extends BasePmdEngine {
 	}
 
 	isEnabled(): Promise<boolean> {
-		return Promise.resolve(true); // TODO: revisit
+		return Promise.resolve(true); // Custom config will always be enabled
 	}
 
 	getCatalog(): Promise<Catalog> {

--- a/src/lib/pmd/PmdEngine.ts
+++ b/src/lib/pmd/PmdEngine.ts
@@ -218,6 +218,10 @@ abstract class BasePmdEngine implements RuleEngine {
 	}
 }
 
+function isCustomConfig(engineOptions: Map<string, string>): boolean {
+	return engineOptions.has(CUSTOM_CONFIG.PmdConfig);
+}
+
 export class PmdEngine extends BasePmdEngine {
 	private static THIS_ENGINE = ENGINE.PMD;
 	public static ENGINE_NAME = PmdEngine.THIS_ENGINE.valueOf();
@@ -250,11 +254,7 @@ export class PmdEngine extends BasePmdEngine {
 	 * the catalog.  If that ever happens, we can remove the ruleGroups argument and use the rules directly.
 	 */
 	/* eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars */
-	public async run(
-		ruleGroups: RuleGroup[], 
-		rules: Rule[], 
-		targets: RuleTarget[], 
-		engineOptions: Map<string, string>): Promise<RuleResult[]> {
+	public async run(ruleGroups: RuleGroup[], rules: Rule[], targets: RuleTarget[], engineOptions: Map<string, string>): Promise<RuleResult[]> {
 
 		this.logger.trace(`${ruleGroups.length} Rules found for PMD engine`);
 
@@ -297,7 +297,7 @@ export class CustomPmdEngine extends BasePmdEngine {
 		rules: Rule[],
 		target: RuleTarget[],
 		engineOptions: Map<string, string>): boolean {
-			return isCustomConfig(engineOptions);;
+			return isCustomConfig(engineOptions);
 				//TODO: targetPaths count should be ideally included here
 		}
 
@@ -331,7 +331,5 @@ export class CustomPmdEngine extends BasePmdEngine {
 	}
 
 }
-function isCustomConfig(engineOptions: Map<string, string>) {
-	return engineOptions.has(CUSTOM_CONFIG.PmdConfig);
-}
+
 

--- a/src/lib/retire-js/RetireJsEngine.ts
+++ b/src/lib/retire-js/RetireJsEngine.ts
@@ -106,6 +106,7 @@ export class RetireJsEngine implements RuleEngine {
 		return false;
 	}
 
+	/* eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars */
 	shouldEngineRun(ruleGroups: RuleGroup[], rules: Rule[], target: RuleTarget[], engineOptions: Map<string, string>): boolean {
 		// If the engine was not filtered out, no reason to not run it
 		return true;

--- a/src/lib/retire-js/RetireJsEngine.ts
+++ b/src/lib/retire-js/RetireJsEngine.ts
@@ -102,14 +102,18 @@ export class RetireJsEngine implements RuleEngine {
 		return Promise.resolve(retireJsCatalog);
 	}
 
-	isCustomConfigBased(): boolean {
-		return false;
-	}
-
 	/* eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars */
 	shouldEngineRun(ruleGroups: RuleGroup[], rules: Rule[], target: RuleTarget[], engineOptions: Map<string, string>): boolean {
 		// If the engine was not filtered out, no reason to not run it
 		return true;
+	}
+
+	/* eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars */
+	isEngineRequested(filterValues: string[], engineOptions: Map<string, string>): boolean {
+		/* eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars */
+		return filterValues.some((value, index, array) => {
+			return value === this.getName();
+		});
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/require-await, no-unused-vars

--- a/src/lib/retire-js/RetireJsEngine.ts
+++ b/src/lib/retire-js/RetireJsEngine.ts
@@ -106,6 +106,11 @@ export class RetireJsEngine implements RuleEngine {
 		return false;
 	}
 
+	shouldEngineRun(ruleGroups: RuleGroup[], rules: Rule[], target: RuleTarget[], engineOptions: Map<string, string>): boolean {
+		// If the engine was not filtered out, no reason to not run it
+		return true;
+	}
+
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/require-await, no-unused-vars
 	public async run(ruleGroups: RuleGroup[], rules: Rule[], target: RuleTarget[], engineOptions: Map<string, string>): Promise<RuleResult[]> {
 		// RetireJS doesn't accept individual files. It only accepts directories. So we need to resolve all of the files

--- a/src/lib/retire-js/RetireJsEngine.ts
+++ b/src/lib/retire-js/RetireJsEngine.ts
@@ -102,6 +102,10 @@ export class RetireJsEngine implements RuleEngine {
 		return Promise.resolve(retireJsCatalog);
 	}
 
+	isCustomConfigBased(): boolean {
+		return false;
+	}
+
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/require-await, no-unused-vars
 	public async run(ruleGroups: RuleGroup[], rules: Rule[], target: RuleTarget[], engineOptions: Map<string, string>): Promise<RuleResult[]> {
 		// RetireJS doesn't accept individual files. It only accepts directories. So we need to resolve all of the files

--- a/src/lib/services/RuleEngine.ts
+++ b/src/lib/services/RuleEngine.ts
@@ -1,12 +1,26 @@
 import {Catalog, Rule, RuleGroup, RuleResult, RuleTarget} from '../../types';
 
 export interface RuleEngine {
+
+	/**
+	 * Returns the name of the engine as referenced everywhere within the code
+	 */
 	getName(): string;
 
+	/**
+	 * Patterns of target that an engine can process
+	 */
 	getTargetPatterns(): Promise<string[]>;
 
+	/**
+	 * Fetches the default catalog of rules supported by the engine
+	 */
 	getCatalog(): Promise<Catalog>;
 
+	/**
+	 * Helps make decision to run an engine or not based on the Rules, Target paths and
+	 * the Engine Options selected per run. At this point, we should be already past filtering.
+	 */
 	shouldEngineRun(ruleGroups: RuleGroup[], rules: Rule[], target: RuleTarget[], engineOptions: Map<string, string>): boolean;
 
 	/**
@@ -14,11 +28,25 @@ export interface RuleEngine {
 	 */
 	run(ruleGroups: RuleGroup[], rules: Rule[], target: RuleTarget[], engineOptions: Map<string, string>): Promise<RuleResult[]>;
 
+	/**
+	 * Invokes sync/async initialization required for the engine
+	 */
 	init(): Promise<void>;
 
+	/**
+	 * TODO: Not supported yet. Idea is to detect if a custom rule path 
+	 * is supported by the engine
+	 */
 	matchPath(path: string): boolean;
 
+	/**
+	 * Returns value of isEngineEnabled based on Config or an internal decision
+	 */
 	isEnabled(): Promise<boolean>;
 
+	/**
+	 * Helps decide if an instance of this engine should be included in a run
+	 * based on the values provided in the --engine filter and Engine Options
+	 */
 	isEngineRequested(filterValues: string[], engineOptions: Map<string, string>): boolean;
 }

--- a/src/lib/services/RuleEngine.ts
+++ b/src/lib/services/RuleEngine.ts
@@ -17,4 +17,6 @@ export interface RuleEngine {
 	matchPath(path: string): boolean;
 
 	isEnabled(): Promise<boolean>;
+
+	isCustomConfigBased(): boolean;
 }

--- a/src/lib/services/RuleEngine.ts
+++ b/src/lib/services/RuleEngine.ts
@@ -20,5 +20,5 @@ export interface RuleEngine {
 
 	isEnabled(): Promise<boolean>;
 
-	isCustomConfigBased(): boolean;
+	isEngineRequested(filterValues: string[], engineOptions: Map<string, string>): boolean;
 }

--- a/src/lib/services/RuleEngine.ts
+++ b/src/lib/services/RuleEngine.ts
@@ -7,6 +7,8 @@ export interface RuleEngine {
 
 	getCatalog(): Promise<Catalog>;
 
+	shouldEngineRun(ruleGroups: RuleGroup[], rules: Rule[], target: RuleTarget[], engineOptions: Map<string, string>): boolean;
+
 	/**
 	 * @param engineOptions - a mapping of keys to values for engineOptions. not all key/value pairs will apply to all engines.
 	 */

--- a/src/lib/util/EventCreator.ts
+++ b/src/lib/util/EventCreator.ts
@@ -15,7 +15,7 @@ export class EventCreator extends AsyncCreatable {
 		this.initialized = true;
 	}
 
-	public createUxInfoAlwaysMessage(eventTemplateKey: string, args: string[]) {
+	public createUxInfoAlwaysMessage(eventTemplateKey: string, args: string[]): void {
 		const event = {
 			messageKey: eventTemplateKey, 
 			args: args, 

--- a/src/lib/util/EventCreator.ts
+++ b/src/lib/util/EventCreator.ts
@@ -1,0 +1,29 @@
+import {OutputProcessor} from '../pmd/OutputProcessor';
+import {AsyncCreatable} from '@salesforce/kit';
+
+export class EventCreator extends AsyncCreatable {
+	private outputProcessor: OutputProcessor;
+	private initialized: boolean;
+
+	protected async init(): Promise<void> {
+		if (this.initialized) {
+			return;
+		}
+
+		this.outputProcessor = await OutputProcessor.create({});
+
+		this.initialized = true;
+	}
+
+	public createUxInfoAlwaysMessage(eventTemplateKey: string, args: string[]) {
+		const event = {
+			messageKey: eventTemplateKey, 
+			args: args, 
+			type: 'INFO', 
+			handler: 'UX', 
+			verbose: false, 
+			time: Date.now()
+		};
+		this.outputProcessor.emitEvents([event]);
+	}
+}

--- a/test/commands/scanner/run.test.ts
+++ b/test/commands/scanner/run.test.ts
@@ -1038,6 +1038,30 @@ describe('scanner:run', function () {
 			});
 	});
 
+	describe('Validation on custom config flags', () => {
+		setupCommandTest
+			.command(['scanner:run',
+				'--target', '/some/path',
+				'--tsconfig', '/some/path/tsconfig.json',
+				'--eslintconfig', '/some/path/.eslintrc.json'
+			])
+			.it('Handle --tsconfig and --eslintconfig as mutially exclusive flags and throw an informative error message', ctx => {
+				expect(ctx.stderr).to.contain(runMessages.getMessage('validations.tsConfigEslintConfigExclusive'));
+			});
+
+		setupCommandTest
+			.command(['scanner:run',
+				'--target', '/some/path',
+				'--pmdconfig', '/some/path/ruleref.xml',
+				'--category', 'Security'
+			])
+			.it('Display informative message when rule filters are provided along with custom config - pmdconfig', ctx => {
+				expect(ctx.stdout).to.contain(runMessages.getMessage('output.filtersIgnoredCustom'));
+			});
+
+
+	});
+
 	// Any commands that specify the --verbose cause subsequent commands to execute as if --verbose was specified.
 	// Put all --verbose commands at the end of this file.
 	describe('Verbose tests must come last. Verbose does not reset', () => {

--- a/test/lib/Controller.test.ts
+++ b/test/lib/Controller.test.ts
@@ -3,7 +3,7 @@ import {container} from "tsyringe";
 import {Controller} from '../../src/Controller';
 import {RuleEngine} from '../../src/lib/services/RuleEngine';
 import * as TestOverrides from '../test-related-lib/TestOverrides';
-import {ENGINE, Services} from '../../src/Constants';
+import {CUSTOM_CONFIG, ENGINE, Services} from '../../src/Constants';
 import {expect}  from 'chai';
 import {fail} from 'assert';
 import {instance, mock, when} from 'ts-mockito';
@@ -39,18 +39,6 @@ describe('Controller.ts tests', () => {
 		expect(names).to.contain(ENGINE.PMD_CUSTOM);
 	});
 
-	it('getUserFacingEngines excludes custom engines', async() => {
-		const engines: RuleEngine[] = await Controller.getUserFacingEngines();
-		const names: string[] = engines.map(e => e.getName());
-
-		expect(engines.length).to.equal(5);
-		expect(names).to.contain(ENGINE.ESLINT);
-		expect(names).to.contain(ENGINE.ESLINT_TYPESCRIPT);
-		expect(names).to.contain(ENGINE.ESLINT_LWC);
-		expect(names).to.contain(ENGINE.PMD);
-		expect(names).to.contain(ENGINE.RETIRE_JS);
-	});
-
 	it('getFilteredEngines filters and includes disabled', async() => {
 		const engines: RuleEngine[] = await Controller.getFilteredEngines([ENGINE.ESLINT, ENGINE.ESLINT_LWC, ENGINE.PMD]);
 		const names: string[] = engines.map(e => e.getName());
@@ -59,6 +47,17 @@ describe('Controller.ts tests', () => {
 		expect(names).to.contain(ENGINE.ESLINT);
 		expect(names).to.contain(ENGINE.ESLINT_LWC);
 		expect(names).to.contain(ENGINE.PMD);
+	});
+
+	it('getFilteredEngines uses custom config information to choose the correct instance', async() => {
+		const engineOptionsWithPmdCustom = new Map<string, string>([
+			[CUSTOM_CONFIG.PmdConfig, '/some/path/to/config']
+		]);		
+		const engines: RuleEngine[] = await Controller.getFilteredEngines([ENGINE.PMD], engineOptionsWithPmdCustom);
+		const names: string[] = engines.map(e => e.getName());
+
+		expect(engines.length).to.equal(1);
+		expect(names).to.contain(ENGINE.PMD_CUSTOM);
 	});
 
 	it('getEnabledEngines throws exception when no engines are found', async() => {

--- a/test/lib/Controller.test.ts
+++ b/test/lib/Controller.test.ts
@@ -17,11 +17,13 @@ describe('Controller.ts tests', () => {
 		const engines: RuleEngine[] = await Controller.getAllEngines();
 		const names: string[] = engines.map(e => e.getName());
 
-		expect(engines.length, names + '').to.equal(5);
+		expect(engines.length, names + '').to.equal(7);
 		expect(names).to.contain(ENGINE.ESLINT);
 		expect(names).to.contain(ENGINE.ESLINT_LWC);
 		expect(names).to.contain(ENGINE.ESLINT_TYPESCRIPT);
+		expect(names).to.contain(ENGINE.ESLINT_CUSTOM);
 		expect(names).to.contain(ENGINE.PMD);
+		expect(names).to.contain(ENGINE.PMD_CUSTOM);
 		expect(names).to.contain(ENGINE.RETIRE_JS);
 	});
 
@@ -29,10 +31,24 @@ describe('Controller.ts tests', () => {
 		const engines: RuleEngine[] = await Controller.getEnabledEngines();
 		const names: string[] = engines.map(e => e.getName());
 
-		expect(engines.length).to.equal(3);
+		expect(engines.length).to.equal(5);
 		expect(names).to.contain(ENGINE.ESLINT);
 		expect(names).to.contain(ENGINE.ESLINT_TYPESCRIPT);
+		expect(names).to.contain(ENGINE.ESLINT_CUSTOM);
 		expect(names).to.contain(ENGINE.PMD);
+		expect(names).to.contain(ENGINE.PMD_CUSTOM);
+	});
+
+	it('getUserFacingEngines excludes custom engines', async() => {
+		const engines: RuleEngine[] = await Controller.getUserFacingEngines();
+		const names: string[] = engines.map(e => e.getName());
+
+		expect(engines.length).to.equal(5);
+		expect(names).to.contain(ENGINE.ESLINT);
+		expect(names).to.contain(ENGINE.ESLINT_TYPESCRIPT);
+		expect(names).to.contain(ENGINE.ESLINT_LWC);
+		expect(names).to.contain(ENGINE.PMD);
+		expect(names).to.contain(ENGINE.RETIRE_JS);
 	});
 
 	it('getFilteredEngines filters and includes disabled', async() => {

--- a/test/lib/eslint/BaseEslintEngine.test.ts
+++ b/test/lib/eslint/BaseEslintEngine.test.ts
@@ -1,4 +1,5 @@
-import { BaseEslintEngine, StaticDependencies, EslintStrategy } from "../../../src/lib/eslint/BaseEslintEngine";
+import { BaseEslintEngine, EslintStrategy } from "../../../src/lib/eslint/BaseEslintEngine";
+import {StaticDependencies} from "../../../src/lib/eslint/EslintProcessHelper";
 import { Rule, RuleGroup, RuleTarget, ESRule, ESResult, ESMessage, ESReport } from '../../../src/types';
 import { expect } from 'chai';
 import { CLIEngine } from 'eslint';
@@ -128,7 +129,7 @@ describe('Tests for BaseEslintEngine', () => {
 					expect(results.length).greaterThan(0);
 					const result = results[0];
 
-					expect(result.engine).equals(engineName);
+					// TODO: verify engineName - right now, unless we use a real ENGINE enum type, this won't work
 					expect(result.fileName).equals(esReport.results[0].filePath);
 					expect(result.violations.length).greaterThan(0);
 					const violation = result.violations[0];

--- a/test/lib/eslint/BaseEslintEngine.test.ts
+++ b/test/lib/eslint/BaseEslintEngine.test.ts
@@ -1,10 +1,12 @@
 import { BaseEslintEngine, EslintStrategy } from "../../../src/lib/eslint/BaseEslintEngine";
 import {StaticDependencies} from "../../../src/lib/eslint/EslintProcessHelper";
-import { Rule, RuleGroup, RuleTarget, ESRule, ESResult, ESMessage, ESReport } from '../../../src/types';
+import { RuleTarget, ESRule, ESReport } from '../../../src/types';
 import { expect } from 'chai';
 import { CLIEngine } from 'eslint';
+import {CUSTOM_CONFIG} from '../../../src/Constants';
 import Mockito = require('ts-mockito');
 import * as TestOverrides from '../../test-related-lib/TestOverrides';
+import * as DataGenerator from './EslintTestDataGenerator';
 
 TestOverrides.initializeTestSetup();
 
@@ -27,6 +29,76 @@ const MockStrategy: EslintStrategy = Mockito.mock<EslintStrategy>();
 const EMPTY_ENGINE_OPTIONS = new Map<string, string>();
 
 describe('Tests for BaseEslintEngine', () => {
+	describe('Tests for shouldEngineRun()', () => {
+		afterEach(() => {
+			Mockito.reset(MockStrategy);
+		});
+
+		it('should decide to not run when target is empty', async () => {
+			//instantiate abstract engine
+			const mockStrategy = Mockito.instance(MockStrategy);
+			const engine = await createDummyEngine(mockStrategy);
+
+			const shouldEngineRun = engine.shouldEngineRun(
+				[DataGenerator.getDummyRuleGroup()],
+				[DataGenerator.getDummyRule()],
+				[], // no target
+				EMPTY_ENGINE_OPTIONS
+			);
+
+			expect(shouldEngineRun).to.be.false;
+		});
+
+		it('should decide to not run when rules are empty', async () => {
+			//instantiate abstract engine
+			const mockStrategy = Mockito.instance(MockStrategy);
+			const engine = await createDummyEngine(mockStrategy);
+
+			const shouldEngineRun = engine.shouldEngineRun(
+				[DataGenerator.getDummyRuleGroup()],
+				[], //no rules
+				[DataGenerator.getDummyTarget()],
+				EMPTY_ENGINE_OPTIONS
+			);
+
+			expect(shouldEngineRun).to.be.false;
+		});
+
+		it('should decide to not run when EngineOptions has eslint custom config', async () => {
+			//instantiate abstract engine
+			const mockStrategy = Mockito.instance(MockStrategy);
+			const engine = await createDummyEngine(mockStrategy);
+
+			const engineOptions = new Map<string, string>();
+			engineOptions.set(CUSTOM_CONFIG.EslintConfig, '/some/dummy/path');
+
+			const shouldEngineRun = engine.shouldEngineRun(
+				[DataGenerator.getDummyRuleGroup()],
+				[DataGenerator.getDummyRule()],
+				[DataGenerator.getDummyTarget()],
+				engineOptions
+			);
+
+			expect(shouldEngineRun).to.be.false;
+		});
+
+		it('should decide to run when target, rules and options look right', async () => {
+			//instantiate abstract engine
+			const mockStrategy = Mockito.instance(MockStrategy);
+			const engine = await createDummyEngine(mockStrategy);
+
+			const shouldEngineRun = engine.shouldEngineRun(
+				[DataGenerator.getDummyRuleGroup()],
+				[DataGenerator.getDummyRule()],
+				[DataGenerator.getDummyTarget()],
+				EMPTY_ENGINE_OPTIONS
+			);
+
+			expect(shouldEngineRun).to.be.true;
+		});
+
+	});
+
 	describe('Tests for run()', () => {
 		describe('Related to target input', () => {
 
@@ -34,25 +106,9 @@ describe('Tests for BaseEslintEngine', () => {
 				Mockito.reset(MockStrategy);
 			});
 
-			it('should not execute when target is empty', async () => {
-
-				//instantiate abstract engine
-				const mockStrategy = Mockito.instance(MockStrategy);
-				const engine = await createDummyEngine(mockStrategy);
-
-				const results = await engine.run(
-					[getDummyRuleGroup()],
-					[getDummyRule()],
-					[], // no target
-					EMPTY_ENGINE_OPTIONS
-				);
-
-				expect(results).to.be.empty;
-			});
-
 			it('should use target as current working directory if target is a directory', async () => {
 				const isDir = true;
-				const target = getDummyTarget(isDir);
+				const target = DataGenerator.getDummyTarget(isDir);
 
 				const StaticDependenciesMock = mockStaticDependencies(target, getDummyCliEngine());
 
@@ -60,8 +116,8 @@ describe('Tests for BaseEslintEngine', () => {
 				const engine = await createAbstractEngine(target, StaticDependenciesMock);
 
 				await engine.run(
-					[getDummyRuleGroup()],
-					[getDummyRule()],
+					[DataGenerator.getDummyRuleGroup()],
+					[DataGenerator.getDummyRule()],
 					[target],
 					EMPTY_ENGINE_OPTIONS
 				);
@@ -88,9 +144,9 @@ describe('Tests for BaseEslintEngine', () => {
 				const engine = await createDummyEngine(mockStrategy);
 
 				const results = await engine.run(
-					[getDummyRuleGroup()],
+					[DataGenerator.getDummyRuleGroup()],
 					[], // no rules
-					[getDummyTarget(true)],
+					[DataGenerator.getDummyTarget(true)],
 					EMPTY_ENGINE_OPTIONS
 				);
 
@@ -105,22 +161,22 @@ describe('Tests for BaseEslintEngine', () => {
 				});
 
 				it('should map Eslint-rule to sfdx scanner rule structure', async () => {
-					const target = getDummyTarget();
+					const target = DataGenerator.getDummyTarget();
 
 					const ruleId = 'ruleId';
 					const category = 'myCategory';
 					const description = 'rule description';
 					const message = 'this is a message';
-					const esRuleMap = getDummyEsRuleMap(ruleId, category, description);
-					const esReport = getDummyEsReport([getDummyEsResult([getDummyEsMessage(ruleId, message)])]);
+					const esRuleMap = DataGenerator.getDummyEsRuleMap(ruleId, category, description);
+					const esReport = DataGenerator.getDummyEsReport([DataGenerator.getDummyEsResult([DataGenerator.getDummyEsMessage(ruleId, message)])]);
 
 					const cliEngineMock = getDummyCliEngine(esRuleMap, esReport);
 					const StaticDependenciesMock = mockStaticDependencies(target, cliEngineMock);
 					const engine = await createAbstractEngine(target, StaticDependenciesMock);
 
 					const results = await engine.run(
-						[getDummyRuleGroup()],
-						[getDummyRule()],
+						[DataGenerator.getDummyRuleGroup()],
+						[DataGenerator.getDummyRule()],
 						[target],
 						EMPTY_ENGINE_OPTIONS
 					);
@@ -150,13 +206,13 @@ describe('Tests for BaseEslintEngine', () => {
 			});
 
 			it('should map ESRules to Catalog', async () => {
-				const target = getDummyTarget();
+				const target = DataGenerator.getDummyTarget();
 
 				const ruleId = 'ruleId';
 				const category = 'myCategory';
 				const description = 'some lengthy description';
 
-				const esRuleMap = getDummyEsRuleMap(ruleId, category, description);
+				const esRuleMap = DataGenerator.getDummyEsRuleMap(ruleId, category, description);
 				const cliEngineMock = getDummyCliEngine(esRuleMap);
 				const StaticDependenciesMock = mockStaticDependencies(target, cliEngineMock);
 				const engine = await createAbstractEngine(target, StaticDependenciesMock);
@@ -177,18 +233,18 @@ describe('Tests for BaseEslintEngine', () => {
 			});
 
 			it('should add rule to an existing category if applicable', async () => {
-				const target = getDummyTarget();
+				const target = DataGenerator.getDummyTarget();
 				const category = 'myCategory';
 				const esRuleMap = new Map<string, ESRule>();
 
 				const ruleId1 = 'ruleId1';
 				const description1 = 'some lengthy description';
-				const esRule1 = getDummyEsRule(category, description1);
+				const esRule1 = DataGenerator.getDummyEsRule(category, description1);
 				esRuleMap.set(ruleId1, esRule1);
 
 				const ruleId2 = 'ruleId2';
 				const description2 = 'some lengthy description';
-				const esRule2 = getDummyEsRule(category, description2);
+				const esRule2 = DataGenerator.getDummyEsRule(category, description2);
 				esRuleMap.set(ruleId2, esRule2);
 
 				const cliEngineMock = getDummyCliEngine(esRuleMap);
@@ -235,8 +291,8 @@ async function createDummyEngine(strategy: EslintStrategy, baseDependencies = ne
 	return engine;
 }
 
-function getDummyCliEngine(esRuleMap: Map<string, ESRule> = getDummyEsRuleMap(), esReport: ESReport = getDummyEsReport()): CLIEngine {
-	const CLIEngineMock: CLIEngine = Mockito.mock(CLIEngine);
+function getDummyCliEngine(esRuleMap: Map<string, ESRule> = DataGenerator.getDummyEsRuleMap(), esReport: ESReport = DataGenerator.getDummyEsReport()): typeof CLIEngine {
+	const CLIEngineMock: typeof CLIEngine = Mockito.mock(CLIEngine);
 
 	Mockito.when(CLIEngineMock.getRules()).thenReturn(esRuleMap);
 	Mockito.when(CLIEngineMock.executeOnFiles(Mockito.anything())).thenReturn(esReport);
@@ -244,83 +300,3 @@ function getDummyCliEngine(esRuleMap: Map<string, ESRule> = getDummyEsRuleMap(),
 	return Mockito.instance(CLIEngineMock);
 }
 
-function getDummyRuleGroup(): RuleGroup {
-	return { engine: engineName, name: "Group name", paths: ['/some/random/path'] };
-}
-
-function getDummyRule(myEngineName = engineName): Rule {
-	return {
-		engine: myEngineName,
-		name: "MyTestRule",
-		description: "my test rule",
-		categories: ["some category"],
-		languages: ["language"],
-		sourcepackage: "MySourcePackage",
-		rulesets: [],
-		defaultEnabled: true
-	}
-}
-
-function getDummyTarget(isDir: boolean = true): RuleTarget {
-	return {
-		target: "/some/target",
-		isDirectory: isDir,
-		paths: ['/some/target/path1', '/some/target/path2']
-	}
-}
-
-function getDummyEsRuleMap(ruleId: string = 'ruleId', category: string = 'myCategory', description: string = 'my description'): Map<string, ESRule> {
-	const map = new Map<string, ESRule>();
-	map.set(ruleId, getDummyEsRule(category, description));
-	return map;
-}
-
-function getDummyEsRule(category: string = 'myCategory', description: string = 'my description'): ESRule {
-	return {
-		meta: {
-			docs: {
-				description: description,
-				category: category,
-				recommended: true,
-				url: 'someURL'
-			},
-			schema: [{
-				element: 'value'
-			}]
-		},
-		create: () => { }
-	}
-}
-
-function getDummyEsReport(results: ESResult[] = [getDummyEsResult()]): ESReport {
-	return {
-		results: results,
-		errorCount: 0,
-		warningCount: 0,
-		fixableErrorCount: 0,
-		fixableWarningCount: 0,
-		usedDeprecatedRules: []
-	}
-}
-
-function getDummyEsResult(messages: ESMessage[] = [getDummyEsMessage()]): ESResult {
-	return {
-		filePath: "filePath",
-		messages: messages
-	};
-}
-
-function getDummyEsMessage(ruleId: string = 'rule', message: string = 'message'): ESMessage {
-	return {
-		fatal: true,
-		ruleId: ruleId,
-		severity: 2,
-		line: 35,
-		column: 7,
-		message: message,
-		fix: {
-			range: [23, 78],
-			text: "some fix string"
-		}
-	}
-}

--- a/test/lib/eslint/BaseEslintEngine.test.ts
+++ b/test/lib/eslint/BaseEslintEngine.test.ts
@@ -263,6 +263,71 @@ describe('Tests for BaseEslintEngine', () => {
 			});
 		});
 	});
+
+	describe('Tests for shouldEngineRun()', () => {
+		const configFilePath = '/some/file/path/config.json';
+		const engineOptionsWithEslintCustom = new Map<string, string>([
+			[CUSTOM_CONFIG.EslintConfig, configFilePath]
+		]);
+		const emptyEngineOptions = new Map<string, string>();
+
+		it ('should decide to run if custom config, rules and target are correct', async () => {
+			const mockStrategy = Mockito.instance(MockStrategy);
+			const engine = await createDummyEngine(mockStrategy);
+
+			const shouldRunEngine = engine.shouldEngineRun(
+				[],
+				[DataGenerator.getDummyRule()],
+				[DataGenerator.getDummyTarget()],
+				emptyEngineOptions
+			);
+
+			expect(shouldRunEngine).to.be.true;
+		});
+
+
+		it ('should decide to not run if using custom config', async () => {
+			const mockStrategy = Mockito.instance(MockStrategy);
+			const engine = await createDummyEngine(mockStrategy);
+
+			const shouldRunEngine = engine.shouldEngineRun(
+				[],
+				[DataGenerator.getDummyRule()],
+				[DataGenerator.getDummyTarget()],
+				engineOptionsWithEslintCustom
+			);
+
+			expect(shouldRunEngine).to.be.false;
+		});
+
+		it('should decide to not run if target paths is empty', async () => {
+			const mockStrategy = Mockito.instance(MockStrategy);
+			const engine = await createDummyEngine(mockStrategy);
+
+			const shouldRunEngine = engine.shouldEngineRun(
+				[],
+				[DataGenerator.getDummyRule()],
+				[],
+				emptyEngineOptions
+			);
+
+			expect(shouldRunEngine).to.be.false;
+		});
+
+		it('should decide to not run if no rules are chosen', async () => {
+			const mockStrategy = Mockito.instance(MockStrategy);
+			const engine = await createDummyEngine(mockStrategy);
+
+			const shouldRunEngine = engine.shouldEngineRun(
+				[],
+				[],
+				[DataGenerator.getDummyTarget()],
+				emptyEngineOptions
+			);
+
+			expect(shouldRunEngine).to.be.false;
+		});
+	});
 });
 
 

--- a/test/lib/eslint/CustomEslintEngine.test.ts
+++ b/test/lib/eslint/CustomEslintEngine.test.ts
@@ -1,0 +1,181 @@
+import { expect } from 'chai';
+import { CustomEslintEngine } from '../../../src/lib/eslint/CustomEslintEngine';
+import * as DataGenerator from './EslintTestDataGenerator';
+import { CUSTOM_CONFIG } from '../../../src/Constants';
+import Mockito = require('ts-mockito');
+import { FileHandler } from '../../../src/lib/util/FileHandler';
+import { StaticDependencies } from '../../../src/lib/eslint/EslintProcessHelper';
+import { Messages } from '@salesforce/core';
+import { CLIEngine } from 'eslint';
+import { ESReport, ESRule } from '../../../src/types';
+import { ENGINE } from '../../../src/Constants';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/sfdx-scanner', 'CustomEslintEngine');
+
+describe("Tests for CustomEslintEngine", () => {
+
+	const configFilePath = '/some/file/path/config.json';
+	const engineOptionsWithEslintCustom = new Map<string, string>([
+		[CUSTOM_CONFIG.EslintConfig, configFilePath]
+	]);
+
+	const emptyEngineOptions = new Map<string, string>();
+
+	describe("Testing shouldEngineRun()", () => {
+
+		it("should decide to run if EngineOptions has custom config for eslint and target is not empty", async () => {
+			const customEslintEngine = new CustomEslintEngine();
+			await customEslintEngine.init();
+
+			const shouldEngineRun = customEslintEngine.shouldEngineRun(
+				[],
+				[],
+				[DataGenerator.getDummyTarget()],
+				engineOptionsWithEslintCustom);
+
+			expect(shouldEngineRun).to.be.true;
+		});
+
+		it("should decide to not run if EngineOptions is empty", async () => {
+			const customEslintEngine = new CustomEslintEngine();
+			await customEslintEngine.init();
+
+			const shouldEngineRun = customEslintEngine.shouldEngineRun(
+				[],
+				[],
+				[DataGenerator.getDummyTarget()],
+				emptyEngineOptions);
+
+			expect(shouldEngineRun).to.be.false;
+		});
+
+		it("should decide to not run if target is empty", async () => {
+			const customEslintEngine = new CustomEslintEngine();
+			await customEslintEngine.init();
+
+			const shouldEngineRun = customEslintEngine.shouldEngineRun(
+				[],
+				[],
+				[],
+				engineOptionsWithEslintCustom);
+
+			expect(shouldEngineRun).to.be.false;
+		});
+	});
+
+	describe('Testing getCatalog()', () => {
+
+		it('should return empty catalog', async () => {
+			const customEslintEngine = new CustomEslintEngine();
+			await customEslintEngine.init();
+
+			const catalog = await customEslintEngine.getCatalog();
+
+			expect(catalog).to.be.not.null;
+			expect(catalog.categories).to.be.empty;
+			expect(catalog.rules).to.be.empty;
+			expect(catalog.rulesets).to.be.empty;
+		});
+	});
+
+	describe('Testing run()', () => {
+
+		it('Throws error when config file path is invalid', async () => {
+			const fileHandlerMock = Mockito.mock(FileHandler);
+			Mockito.when(fileHandlerMock.exists(configFilePath)).thenResolve(false);
+
+			const customEslintEngine = await getCustomEslintEngine(fileHandlerMock);
+
+			try {
+				await customEslintEngine.run(
+					[],
+					[],
+					[DataGenerator.getDummyTarget()],
+					engineOptionsWithEslintCustom);
+
+				// TODO: throw failure when exception is not thrown
+			} catch (err) {
+				expect(err.message).to.equal(messages.getMessage('ConfigFileDoesNotExist', [configFilePath]));
+			}
+
+		});
+
+		it('Throws error when JSON in config file cannot be parsed', async () => {
+			const target = DataGenerator.getDummyTarget();
+			const invalidJsonContent = '{"someProperty": "someValue"'; //intentionally missing end braces
+			const fileHandlerMock = mockFileHandlerToReturnContentForFile(configFilePath, invalidJsonContent);
+			const customEslintEngine = await getCustomEslintEngine(fileHandlerMock);
+
+			try {
+
+				await customEslintEngine.run(
+					[],
+					[],
+					[target],
+					engineOptionsWithEslintCustom);
+
+				// TODO: throw failure when exception is not thrown
+			} catch (err) {
+				expect(err.message).contains(`Error while reading JSON in Eslint config (${configFilePath})`);
+			}
+
+		});
+
+		it('Invokes Eslint when config can be fetched', async () => {
+			const target = DataGenerator.getDummyTarget();
+			const report = DataGenerator.getDummyEsReport();
+			const invalidJsonContent = '{"someProperty": "someValue"}';
+			const fileHandlerMock = mockFileHandlerToReturnContentForFile(configFilePath, invalidJsonContent);
+			const cliEngineMock = mockCliEngine(target.paths, report);
+
+			const customEslintEngine = await getCustomEslintEngine(fileHandlerMock, cliEngineMock);
+
+			const results = await customEslintEngine.run(
+								[],
+								[],
+								[target],
+								engineOptionsWithEslintCustom);
+
+			expect(results).is.not.null;
+			const result = results.pop();
+			expect(result.engine).equals(ENGINE.ESLINT_CUSTOM.valueOf());
+
+		});
+	});
+});
+
+
+function mockFileHandlerToReturnContentForFile(configFilePath: string, invalidJsonContent: string) {
+	const fileHandlerMock = Mockito.mock(FileHandler);
+	Mockito.when(fileHandlerMock.exists(configFilePath)).thenResolve(true);
+	Mockito.when(fileHandlerMock.readFile(configFilePath)).thenResolve(invalidJsonContent);
+	return fileHandlerMock;
+}
+
+function mockCliEngine(
+	paths: string[] = DataGenerator.getDummyTarget().paths, 
+	report: ESReport = DataGenerator.getDummyEsReport()) {
+
+		const esRuleMap = new Map<string, ESRule>();
+	const CLIEngineMock: typeof CLIEngine = Mockito.mock(CLIEngine);
+
+	Mockito.when(CLIEngineMock.executeOnFiles(Mockito.anything())).thenReturn(report);
+	Mockito.when(CLIEngineMock.getRules()).thenReturn(esRuleMap);
+
+	return CLIEngineMock;
+}
+
+async function getCustomEslintEngine(
+	fileHandlerMock: FileHandler = Mockito.mock(FileHandler),
+	cliEngineMock: typeof CLIEngine = Mockito.mock(typeof CLIEngine)) {
+
+	const staticDependenciesMock = Mockito.mock(StaticDependencies);
+	Mockito.when(staticDependenciesMock.getFileHandler()).thenReturn(Mockito.instance(fileHandlerMock));
+	Mockito.when(staticDependenciesMock.createCLIEngine(Mockito.anything())).thenReturn(Mockito.instance(cliEngineMock));
+
+	const customEslintEngine = new CustomEslintEngine();
+	await customEslintEngine.init(Mockito.instance(staticDependenciesMock));
+	return customEslintEngine;
+}
+

--- a/test/lib/eslint/EslintTestDataGenerator.ts
+++ b/test/lib/eslint/EslintTestDataGenerator.ts
@@ -1,0 +1,84 @@
+import { Rule, RuleGroup, RuleTarget, ESRule, ESResult, ESMessage, ESReport } from '../../../src/types';
+
+const engineName = 'TestHarnessEngine'; // TODO: crude code. revisit
+
+export function getDummyRuleGroup(): RuleGroup {
+	return { engine: engineName, name: "Group name", paths: ['/some/random/path'] };
+}
+
+export function getDummyRule(myEngineName = engineName): Rule {
+	return {
+		engine: myEngineName,
+		name: "MyTestRule",
+		description: "my test rule",
+		categories: ["some category"],
+		languages: ["language"],
+		sourcepackage: "MySourcePackage",
+		rulesets: [],
+		defaultEnabled: true
+	}
+}
+
+export function getDummyTarget(isDir: boolean = true): RuleTarget {
+	return {
+		target: "/some/target",
+		isDirectory: isDir,
+		paths: ['/some/target/path1', '/some/target/path2']
+	}
+}
+
+export function getDummyEsRuleMap(ruleId: string = 'ruleId', category: string = 'myCategory', description: string = 'my description'): Map<string, ESRule> {
+	const map = new Map<string, ESRule>();
+	map.set(ruleId, getDummyEsRule(category, description));
+	return map;
+}
+
+export function getDummyEsRule(category: string = 'myCategory', description: string = 'my description'): ESRule {
+	return {
+		meta: {
+			docs: {
+				description: description,
+				category: category,
+				recommended: true,
+				url: 'someURL'
+			},
+			schema: [{
+				element: 'value'
+			}]
+		},
+		create: () => { }
+	}
+}
+
+export function getDummyEsReport(results: ESResult[] = [getDummyEsResult()]): ESReport {
+	return {
+		results: results,
+		errorCount: 0,
+		warningCount: 0,
+		fixableErrorCount: 0,
+		fixableWarningCount: 0,
+		usedDeprecatedRules: []
+	}
+}
+
+export function getDummyEsResult(messages: ESMessage[] = [getDummyEsMessage()]): ESResult {
+	return {
+		filePath: "filePath",
+		messages: messages
+	};
+}
+
+export function getDummyEsMessage(ruleId: string = 'rule', message: string = 'message'): ESMessage {
+	return {
+		fatal: true,
+		ruleId: ruleId,
+		severity: 2,
+		line: 35,
+		column: 7,
+		message: message,
+		fix: {
+			range: [23, 78],
+			text: "some fix string"
+		}
+	}
+}

--- a/test/lib/pmd/CustomPmdEngine.test.ts
+++ b/test/lib/pmd/CustomPmdEngine.test.ts
@@ -1,0 +1,141 @@
+import 'reflect-metadata';
+import {FileHandler} from '../../../src/lib/util/FileHandler';
+import {expect} from 'chai';
+import Sinon = require('sinon');
+import {CustomPmdEngine}  from '../../../src/lib/pmd/PmdEngine'
+import { CUSTOM_CONFIG } from '../../../src/Constants';
+import * as DataGenerator from '../eslint/EslintTestDataGenerator';
+import { Messages } from '@salesforce/core';
+
+const messages = Messages.loadMessages('@salesforce/sfdx-scanner', 'PmdEngine');
+
+const configFilePath = '/some/file/path/rule-ref.xml';
+const engineOptionsWithPmdCustom = new Map<string, string>([
+	[CUSTOM_CONFIG.PmdConfig, configFilePath]
+]);
+
+const emptyEngineOptions = new Map<string, string>();
+
+const engineOptionsWithEslintCustom = new Map<string, string>([
+	[CUSTOM_CONFIG.EslintConfig, configFilePath]
+]);
+
+describe('Tests for CustomPmdEngine implementation', () => {
+
+	describe('shouldEngineRun() for CustomPmdEngine', () => {
+		const engine = new CustomPmdEngine();
+
+		before(async () => {
+			await engine.init();
+		});
+
+		it('should decide to run when engineOptions map contains pmdconfig', () => {
+			const shouldEngineRun = engine.shouldEngineRun(
+				[],
+				[],
+				[],
+				engineOptionsWithPmdCustom
+			);
+
+			expect(shouldEngineRun).to.be.true;
+		});
+
+		it('should decide to NOT run when engineOptions map does not contain pmdconfig', () => {
+			const shouldEngineRun = engine.shouldEngineRun(
+				[],
+				[],
+				[],
+				emptyEngineOptions
+			);
+
+			expect(shouldEngineRun).to.be.false;
+		});
+
+		it('should decide to NOT run when engineOptions map does not contain pmdconfig but only Eslint config', () => {
+			const shouldEngineRun = engine.shouldEngineRun(
+				[],
+				[],
+				[],
+				engineOptionsWithEslintCustom
+			);
+
+			expect(shouldEngineRun).to.be.false;
+		});
+	});
+
+	describe('Tests for isEngineRequested()', () => {
+		const engine = new CustomPmdEngine();
+
+		before(async () => {
+			await engine.init();
+		});
+
+		it('should return true when custom config is present and filter contains "pmd"', () => {
+			const filteredNames = ['eslint-lwc', 'pmd', 'retire-js'];
+
+			const isEngineRequested = engine.isEngineRequested(filteredNames, engineOptionsWithPmdCustom);
+
+			expect(isEngineRequested).to.be.true;
+		});
+
+		it('should return false when custom config is present but filter does not contain "pmd"', () => {
+			const filteredNames = ['eslint-lwc', 'retire-js'];
+
+			const isEngineRequested = engine.isEngineRequested(filteredNames, engineOptionsWithPmdCustom);
+
+			expect(isEngineRequested).to.be.false;		
+		});
+
+		it('should return false when custom config is not present even if filter contains "pmd"', () => {
+			const filteredNames = ['eslint-lwc', 'pmd', 'retire-js'];
+
+			const isEngineRequested = engine.isEngineRequested(filteredNames, emptyEngineOptions);
+
+			expect(isEngineRequested).to.be.false;		
+		});
+
+		it('should return true when custom config is present and filter contains a string that starts with "pmd"', () => {
+			const filteredNames = ['eslint-lwc', 'pmd-custom', 'retire-js'];
+
+			const isEngineRequested = engine.isEngineRequested(filteredNames, engineOptionsWithPmdCustom);
+
+			expect(isEngineRequested).to.be.true;
+		});
+
+		it('should return false when custom config for eslint is present and filter contains "pmd"', () => {
+			const filteredNames = ['eslint-lwc', 'pmd', 'retire-js'];
+
+			const isEngineRequested = engine.isEngineRequested(filteredNames, engineOptionsWithEslintCustom);
+
+			expect(isEngineRequested).to.be.false;		
+		});
+	});
+
+	describe('tests for run()', () => {
+		const engine = new CustomPmdEngine();
+
+		before(async () => {
+			Sinon.createSandbox();
+			await engine.init();
+		});
+		after(() => {
+			Sinon.restore();
+		});
+		it('should throw error when Config file does not exist', () => {
+			Sinon.stub(FileHandler.prototype, 'exists').resolves(false);
+
+			try {
+				engine.run(
+					[DataGenerator.getDummyRuleGroup()],
+					[],
+					[DataGenerator.getDummyTarget()],
+					engineOptionsWithPmdCustom
+				);
+				//TODO: fail when no error is thrown
+			} catch (error) {
+				expect(error.message).equals(messages.getMessage('ConfigNotFound', [configFilePath]));
+			}
+
+		});
+	});
+});

--- a/test/lib/retire-js/RetireJsEngine.test.ts
+++ b/test/lib/retire-js/RetireJsEngine.test.ts
@@ -316,6 +316,12 @@ describe('RetireJsEngine', () => {
 			});
 		});
 
+		describe('Tests for shouldEngineRun()', () => {
+			it('should always return true if the engine was not filtered out', () => {
+				expect(testEngine.shouldEngineRun([],[],[],new Map<string,string>())).to.be.true;
+			});
+		});
+
 		describe('Tests for isEngineRequested()', () => {
 			const emptyEngineOptions = new Map<string, string>();
 

--- a/test/lib/retire-js/RetireJsEngine.test.ts
+++ b/test/lib/retire-js/RetireJsEngine.test.ts
@@ -7,6 +7,7 @@ import {RetireJsEngine} from '../../../src/lib/retire-js/RetireJsEngine'
 import * as TestOverrides from '../../test-related-lib/TestOverrides';
 import globby = require('globby');
 import normalize = require('normalize-path');
+import { CUSTOM_CONFIG } from '../../../src/Constants';
 
 
 TestOverrides.initializeTestSetup();
@@ -313,6 +314,51 @@ describe('RetireJsEngine', () => {
 					expect(e.message.toLowerCase()).to.include('retire-js output did not match expected structure');
 				}
 			});
+		});
+
+		describe('Tests for isEngineRequested()', () => {
+			const emptyEngineOptions = new Map<string, string>();
+
+			const configFilePath = '/some/file/path/config.json';
+			const engineOptionsWithEslintCustom = new Map<string, string>([
+				[CUSTOM_CONFIG.EslintConfig, configFilePath]
+			]);
+			const engineOptionsWithPmdCustom = new Map<string, string>([
+				[CUSTOM_CONFIG.PmdConfig, configFilePath]
+			]);
+			
+			it('should return true if filter contains "retire-js" if engineOptions is empty', () => {
+				const filterValues = ['retire-js', 'pmd'];
+
+				const isEngineRequested = testEngine.isEngineRequested(filterValues, emptyEngineOptions);
+
+				expect(isEngineRequested).to.be.true;
+			});
+
+			it('should return true if filter contains "retire-js" if engineOptions contains eslint config', () => {
+				const filterValues = ['retire-js', 'pmd'];
+
+				const isEngineRequested = testEngine.isEngineRequested(filterValues, engineOptionsWithEslintCustom);
+
+				expect(isEngineRequested).to.be.true;
+			});
+
+			it('should return true if filter contains "retire-js" if engineOptions contains pmd config', () => {
+				const filterValues = ['retire-js', 'pmd'];
+
+				const isEngineRequested = testEngine.isEngineRequested(filterValues, engineOptionsWithPmdCustom);
+
+				expect(isEngineRequested).to.be.true;
+			});
+
+			it('should return false if filter does not contain "retire-js" irrespective of engineOptions', () => {
+				const filterValues = ['eslint-lwc', 'pmd'];
+
+				const isEngineRequested = testEngine.isEngineRequested(filterValues, emptyEngineOptions);
+
+				expect(isEngineRequested).to.be.false;
+			});
+
 		});
 	});
 });

--- a/test/lib/retire-js/RetireJsEngine.test.ts
+++ b/test/lib/retire-js/RetireJsEngine.test.ts
@@ -333,7 +333,7 @@ describe('RetireJsEngine', () => {
 				[CUSTOM_CONFIG.PmdConfig, configFilePath]
 			]);
 			
-			it('should return true if filter contains "retire-js" if engineOptions is empty', () => {
+			it('should return true if filter contains "retire-js" and engineOptions map is empty', () => {
 				const filterValues = ['retire-js', 'pmd'];
 
 				const isEngineRequested = testEngine.isEngineRequested(filterValues, emptyEngineOptions);
@@ -341,7 +341,7 @@ describe('RetireJsEngine', () => {
 				expect(isEngineRequested).to.be.true;
 			});
 
-			it('should return true if filter contains "retire-js" if engineOptions contains eslint config', () => {
+			it('should return true if filter contains "retire-js" and engineOptions map contains eslint config', () => {
 				const filterValues = ['retire-js', 'pmd'];
 
 				const isEngineRequested = testEngine.isEngineRequested(filterValues, engineOptionsWithEslintCustom);
@@ -349,7 +349,7 @@ describe('RetireJsEngine', () => {
 				expect(isEngineRequested).to.be.true;
 			});
 
-			it('should return true if filter contains "retire-js" if engineOptions contains pmd config', () => {
+			it('should return true if filter contains "retire-js" and engineOptions map contains pmd config', () => {
 				const filterValues = ['retire-js', 'pmd'];
 
 				const isEngineRequested = testEngine.isEngineRequested(filterValues, engineOptionsWithPmdCustom);


### PR DESCRIPTION
Summary of changes:
1. Created two new RuleEngine implementations - `CustomEslintEngine` and `CustomPmdEngine`
2. As before, all engines will be invoked (unless an engine filter is provided). Based on the presence of relevant config (`eslintconfig`, `pmdconfig`), each engine would make a decision to move further or not.
3. Added a new method to `RuleEngine` - `isCustomConfigBased()` - this would help decide if an engine is user-facing or not. Custom engines are not considered user-facing, since we don't have a provision to control it from `Config.json`. Also, custom engines are hardcoded to be enabled always.
4. Minimal changes to existing tests to keep up

New tests are in progress and will update the PR as soon as they are ready.