### PR TITLE
@W-7992418@ Allow negated category filtering

### DIFF
--- a/docs/_articles/en/scanner-commands/list.md
+++ b/docs/_articles/en/scanner-commands/list.md
@@ -44,5 +44,10 @@ If you specify multiple filters, they are combined with a logical AND. This exam
 $ sfdx scanner:rule:list --language apex,javascript --ruleset Braces,Security
 ```
 
+When you negate a category, the category is excluded. This example returns all rules except those in the Design or Best Practices categories. The values must be enclosed in single quotes.
+```bash
+$ sfdx scanner:rule:list --category '!Design,!Best Practices'
+```
+
 ## Demo
 ![List Example](./assets/images/list.gif) 

--- a/docs/_articles/en/scanner-commands/run.md
+++ b/docs/_articles/en/scanner-commands/run.md
@@ -44,18 +44,23 @@ This example evaluates all rules against ```somefile.js```.
 $ sfdx scanner:run --format xml --target "somefile.js"
 ```
 
-When you specify multiple categories or rulesets, the results are combined with a logical OR. This example evaluates all rules in the Design and Best Practices categories and all rules in the Braces ruleset.
+When you specify multiple categories, the categories are combined with a logical OR. This example evaluates all rules in the Design or Best Practices categories.
 ```bash
-$ sfdx scanner:run --format xml --target "somefile.js" --category "Design,Best Practices" --ruleset "Braces"
-```       
+$ sfdx scanner:run --format xml --target "somefile.js" --category "Design,Best Practices"
+```
+
+When you negate a category, the category is excluded. This example evaluates all rules except those in the Design or Best Practices categories. The values must be enclosed in single quotes.
+```bash
+$ sfdx scanner:run --format xml --target "somefile.js" --category '!Design,!Best Practices'
+```
 
 Wrap globs in quotes.  This example evaluates rules against all ```*.js``` files in the current directory, except for ```IgnoreMe.js```.
 
 Unix example:
-```bash    
+```bash
 $ sfdx scanner:run --target './**/*.js,!./**/IgnoreMe.js' ...
 ````
-Windows example: 
+Windows example:
 ```DOS
 > sfdx scanner:run --target ".\**\*.js,!.\**\IgnoreMe.js" ...
 ```
@@ -93,6 +98,4 @@ $ sfdx scanner:run --target "src" --eslintconfig "/home/my/setup/.eslintrc.json"
 ```
 
 ## Demo
-![Run Example](./assets/images/run.gif) 
-
-
+![Run Example](./assets/images/run.gif)

--- a/messages/Exceptions.js
+++ b/messages/Exceptions.js
@@ -1,0 +1,6 @@
+module.exports = {
+	"RuleFilter" : {
+		"PositiveOnly": "Illegal %s filter. This filter does not support exclusion",
+		"MixedTypes": "Illegal %s filter. Inclusive and exclusive values cannot be combined",
+	}
+}

--- a/messages/list.js
+++ b/messages/list.js
@@ -32,6 +32,10 @@ The values supplied to a single filter are handled with a logical OR.
 	E.g., $ sfdx scanner:rule:list --language apex,javascript
 		Returns all rules for Apex OR Javascript.
 
+Categories can be excluded by specifying the negation operator, the values must be enclosed in single quotes.
+	E.g., $ sfdx scanner:rule:list --category '!Design,!Best Practices'
+		Returns all rules except those in the Design or Best Practices categories.
+
 Different filters are combined with a logical AND.
 	E.g., $ sfdx scanner:rule:list --language apex,javascript --ruleset Braces,Security
 		Returns all rules that:

--- a/messages/run.js
+++ b/messages/run.js
@@ -30,7 +30,6 @@ module.exports = {
 		'pmdConfigDescriptionLong': 'Location of PMD rule reference XML file to customize rule selection'
 	},
 	"validations": {
-		"mustTargetSomething": "Please specify a codebase using --target.", // TODO: Once --org is implemented, rewrite this message.
 		"outfileFormatMismatch": "Your chosen format %s does not appear to match your output file type of %s.",
 		"outfileMustBeValid": "--outfile must be a well-formed filepath.",
 		"outfileMustBeSupportedType": "--outfile must be of a supported type. Current options are .xml and .csv.",
@@ -49,9 +48,13 @@ module.exports = {
 	E.g., $ sfdx scanner:run --format xml --target "somefile.js"
 		Evaluates all rules against somefile.js.
 
-	Specifying multiple categories or rulesets is treated as a logical OR.
-		E.g., $ sfdx scanner:run --format xml --target "somefile.js" --category "Design,Best Practices" --ruleset "Braces"
-			Evaluates all rules in the Design and Best Practices categories, and all rules in the Braces ruleset.
+	Specifying multiple categories is treated as a logical OR.
+		E.g., $ sfdx scanner:run --format xml --target "somefile.js" --category "Design,Best Practices"
+			Evaluates all rules in the Design or Best Practices categories.
+
+	Categories can be excluded by specifying the negation operator, the values must be enclosed in single quotes.
+		E.g., $ sfdx scanner:run --format xml --target "somefile.js" --category '!Design,!Best Practices'
+			Evaluates all rules except those in the Design or Best Practices categories.
 
 	Wrap globs in quotes.
 		Unix example:    $ sfdx scanner:run --target './**/*.js,!./**/IgnoreMe.js' ...

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -38,10 +38,10 @@ export const EngineBase = {
  * These are the filter values that Users can filter by when using
  * --engine flag
  */
-export const AllowedEngineFilters = [ 
-	ENGINE.ESLINT, 
-	ENGINE.ESLINT_LWC, 
-	ENGINE.ESLINT_TYPESCRIPT, 
+export const AllowedEngineFilters = [
+	ENGINE.ESLINT,
+	ENGINE.ESLINT_LWC,
+	ENGINE.ESLINT_TYPESCRIPT,
 	ENGINE.PMD,
 	ENGINE.RETIRE_JS
 ]
@@ -52,7 +52,8 @@ export enum LANGUAGE {
 	JAVA = 'java',
 	JAVASCRIPT = 'javascript',
 	PLSQL = 'plsql',
-	TYPESCRIPT = 'typescript'
+	TYPESCRIPT = 'typescript',
+	VISUALFORCE = 'vf'
 }
 
 export const Services = {

--- a/src/commands/scanner/rule/remove.ts
+++ b/src/commands/scanner/rule/remove.ts
@@ -2,7 +2,7 @@ import {flags} from '@salesforce/command';
 import {Messages, SfdxError} from '@salesforce/core';
 import {AnyJson} from '@salesforce/ts-types';
 import {Controller} from '../../../Controller';
-import {FilterType, RuleFilter} from '../../../lib/RuleFilter';
+import {RuleFilter, SourcePackageFilter} from '../../../lib/RuleFilter';
 import {ScannerCommand} from '../../../lib/ScannerCommand';
 import {Rule} from '../../../types';
 import path = require('path');
@@ -80,7 +80,7 @@ export default class Remove extends ScannerCommand {
 		if (!this.flags.force) {
 			// Step 6a: We'll want to create filter criteria.
 			const filters: RuleFilter[] = [];
-			filters.push(new RuleFilter(FilterType.SOURCEPACKAGE, deletablePaths));
+			filters.push(new SourcePackageFilter(deletablePaths));
 
 			// Step 6b: We'll want to retrieve the matching rules.
 			const rm = await Controller.createRuleManager();

--- a/src/lib/DefaultRuleManager.ts
+++ b/src/lib/DefaultRuleManager.ts
@@ -3,7 +3,7 @@ import * as assert from 'assert';
 import {Stats} from 'fs';
 import {inject, injectable} from 'tsyringe';
 import {RecombinedRuleResults, Rule, RuleGroup, RuleResult, RuleTarget} from '../types';
-import {FilterType, RuleFilter} from './RuleFilter';
+import {isEngineFilter, RuleFilter} from './RuleFilter';
 import {OUTPUT_FORMAT, RuleManager} from './RuleManager';
 import {RuleResultRecombinator} from './RuleResultRecombinator';
 import {RuleCatalog} from './services/RuleCatalog';
@@ -78,7 +78,7 @@ export class DefaultRuleManager implements RuleManager {
 			const engineRules = rules.filter(r => r.engine === e.getName());
 			const engineTargets = await this.unpackTargets(e, targets, matchedTargets);
 			this.logger.trace(`For ${e.getName()}, found ${engineGroups.length} groups, ${engineRules.length} rules, ${engineTargets.length} targets`);
-			
+
 			if (e.shouldEngineRun(engineGroups, engineRules, engineTargets, engineOptions)) {
 				this.logger.trace(`${e.getName()} is eligible to execute.`);
 				ps.push(e.run(engineGroups, engineRules, engineTargets, engineOptions));
@@ -112,8 +112,8 @@ export class DefaultRuleManager implements RuleManager {
 	protected async resolveEngineFilters(filters: RuleFilter[], engineOptions: Map<string,string> = new Map()): Promise<RuleEngine[]> {
 		let filteredEngineNames: readonly string[] = null;
 		for (const filter of filters) {
-			if (filter.filterType === FilterType.ENGINE) {
-				filteredEngineNames = filter.filterValues;
+			if (isEngineFilter(filter)) {
+				filteredEngineNames = filter.getEngines();
 				break;
 			}
 		}

--- a/src/lib/RuleFilter.ts
+++ b/src/lib/RuleFilter.ts
@@ -102,7 +102,7 @@ export abstract class RuleFilter {
 		return (!this.filterValues || this.filterValues.length === 0);
 	}
 
-	protected static mapFilterValues(filterValues: string[]): {positive: string[]; negative: string[]} {
+	protected static processForPosAndNegFilterValues(filterValues: string[]): {positive: string[]; negative: string[]} {
 		filterValues = filterValues.map(v => v.trim());
 		const positive = filterValues.filter(v => !v.startsWith(NEGATION_CHAR));
 		const negative = filterValues.filter(v => v.startsWith(NEGATION_CHAR)).map(v => v.substr(1));
@@ -115,7 +115,7 @@ export abstract class RuleFilter {
  */
 abstract class PositiveRuleFilter extends RuleFilter {
     constructor(filterDisplayName: FilterDisplayName, filterValues: string[]) {
-		const mapped = RuleFilter.mapFilterValues(filterValues);
+		const mapped = RuleFilter.processForPosAndNegFilterValues(filterValues);
 		if (mapped.negative.length > 0) {
 			throw SfdxError.create('@salesforce/sfdx-scanner', 'Exceptions', 'RuleFilter.PositiveOnly', [filterDisplayName]);
 		}
@@ -128,7 +128,7 @@ abstract class PositiveRuleFilter extends RuleFilter {
  */
 abstract class NegateableRuleFilter extends RuleFilter {
     constructor(filterDisplayName: FilterDisplayName, filterValues: string[]) {
-		const mapped = RuleFilter.mapFilterValues(filterValues);
+		const mapped = RuleFilter.processForPosAndNegFilterValues(filterValues);
 
 		// Throw an exception if there are mixed types
 		if (mapped.positive.length > 0 && mapped.negative.length > 0) {

--- a/src/lib/RuleFilter.ts
+++ b/src/lib/RuleFilter.ts
@@ -1,18 +1,216 @@
-export enum FilterType {
-	RULENAME,
-	CATEGORY,
-	RULESET,
-	LANGUAGE,
-	SOURCEPACKAGE,
-	ENGINE
+import { SfdxError } from '@salesforce/core';
+import { Catalog, Rule, RuleGroup } from '../types';
+
+/**
+ * Filter values preceded by this character are negated
+ */
+const NEGATION_CHAR = '!';
+
+/**
+ * Human readable string for this filter type. Programmatic use of this value is discouraged.
+ */
+enum FilterDisplayName {
+	CATEGORY = 'Category',
+	ENGINE = 'Engine',
+	LANGUAGE = 'Language',
+	RULENAME = 'Rule Name',
+	RULESET = 'Ruleset',
+	SOURCEPACKAGE = 'Source Package'
 }
 
-export class RuleFilter {
-    readonly filterType: FilterType;
-    readonly filterValues: ReadonlyArray<string>;
+/**
+ * Represents a filter that operates on RuleGroups
+ */
+export interface RuleGroupFilter {
+	/**
+	 * Return the RuleGroup array that is relevant to this filter from the catalog
+	 */
+	getRuleGroups(catalog: Catalog): RuleGroup[];
+}
 
-    constructor(filterType: FilterType, filterValues: string[]) {
-        this.filterType = filterType;
-        this.filterValues = filterValues.map(v => v.trim());
-    }
+/**
+ * Represents a filter that operates on Engines
+ */
+export interface EngineFilterInterface {
+	/**
+	 * Return the RuleGroup array that is relevant to this filter from the catalog
+	 */
+	getEngines(): readonly string[];
+}
+
+/**
+ * Return true if object implements the RuleGroupFilter interface
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function isRuleGroupFilter(object: any): object is RuleGroupFilter {
+    return 'getRuleGroups' in object;
+}
+
+/**
+ * Return true if object implements the EngineFilterInterface interface
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function isEngineFilter(object: any): object is EngineFilterInterface {
+    return 'getEngines' in object;
+}
+
+export abstract class RuleFilter {
+	protected readonly filterValues: ReadonlyArray<string>;
+	private readonly negated: boolean;
+
+	protected constructor(filterValues: string[], negated: boolean) {
+		this.filterValues = filterValues;
+		this.negated = negated;
+	}
+
+	public matchesRuleGroup(ruleGroup: RuleGroup): boolean {
+		if (this.isEmpty()) {
+			return true;
+		}
+
+		const includes = this.filterValues.includes(ruleGroup.name);
+		return this.negated ? !includes : includes;
+	}
+
+	public matchesRule(rule: Rule): boolean {
+		if (this.isEmpty()) {
+			return true;
+		}
+
+		// Positive filtering a rule includes those rules that aren't enabled by default
+		// This ensures that negative filtering doesn't include default disabled rules
+		if (this.negated && !rule.defaultEnabled) {
+			return false;
+		}
+
+		const ruleValues = this.getRuleValues(rule);
+		const includes = this.filterValues.some(v => ruleValues.includes(v));
+		return this.negated ? !includes : includes;
+	}
+
+	public prettyPrint(): string {
+		return `RuleFilter[filterType=${this.constructor.name}, filterValues=${this.filterValues}, negated=${this.negated}]`;
+	}
+
+	/**
+	 * Extract rule values relevant to this filter and return as a string array.
+	 * Single values should be returned as a one length array.
+	 */
+	protected abstract getRuleValues(rule: Rule): string[];
+
+	private isEmpty(): boolean {
+		return (!this.filterValues || this.filterValues.length === 0);
+	}
+
+	protected static mapFilterValues(filterValues: string[]): {positive: string[]; negative: string[]} {
+		filterValues = filterValues.map(v => v.trim());
+		const positive = filterValues.filter(v => !v.startsWith(NEGATION_CHAR));
+		const negative = filterValues.filter(v => v.startsWith(NEGATION_CHAR)).map(v => v.substr(1));
+		return {positive: positive, negative: negative};
+	}
+}
+
+/**
+ * This class will throw an exception if any of the filter values are negated
+ */
+abstract class PositiveRuleFilter extends RuleFilter {
+    constructor(filterDisplayName: FilterDisplayName, filterValues: string[]) {
+		const mapped = RuleFilter.mapFilterValues(filterValues);
+		if (mapped.negative.length > 0) {
+			throw SfdxError.create('@salesforce/sfdx-scanner', 'Exceptions', 'RuleFilter.PositiveOnly', [filterDisplayName]);
+		}
+		super(mapped.positive, false);
+	}
+}
+
+/**
+ * This class will parse filter values for positive and negative filters. Mixed types will throw an exception.
+ */
+abstract class NegateableRuleFilter extends RuleFilter {
+    constructor(filterDisplayName: FilterDisplayName, filterValues: string[]) {
+		const mapped = RuleFilter.mapFilterValues(filterValues);
+
+		// Throw an exception if there are mixed types
+		if (mapped.positive.length > 0 && mapped.negative.length > 0) {
+			throw SfdxError.create('@salesforce/sfdx-scanner', 'Exceptions', 'RuleFilter.MixedTypes', [filterDisplayName]);
+		}
+
+		const negated = mapped.negative.length > 0;
+		super(negated ? mapped.negative : mapped.positive, negated);
+	}
+}
+
+export class EngineFilter extends PositiveRuleFilter implements EngineFilterInterface {
+    constructor(filterValues: string[]) {
+		super(FilterDisplayName.ENGINE, filterValues);
+	}
+
+	protected getRuleValues(rule: Rule): string[] {
+		// Rules have one engine, so we'll turn it into a singleton list
+		return [rule.engine];
+	}
+
+	public getEngines(): readonly string[] {
+		return this.filterValues;
+	}
+}
+
+export class LanguageFilter extends PositiveRuleFilter {
+    constructor(filterValues: string[]) {
+		super(FilterDisplayName.LANGUAGE, filterValues);
+	}
+
+	protected getRuleValues(rule: Rule): string[] {
+		return rule.languages;
+	}
+}
+
+export class RulenameFilter extends PositiveRuleFilter {
+    constructor(filterValues: string[]) {
+		super(FilterDisplayName.RULENAME, filterValues);
+	}
+
+	protected getRuleValues(rule: Rule): string[] {
+		// Rules have one name, so we'll turn it into a singleton list
+		return [rule.name];
+	}
+}
+
+export class RulesetFilter extends PositiveRuleFilter implements RuleGroupFilter {
+    constructor(filterValues: string[]) {
+		super(FilterDisplayName.RULESET, filterValues);
+	}
+
+	protected getRuleValues(rule: Rule): string[] {
+		return rule.rulesets;
+	}
+
+	public getRuleGroups(catalog: Catalog): RuleGroup[] {
+		return catalog.rulesets;
+	}
+}
+
+export class SourcePackageFilter extends PositiveRuleFilter {
+    constructor(filterValues: string[]) {
+		super(FilterDisplayName.SOURCEPACKAGE, filterValues);
+	}
+
+	protected getRuleValues(rule: Rule): string[] {
+		// Rules have one sourcepackage, so we'll turn it into a singleton list
+		return [rule.sourcepackage];
+	}
+}
+
+export class CategoryFilter extends NegateableRuleFilter implements RuleGroupFilter {
+	constructor(filterValues: string[]) {
+		super(FilterDisplayName.CATEGORY, filterValues);
+	}
+
+	protected getRuleValues(rule: Rule): string[] {
+		return rule.categories;
+	}
+
+	public getRuleGroups(catalog: Catalog): RuleGroup[] {
+		return catalog.categories;
+	}
 }

--- a/src/lib/ScannerCommand.ts
+++ b/src/lib/ScannerCommand.ts
@@ -1,5 +1,5 @@
 import {SfdxCommand} from '@salesforce/command';
-import {FilterType, RuleFilter} from './RuleFilter';
+import {CategoryFilter, LanguageFilter, RuleFilter, RulesetFilter, RulenameFilter, EngineFilter} from './RuleFilter';
 import {uxEvents} from './ScannerEvents';
 
 export abstract class ScannerCommand extends SfdxCommand {
@@ -8,28 +8,28 @@ export abstract class ScannerCommand extends SfdxCommand {
 		const filters: RuleFilter[] = [];
 		// Create a filter for any provided categories.
 		if (this.flags.category && this.flags.category.length) {
-			filters.push(new RuleFilter(FilterType.CATEGORY, this.flags.category));
+			filters.push(new CategoryFilter(this.flags.category));
 		}
 
 		// Create a filter for any provided rulesets.
 		if (this.flags.ruleset && this.flags.ruleset.length) {
-			filters.push(new RuleFilter(FilterType.RULESET, this.flags.ruleset));
+			filters.push(new RulesetFilter(this.flags.ruleset));
 		}
 
 		// Create a filter for any provided languages.
 		if (this.flags.language && this.flags.language.length) {
-			filters.push(new RuleFilter(FilterType.LANGUAGE, this.flags.language));
+			filters.push(new LanguageFilter(this.flags.language));
 		}
 
 		// Create a filter for provided rule names.
 		// NOTE: Only a single rule name can be provided. It will be treated as a singleton list.
 		if (this.flags.rulename) {
-			filters.push(new RuleFilter(FilterType.RULENAME, [this.flags.rulename]));
+			filters.push(new RulenameFilter([this.flags.rulename]));
 		}
 
 		// Create a filter for any provided engines.
 		if (this.flags.engine && this.flags.engine.length) {
-			filters.push(new RuleFilter(FilterType.ENGINE, this.flags.engine));
+			filters.push(new EngineFilter(this.flags.engine));
 		}
 
 		return filters;

--- a/src/lib/services/LocalCatalog.ts
+++ b/src/lib/services/LocalCatalog.ts
@@ -4,7 +4,7 @@ import {injectable} from 'tsyringe';
 import {CATALOG_FILE} from '../../Constants';
 import {Catalog, Rule, RuleEvent, RuleGroup} from '../../types';
 import {OutputProcessor} from '../pmd/OutputProcessor';
-import {FilterType, RuleFilter} from '../RuleFilter';
+import {isRuleGroupFilter, RuleFilter} from '../RuleFilter';
 import {FileHandler} from '../util/FileHandler';
 import * as PrettyPrinter from '../util/PrettyPrinter';
 import {RuleCatalog} from './RuleCatalog';
@@ -52,24 +52,23 @@ export default class LocalCatalog implements RuleCatalog {
 		}
 		// If we actually do have filters, we'll want to iterate over all of them and see which ones
 		// correspond to a path in the catalog.
-		// Since categories and rulesets are both just NamedPaths, we can put both types of
+		// Since categories and rulesets are both just RuleGroups, we can put both types of
 		// path into a single array and return that.
-		const foundPaths: RuleGroup[] = [];
+		const foundRuleGroups: RuleGroup[] = [];
 		for (const filter of filters) {
 			// For now, we only care about filters that act on rulesets and categories.
-			const type = filter.filterType;
-			if (type === FilterType.CATEGORY || type === FilterType.RULESET) {
+			if (isRuleGroupFilter(filter)) {
 				// We only want to evaluate category filters against category names, and ruleset filters against ruleset names.
-				const namedPaths: RuleGroup[] = type === FilterType.CATEGORY ? this.catalog.categories : this.catalog.rulesets;
-				for (const value of filter.filterValues) {
-					// If there's a matching category/ruleset for the specified filter, we'll need to add all the
-					// corresponding paths to our list.
-					const np = namedPaths.filter(np => np.name === value);
-					foundPaths.push(...np);
-				}
+				const ruleGroups: RuleGroup[] = filter.getRuleGroups(this.catalog);
+
+				// If there's a matching category/ruleset for the specified filter, we'll need to add all the
+				// corresponding paths to our list.
+				const filteredRuleGroups = ruleGroups.filter(rg => filter.matchesRuleGroup(rg));
+				foundRuleGroups.push(...filteredRuleGroups);
 			}
 		}
-		return foundPaths;
+
+		return foundRuleGroups;
 	}
 
 	getRulesMatchingFilters(filters: RuleFilter[]): Rule[] {
@@ -171,48 +170,12 @@ export default class LocalCatalog implements RuleCatalog {
 
 		// Otherwise, we'll iterate over all provided criteria and make sure that the rule satisfies them.
 		for (const filter of filters) {
-			const filterType = filter.filterType;
-			const filterValues = filter.filterValues;
-
-			// Which property of the rule we're testing against depends on this filter's type.
-			let ruleValues = null;
-			switch (filterType) {
-				case FilterType.CATEGORY:
-					ruleValues = rule.categories;
-					break;
-				case FilterType.RULESET:
-					ruleValues = rule.rulesets;
-					break;
-				case FilterType.LANGUAGE:
-					ruleValues = rule.languages;
-					break;
-				case FilterType.RULENAME:
-					// Rules only have one name, so we'll just turn that name into a singleton list so we can compare names the
-					// same way we compare everything else.
-					ruleValues = [rule.name];
-					break;
-				case FilterType.SOURCEPACKAGE:
-					// Rules have one source package, so we'll turn it into a singleton list just like we do with 'name'.
-					ruleValues = [rule.sourcepackage];
-					break;
-				case FilterType.ENGINE:
-					// Rules have one engine, so we'll turn it into a singleton list just like we do with 'name'.
-					ruleValues = [rule.engine];
-					break;
-			}
-
-			// For each filter, one of the values it specifies as acceptable must be present in the rule's corresponding list.
-			// e.g., if the user specified one or more categories, the rule must be a member of at least one of those categories.
-			if (filterValues.length > 0 && !this.listContentsOverlap(filterValues, ruleValues)) {
+			if (!filter.matchesRule(rule)) {
 				return false;
 			}
 		}
 		// If we're at this point, it's because we looped through all of the filter criteria without finding a single one that
 		// wasn't satisfied, which means the rule is good.
 		return true;
-	}
-
-	private listContentsOverlap<T>(list1: ReadonlyArray<T>, list2: T[]): boolean {
-		return list1.some(x => list2.includes(x));
 	}
 }

--- a/src/lib/util/PrettyPrinter.ts
+++ b/src/lib/util/PrettyPrinter.ts
@@ -37,7 +37,7 @@ export function stringifyMapOfMaps(mapOfMap: Map<string, Map<string, Set<string>
  * @param filter RuleFilter to stringify
  */
 export function stringifyRuleFilter(filter: RuleFilter): string {
-	return `RuleFilter[filterType=${filter.filterType}, filterValues=${filter.filterValues}]`;
+	return filter.prettyPrint();
 }
 
 /**

--- a/test/TestUtils.ts
+++ b/test/TestUtils.ts
@@ -1,5 +1,38 @@
-import {test} from '@salesforce/command/lib/test';
+import fs = require('fs');
+import path = require('path');
+import { test } from '@salesforce/command/lib/test';
 import * as TestOverrides from './test-related-lib/TestOverrides';
+import Sinon = require('sinon');
+import LocalCatalog from '../src/lib/services/LocalCatalog';
+
+
+const CATALOG_FIXTURE_PATH = path.join('test', 'catalog-fixtures', 'DefaultCatalogFixture.json');
+export const CATALOG_FIXTURE_RULE_COUNT = 15;
+export const CATALOG_FIXTURE_DEFAULT_ENABLED_RULE_COUNT = 11;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function prettyPrint(obj: any): string {
+	return JSON.stringify(obj, null, 2);
+}
+
+export function stubCatalogFixture(): void {
+	// Make sure all catalogs exist where they're supposed to.
+	if (!fs.existsSync(CATALOG_FIXTURE_PATH)) {
+		throw new Error('Fake catalog does not exist');
+	}
+
+	// Make sure all catalogs have the expected number of rules.
+	const catalogJson = JSON.parse(fs.readFileSync(CATALOG_FIXTURE_PATH).toString());
+	if (catalogJson.rules.length !== CATALOG_FIXTURE_RULE_COUNT) {
+		throw new Error('Fake catalog has ' + catalogJson.rules.length + ' rules instead of ' + CATALOG_FIXTURE_RULE_COUNT);
+	}
+
+	// Stub out the LocalCatalog's getCatalog method so it always returns the fake catalog, whose contents are known,
+	// and never overwrites the real catalog. (Or we could use the IOC container to do this without sinon.)
+	Sinon.stub(LocalCatalog.prototype, 'getCatalog').callsFake(async () => {
+		return JSON.parse(fs.readFileSync(CATALOG_FIXTURE_PATH).toString());
+	});
+}
 
 /**
  * Initial setup needed by all oclif command unit tests.
@@ -11,9 +44,8 @@ import * as TestOverrides from './test-related-lib/TestOverrides';
  * 		expect(ctx.stdout).to.contain('No rule violations found.');
  * 	});
  */
-const setupCommandTest = test
+export const setupCommandTest = test
 	.do(() => TestOverrides.initializeTestSetup())
 	.stdout()
 	.stderr();
 
-export { setupCommandTest };

--- a/test/catalog-fixtures/DefaultCatalogFixture.json
+++ b/test/catalog-fixtures/DefaultCatalogFixture.json
@@ -66,10 +66,10 @@
 		},
 		{
 			"paths": [
-				"rulesets/ecmascript/braces.xml",
-				"rulesets/apex/braces.xml"
+				"rulesets/apex/security.xml",
+				"rulesets/vf/security.xml"
 			],
-			"name": "Braces",
+			"name": "Security",
 			"engine": "pmd"
 		}
 	],

--- a/test/commands/scanner/rule/list.test.ts
+++ b/test/commands/scanner/rule/list.test.ts
@@ -31,7 +31,7 @@ function listContentsOverlap<T>(list1: T[], list2: T[]): boolean {
  *
  * @return the number of rules returned
  */
-async function getRulesFilteredByCategoryCount (includeDefaultDisabled: boolean, includedCategories: string[]=undefined, excludeCategories: string[]=undefined): Promise<number> {
+async function getRulesFilteredByCategoryCount(includeDefaultDisabled: boolean, includedCategories: string[]=undefined, excludeCategories: string[]=undefined): Promise<number> {
 	const catalog = getCatalogJson();
 	const enabledEngineNames = (await Controller.getEnabledEngines()).map(e => e.getName());
 	let rules: Rule[] = catalog.rules.filter(r => (includeDefaultDisabled || r.defaultEnabled) && enabledEngineNames.includes(r.engine));

--- a/test/commands/scanner/rule/list.test.ts
+++ b/test/commands/scanner/rule/list.test.ts
@@ -21,6 +21,30 @@ function listContentsOverlap<T>(list1: T[], list2: T[]): boolean {
 	return list1.some(x => list2.includes(x));
 }
 
+/**
+ * Rather than painstakingly check all of the rules, we'll just make sure that we got the right number of rules,
+ * compared to the number of rules in the catalog. This method filters the catalogs rules.
+ *
+ * @param includeDefaultDisabled - if true, include rule when Rule.defaultEnabled is false. if false, include rule when Rule.defaultEnabled is true
+ * @param includedCategories - include rule if any of its categories overlaps with this array
+ * @param excludeCategories- exclude rule if any of its categories overlaps with this array
+ *
+ * @return the number of rules returned
+ */
+async function getRulesFilteredByCategoryCount (includeDefaultDisabled: boolean, includedCategories: string[]=undefined, excludeCategories: string[]=undefined): Promise<number> {
+	const catalog = getCatalogJson();
+	const enabledEngineNames = (await Controller.getEnabledEngines()).map(e => e.getName());
+	let rules: Rule[] = catalog.rules.filter(r => (includeDefaultDisabled || r.defaultEnabled) && enabledEngineNames.includes(r.engine));
+	if (includedCategories?.length > 0) {
+		rules = rules.filter((r: Rule) => includedCategories.some(c => r.categories.includes(c)));
+	}
+	if (excludeCategories?.length > 0) {
+		rules = rules.filter((r: Rule) => !excludeCategories.some(c => r.categories.includes(c)));
+	}
+	expect(rules.length).to.be.above(0, 'Expected rule count cannot be zero. Test invalid');
+	return rules.length;
+}
+
 describe('scanner:rule:list', () => {
 
 	describe('E2E', () => {
@@ -28,82 +52,94 @@ describe('scanner:rule:list', () => {
 			setupCommandTest
 				.command(['scanner:rule:list'])
 				.it('All rules for enabled engines are returned', async ctx => {
-					// Rather than painstakingly check all of the rules, we'll just make sure that we got the right number of rules,
-					// compared to the number of rules in the catalog.
-					const catalog = getCatalogJson();
-					const enabledEngines = (await Controller.getEnabledEngines()).map(e => e.getName());
-					const totalRuleCount = catalog.rules.filter(r => r.defaultEnabled && enabledEngines.includes(r.engine)).length;
+					const totalRuleCount = await getRulesFilteredByCategoryCount(false);
 
 					// Split the output table by newline and throw out the first two rows, since they just contain header information. That
 					// should leave us with the actual data.
 					const rows = ctx.stdout.trim().split('\n');
 					rows.shift();
 					rows.shift();
-					expect(rows, rows + '').to.have.lengthOf(totalRuleCount, 'All rules should have been returned');
+					expect(rows).to.have.lengthOf(totalRuleCount, 'All rules should have been returned');
 				});
 
 			setupCommandTest
 				.command(['scanner:rule:list', '--json'])
 				.it('--json flag yields expected JSON', async ctx => {
-					// Rather than painstakingly check all of the rules, we'll just make sure that we got the right number of rules,
-					// compared to the number of rules in the catalog.
-					const catalog = getCatalogJson();
-					const enabledEngines = (await Controller.getEnabledEngines()).map(e => e.getName());
-					const totalRuleCount = catalog.rules.filter(r => r.defaultEnabled && enabledEngines.includes(r.engine)).length;
+					const totalRuleCount = await getRulesFilteredByCategoryCount(false);
 
-					// Parse the output back into a JSON, then make sure it has the same number of rules as the catalog did.
+					// Parse the output back into a JSON, and make sure it has the right number of rules.
 					const outputJson = JSON.parse(ctx.stdout);
-
 					expect(outputJson.result).to.have.lengthOf(totalRuleCount, 'All rules should have been returned');
 				});
 		});
 
 		describe('Test Case: Filtering by category only', () => {
-			const filteredCategories = ['Best Practices', 'Design'];
+			const positiveCategories = ['Best Practices', 'Design'];
+			// Add a preceding '!' to each category
+			const negatedCategories = positiveCategories.map(c => `!${c}`);
+
 			setupCommandTest
-				.command(['scanner:rule:list', '--category', filteredCategories[0], '--json'])
+				.command(['scanner:rule:list', '--category', positiveCategories[0], '--json'])
 				.it('Filtering by one category returns only the rules in that category for enabled engines', async ctx => {
-					// Rather than painstakingly checking everything about all the rules, we'll just make sure that the number of rules
-					// returned is the same as the number of rules in the target category, and that every rule returned is actually
-					// a member of that category.
-					// The first step is to identify how many satisfactory rules are in the catalog.
-					const catalog = getCatalogJson();
-					const enabledEngines = (await Controller.getEnabledEngines()).map(e => e.getName());
-					const filterFunction: (Rule) => boolean = (r: Rule) => r.categories.includes(filteredCategories[0]) && enabledEngines.includes(r.engine);
-					const targetRuleCount = catalog.rules.filter(filterFunction).length;
-					expect(targetRuleCount).to.be.above(0, 'Expected rule count cannot be zero. Test invalid');
+					const targetRuleCount = await getRulesFilteredByCategoryCount(true, [positiveCategories[0]]);
 
-
-					// Then, we parse the output back into a JSON, make sure it has the right number of rules, and make sure that each
-					// rule is the right type.
+					// Parse the output back into a JSON, and make sure it has the right number of rules.
 					const outputJson = JSON.parse(ctx.stdout);
-
 					expect(outputJson.result).to.have.lengthOf(targetRuleCount, 'All rules in the specified category should have been returned');
+
+					// Make sure that each rule overlaps with the expected categories
 					outputJson.result.forEach((rule: Rule) => {
-						expect(rule.categories).to.contain(filteredCategories[0], `Rule ${rule.name} was included despite being in the wrong category`);
+						expect(rule.categories).to.contain(positiveCategories[0], `Rule ${rule.name} was included despite being in the wrong category`);
 					});
 				});
 
 			setupCommandTest
-				.command(['scanner:rule:list', '--category', filteredCategories.join(','), '--json'])
+				.command(['scanner:rule:list', '--category', positiveCategories.join(','), '--json'])
 				.it('Filtering by multiple categories returns any rule in either category', async ctx => {
-					// Count how many rules in the catalog fit the criteria.
-					const catalog = getCatalogJson();
-					const enabledEngines = (await Controller.getEnabledEngines()).map(e => e.getName());
-					const filterFunction: (Rule) => boolean =
-						(r: Rule) => listContentsOverlap(r.categories, filteredCategories) && enabledEngines.includes(r.engine);
-					const targetRuleCount = catalog.rules.filter(filterFunction).length;
-					expect(targetRuleCount).to.be.above(0, 'Expected rule count cannot be zero. Test invalid');
+					const targetRuleCount = await getRulesFilteredByCategoryCount(true, positiveCategories);
 
 					// Parse the output back into a JSON, and make sure it has the right number of rules.
 					const outputJson = JSON.parse(ctx.stdout);
 					expect(outputJson.result).to.have.lengthOf(targetRuleCount, 'All rules in either category should be returned');
-					// Make sure that only rules in the right categories were returned.
+
+					// Make sure that each rule overlaps with the expected categories
 					outputJson.result.forEach((rule: Rule) => {
 						expect(rule).to.satisfy((rule) => {
-								return listContentsOverlap(rule.categories, filteredCategories)
+								return listContentsOverlap(rule.categories, positiveCategories)
 							},
 							`Rule ${rule.name} was included despite being in the wrong category`
+						);
+					});
+			});
+
+			setupCommandTest
+				.command(['scanner:rule:list', '--category', negatedCategories[0], '--json'])
+				.it('Excluding by one category excludes all rules from that category', async ctx => {
+					const targetRuleCount = await getRulesFilteredByCategoryCount(false, [], [positiveCategories[0]]);
+
+					// Parse the output back into a JSON, and make sure it has the right number of rules.
+					const outputJson = JSON.parse(ctx.stdout);
+					expect(outputJson.result).to.have.lengthOf(targetRuleCount, 'All rules in the specified category should have been returned');
+
+					// Ensure that all of the returned rules have excluded the single category
+					outputJson.result.forEach((rule: Rule) => {
+						expect(rule.categories).to.not.contain(positiveCategories[0], `Rule ${rule.name} with categories ${rule.categories} was included despite being in the wrong category`);
+					});
+				});
+
+			setupCommandTest
+				.command(['scanner:rule:list', '--category', negatedCategories.join(','), '--json'])
+				.it('Excluding by multiple categories excludes all rules from those categories', async ctx => {
+					const targetRuleCount = await getRulesFilteredByCategoryCount(false, [], positiveCategories);
+
+					// Parse the output back into a JSON, and make sure it has the right number of rules.
+					const outputJson = JSON.parse(ctx.stdout);
+					expect(outputJson.result).to.have.lengthOf(targetRuleCount, 'All rules in the specified category should have been returned');
+
+					// Ensure that all of the returned rules have excluded both categories
+					outputJson.result.forEach((rule: Rule) => {
+						expect(rule).to.satisfy((rule) => { return !positiveCategories.some(c => rule.categories.includes(c)) },
+							`Rule ${rule.name} with categories ${rule.categories} was included despite being in the wrong category`
 						);
 					});
 				});

--- a/test/commands/scanner/run.filters.test.ts
+++ b/test/commands/scanner/run.filters.test.ts
@@ -1,0 +1,207 @@
+import {expect} from '@salesforce/command/lib/test';
+import {setupCommandTest} from '../../TestUtils';
+import {Messages} from '@salesforce/core';
+import path = require('path');
+import * as TestUtils from '../../TestUtils';
+
+Messages.importMessagesDirectory(__dirname);
+const exceptionMessages = Messages.loadMessages('@salesforce/sfdx-scanner', 'Exceptions');
+
+/**
+ * IMPORTANT. The oclif CLI test framework requires the .it to come after the .command
+ */
+describe('scanner:run tests that result in the use of RuleFilters', function () {
+	describe('--engine flag', () => {
+		setupCommandTest
+			.command(['scanner:run',
+				'--target', path.join('test', 'code-fixtures', 'lwc'),
+				'--format', 'csv',
+				'--engine', 'eslint-lwc'
+			])
+			.it('LWC Engine Successfully parses LWC code', ctx => {
+				expect(ctx.stdout).to.contain('No rule violations found.');
+			});
+
+		setupCommandTest
+			.command(['scanner:run',
+				'--target', path.join('test', 'code-fixtures', 'invalid-lwc'),
+				'--format', 'json',
+				'--engine', 'eslint-lwc'
+			])
+			.it('LWC Engine detects LWC errors', ctx => {
+				const results = JSON.parse(ctx.stdout);
+				expect(results, `results does not have expected length. ${results.map(r => r.fileName).join(',')}`)
+					.to.be.an('Array').that.has.length(1);
+				const messages = results[0].violations.map(v => v.message);
+				const expectedMessages = ['Invalid public property initialization for "foo". Boolean public properties should not be initialized to "true", consider initializing the property to "false".',
+					`'Foo' is defined but never used.`];
+				for (const expectedMessage of expectedMessages) {
+					expect(messages).to.contain(expectedMessage);
+				}
+			});
+	});
+
+	describe('--category and --engine flag', () => {
+		describe('Eslint Javascript Engine --category flag', () => {
+			const category = 'Stylistic Issues';
+			setupCommandTest
+				.command(['scanner:run',
+					'--target', path.join('test', 'code-fixtures', 'projects', 'app', 'force-app', 'main', 'default', 'aura', 'dom_parser', 'dom_parserController.js'),
+					'--format', 'json',
+					'--engine', 'eslint',
+					'--category', category
+				])
+				.it('Only correct categories are returned', ctx => {
+					const output = JSON.parse(ctx.stdout);
+					expect(output.length).to.equal(1, 'Should only be violations from one file');
+					expect(output[0].engine).to.equal('eslint');
+					expect(output[0].violations, TestUtils.prettyPrint(output[0].violations)).to.be.lengthOf(55);
+
+					// Make sure only violations are returned for the requested category
+					for (const v of output[0].violations) {
+						expect(v.category, TestUtils.prettyPrint(v)).to.equal(category);
+					}
+				});
+		});
+
+		describe('Eslint LWC Engine --category flag', () => {
+			const category = 'Best Practices';
+			setupCommandTest
+				.command(['scanner:run',
+					'--target', path.join('test', 'code-fixtures', 'projects', 'app', 'force-app', 'main', 'default', 'aura', 'dom_parser', 'dom_parserController.js'),
+					'--format', 'json',
+					'--engine', 'eslint-lwc',
+					'--category', category
+				])
+				.it('Only correct categories are returned', ctx => {
+					const output = JSON.parse(ctx.stdout);
+					expect(output.length).to.equal(1, 'Should only be violations from one file');
+					expect(output[0].engine).to.equal('eslint-lwc');
+					expect(output[0].violations, TestUtils.prettyPrint(output[0].violations)).to.be.lengthOf(13);
+
+					// Make sure only violations are returned for the requested category
+					for (const v of output[0].violations) {
+						expect(v.category, TestUtils.prettyPrint(v)).to.equal(category);
+					}
+				});
+
+		});
+
+		describe('Eslint Typescript Engine --category flag', () => {
+			const category = 'Possible Errors';
+			setupCommandTest
+				.command(['scanner:run',
+					'--target', path.join('test', 'code-fixtures', 'projects', 'ts', 'src', 'simpleYetWrong.ts'),
+					'--tsconfig', path.join('test', 'code-fixtures', 'projects', 'tsconfig.json'),
+					'--format', 'json',
+					'--engine', 'eslint-typescript',
+					'--category', category
+				])
+				.it('Only correct categories are returned', ctx => {
+					const output = JSON.parse(ctx.stdout);
+					expect(output.length).to.equal(1, 'Should only be violations from one file');
+					expect(output[0].engine).to.equal('eslint-typescript');
+					expect(output[0].violations, TestUtils.prettyPrint(output[0].violations)).to.be.lengthOf(2);
+
+					// Make sure only violations are returned for the requested category
+					for (const v of output[0].violations) {
+						expect(v.category, TestUtils.prettyPrint(v)).to.equal(category);
+					}
+				});
+		});
+
+		describe('PMD Engine --category flag', () => {
+			const category = 'Code Style';
+			setupCommandTest
+				.command(['scanner:run',
+					'--target', path.join('test', 'code-fixtures', 'apex'),
+					'--format', 'json',
+					'--engine', 'pmd',
+					'--category', category
+				])
+				.it('Only correct categories are returned', ctx => {
+					const output = JSON.parse(ctx.stdout);
+					expect(output.length).to.equal(1, 'Should only be violations from one file');
+					expect(output[0].engine).to.equal('pmd');
+					expect(output[0].violations, TestUtils.prettyPrint(output[0].violations)).to.be.lengthOf(2);
+
+					// Make sure only violations are returned for the requested category
+					for (const v of output[0].violations) {
+						expect(v.category, TestUtils.prettyPrint(v)).to.equal(category);
+					}
+				});
+		});
+	});
+
+	describe('Negated --category', () => {
+		describe('Single --category', () => {
+			const category = '!Code Style';
+			setupCommandTest
+				.command(['scanner:run',
+					'--target', path.join('test', 'code-fixtures', 'apex'),
+					'--format', 'json',
+					'--category', category
+				])
+				.it('Only correct categories are returned', ctx => {
+					const output = JSON.parse(ctx.stdout);
+					expect(output.length, TestUtils.prettyPrint(output)).to.equal(4);
+					for (const file of output) {
+						expect(file.engine).to.equal('pmd');
+						for (const violation of file.violations) {
+							expect(violation.category, TestUtils.prettyPrint(violation)).to.not.equal(category);
+						}
+					}
+				});
+		});
+
+		describe('Multiple --category', () => {
+			const category = '!Code Style,!Security';
+			const expectedCategories: Set<string> = new Set<string>();
+			expectedCategories.add('Code Style').add('Security');
+			setupCommandTest
+				.command(['scanner:run',
+					'--target', path.join('test', 'code-fixtures', 'apex'),
+					'--format', 'json',
+					'--category', category
+				])
+				.it('Only correct categories are returned', ctx => {
+					const output = JSON.parse(ctx.stdout);
+					expect(output.length, TestUtils.prettyPrint(output)).to.equal(4);
+					for (const file of output) {
+						expect(file.engine).to.equal('pmd');
+						for (const violation of file.violations) {
+							expect(expectedCategories.has(violation.category), TestUtils.prettyPrint(violation)).to.be.false;
+						}
+					}
+				});
+		});
+
+		describe('Invalid --category', () => {
+			// Positive and negative categories can't be mixed
+			const category = '!Code Style,Security';
+			setupCommandTest
+				.command(['scanner:run',
+					'--target', path.join('test', 'code-fixtures', 'apex'),
+					'--format', 'json',
+					'--category', category
+				])
+				.it('Positive and Negative Combinations throws an error', ctx => {
+					expect(ctx.stderr).to.contain(exceptionMessages.getMessage('RuleFilter.MixedTypes', ['Category']));
+				});
+		});
+
+		describe('Invalid --engine', () => {
+			// Ruleset doesn't support negation
+			const ruleset = '!some-value';
+			setupCommandTest
+				.command(['scanner:run',
+					'--target', path.join('test', 'code-fixtures', 'apex'),
+					'--format', 'json',
+					'--ruleset', ruleset
+				])
+				.it('Negative filters that are not supported throws an error', ctx => {
+					expect(ctx.stderr).to.contain(exceptionMessages.getMessage('RuleFilter.PositiveOnly', ['Ruleset']));
+				});
+		});
+	});
+});

--- a/test/commands/scanner/run.test.ts
+++ b/test/commands/scanner/run.test.ts
@@ -567,129 +567,9 @@ describe('scanner:run', function () {
 				});
 		});
 
-		describe('Eslint Javascript Engine --category flag', () => {
-			const category = 'Stylistic Issues';
-			setupCommandTest
-				.command(['scanner:run',
-					'--target', path.join('test', 'code-fixtures', 'projects', 'app', 'force-app', 'main', 'default', 'aura', 'dom_parser', 'dom_parserController.js'),
-					'--format', 'json',
-					'--engine', 'eslint',
-					'--category', category
-				])
-				.it('Only correct categories are returned', ctx => {
-					const output = JSON.parse(ctx.stdout);
-					expect(output.length).to.equal(1, 'Should only be violations from one engine');
-					expect(output[0].engine).to.equal('eslint');
-					expect(output[0].violations, JSON.stringify(output[0].violations)).to.be.lengthOf(55);
-
-					// Make sure only violations are returned for the requested category
-					for (const v of output[0].violations) {
-						expect(v.category, JSON.stringify(v)).to.equal(category);
-					}
-				});
-
-		});
-
-		describe('Eslint Javascript Engine --category flag', () => {
-			const category = 'Best Practices';
-			setupCommandTest
-				.command(['scanner:run',
-					'--target', path.join('test', 'code-fixtures', 'projects', 'app', 'force-app', 'main', 'default', 'aura', 'dom_parser', 'dom_parserController.js'),
-					'--format', 'json',
-					'--engine', 'eslint-lwc',
-					'--category', category
-				])
-				.it('Only correct categories are returned', ctx => {
-					const output = JSON.parse(ctx.stdout);
-					expect(output.length).to.equal(1, 'Should only be violations from one engine');
-					expect(output[0].engine).to.equal('eslint-lwc');
-					expect(output[0].violations, JSON.stringify(output[0].violations)).to.be.lengthOf(13);
-
-					// Make sure only violations are returned for the requested category
-					for (const v of output[0].violations) {
-						expect(v.category, JSON.stringify(v)).to.equal(category);
-					}
-				});
-
-		});
-
-		describe('Eslint Typescript Engine --category flag', () => {
-			const category = 'Possible Errors';
-			setupCommandTest
-				.command(['scanner:run',
-					'--target', path.join('test', 'code-fixtures', 'projects', 'ts', 'src', 'simpleYetWrong.ts'),
-					'--tsconfig', path.join('test', 'code-fixtures', 'projects', 'tsconfig.json'),
-					'--format', 'json',
-					'--engine', 'eslint-typescript',
-					'--category', category
-				])
-				.it('Only correct categories are returned', ctx => {
-					const output = JSON.parse(ctx.stdout);
-					expect(output.length).to.equal(1, 'Should only be violations from one engine');
-					expect(output[0].engine).to.equal('eslint-typescript');
-					expect(output[0].violations, JSON.stringify(output[0].violations)).to.be.lengthOf(2);
-
-					// Make sure only violations are returned for the requested category
-					for (const v of output[0].violations) {
-						expect(v.category, JSON.stringify(v)).to.equal(category);
-					}
-				});
-
-		});
-
-		describe('PMD Engine --category flag', () => {
-			const category = 'Code Style';
-			setupCommandTest
-				.command(['scanner:run',
-					'--target', path.join('test', 'code-fixtures', 'apex'),
-					'--format', 'json',
-					'--engine', 'pmd',
-					'--category', category
-				])
-				.it('Only correct categories are returned', ctx => {
-					const output = JSON.parse(ctx.stdout);
-					expect(output.length).to.equal(1, 'Should only be violations from one engine');
-					expect(output[0].engine).to.equal('pmd');
-					expect(output[0].violations, JSON.stringify(output[0].violations)).to.be.lengthOf(2);
-
-					// Make sure only violations are returned for the requested category
-					for (const v of output[0].violations) {
-						expect(v.category, JSON.stringify(v)).to.equal(category);
-					}
-				});
-
-		});
-
 		// TODO: this test has become more of an integration test, than just testing the run command. break it up to make it more manageable, maybe based on engine or flags.
 
 		describe('--engine flag', () => {
-			setupCommandTest
-				.command(['scanner:run',
-					'--target', path.join('test', 'code-fixtures', 'lwc'),
-					'--format', 'csv',
-					'--engine', 'eslint-lwc'
-				])
-				.it('LWC Engine Successfully parses LWC code', ctx => {
-					expect(ctx.stdout).to.contain('No rule violations found.');
-				});
-
-			setupCommandTest
-				.command(['scanner:run',
-					'--target', path.join('test', 'code-fixtures', 'invalid-lwc'),
-					'--format', 'json',
-					'--engine', 'eslint-lwc'
-				])
-				.it('LWC Engine detects LWC errors', ctx => {
-					const results = JSON.parse(ctx.stdout);
-					expect(results, `results does not have expected length. ${results.map(r => r.fileName).join(',')}`)
-						.to.be.an('Array').that.has.length(1);
-					const messages = results[0].violations.map(v => v.message);
-					const expectedMessages = ['Invalid public property initialization for "foo". Boolean public properties should not be initialized to "true", consider initializing the property to "false".',
-						`'Foo' is defined but never used.`];
-					for (const expectedMessage of expectedMessages) {
-						expect(messages).to.contain(expectedMessage);
-					}
-				});
 		});
 
 		describe('Dynamic Input', () => {
@@ -794,12 +674,6 @@ describe('scanner:run', function () {
 		});
 
 		describe('Error handling', () => {
-			setupCommandTest
-				.command(['scanner:run', '--ruleset', 'ApexUnit', '--format', 'xml'])
-				.it('Error thrown when no target is specified', ctx => {
-					expect(ctx.stderr).to.contain(`ERROR running scanner:run:  ${runMessages.getMessage('validations.mustTargetSomething')}`);
-				});
-
 			setupCommandTest
 				.command(['scanner:run', '--target', 'path/that/does/not/matter', '--ruleset', 'ApexUnit', '--outfile', 'NotAValidFileName'])
 				.it('Error thrown when output file is malformed', ctx => {

--- a/test/lib/RuleFilter.test.ts
+++ b/test/lib/RuleFilter.test.ts
@@ -1,0 +1,232 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { fail } from 'assert';
+import { expect } from 'chai';
+import { Messages } from '@salesforce/core';
+import { isRuleGroupFilter, CategoryFilter, LanguageFilter, RuleFilter,
+	RulenameFilter, RulesetFilter, SourcePackageFilter, EngineFilter, isEngineFilter } from '../../src/lib/RuleFilter';
+import { ENGINE, LANGUAGE } from '../../src/Constants';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/sfdx-scanner', 'Exceptions');
+
+const POSITIVE_FILTERS = ['val1 ', ' val2'];
+const NEGATIVE_FILTERS = ['!val1 ', ' !val2'];
+const MIXED_FILTERS = ['!val1 ', ' val2'];
+
+const TRIMMED_FILTERS = ['val1', 'val2'];
+
+const assertNegativeFilterThrows = (method: () => void, filterName: string): void => {
+	try {
+		method();
+		fail(`${filterName} should have thrown`);
+	} catch(err) {
+		expect(err.message).to.equal(messages.getMessage("RuleFilter.PositiveOnly", [filterName]));
+	}
+};
+
+const assertMixedFilterThrows = (method: () => void, filterName: string): void => {
+	try {
+		method();
+		fail(`${filterName} should have thrown`);
+	} catch(err) {
+		expect(err.message).to.equal(messages.getMessage("RuleFilter.MixedTypes", [filterName]));
+	}
+};
+
+describe('RuleFilter', () => {
+	describe('Positive Cases', () => {
+		it('Values are trimmed', () => {
+			const filter: RuleFilter = new CategoryFilter(POSITIVE_FILTERS);
+			expect((filter as any).filterValues, 'Filter Values').to.eql(TRIMMED_FILTERS);
+			expect((filter as any).negated, 'Negated').to.be.false;
+		});
+
+		it('Negated values are converted', () => {
+			const filter: RuleFilter = new CategoryFilter(NEGATIVE_FILTERS);
+			expect((filter as any).filterValues, 'Filter Values').to.eql(TRIMMED_FILTERS);
+			expect((filter as any).negated, 'Negated').to.be.true;
+		});
+
+		it('isRuleGroupFilter', () => {
+			expect(isRuleGroupFilter(new CategoryFilter([])), 'CategoryFilter').to.be.true;
+			expect(isRuleGroupFilter(new RulesetFilter([])), 'RulesetFilter').to.be.true;
+			expect(isRuleGroupFilter(new RulenameFilter([])), 'RulenameFilter').to.be.false;
+		});
+
+		it('isEngineFilter', () => {
+			expect(isEngineFilter(new EngineFilter([])), 'EngineFilter').to.be.true;
+			expect(isEngineFilter(new RulesetFilter([])), 'RulesetFilter').to.be.false;
+		});
+
+		describe('getRuleValues', () => {
+			const baseRule = {
+				engine: null,
+				sourcepackage: null,
+				name: null,
+				description: null,
+				categories: null,
+				rulesets: null,
+				languages: null,
+				defaultEnabled: true
+			};
+
+			it('CategoryFilter',  () => {
+				const rule = {
+					...baseRule,
+					categories: TRIMMED_FILTERS
+				}
+				const filter: RuleFilter = new CategoryFilter([]);
+				expect((filter as any).getRuleValues(rule), 'Category').to.eql(TRIMMED_FILTERS);
+			});
+
+			it('CategoryFilter',  () => {
+				const rule = {
+					...baseRule,
+					engine: ENGINE.PMD
+				}
+				const filter: RuleFilter = new EngineFilter([]);
+				expect((filter as any).getRuleValues(rule), 'Engine').to.eql([ENGINE.PMD]);
+			});
+
+			it('LanguageFilter',  () => {
+				const rule = {
+					...baseRule,
+					languages: [LANGUAGE.APEX]
+				}
+				const filter: RuleFilter = new LanguageFilter([]);
+				expect((filter as any).getRuleValues(rule), 'Language').to.eql([LANGUAGE.APEX]);
+			});
+
+			it('RulenameFilter',  () => {
+				const ruleName = 'MyRule';
+				const rule = {
+					...baseRule,
+					name: ruleName
+				}
+				const filter: RuleFilter = new RulenameFilter([]);
+				expect((filter as any).getRuleValues(rule), 'Rule Name').to.eql([ruleName]);
+			});
+
+			it('SourcePackageFilter',  () => {
+				const packageName = 'com.a.package';
+				const rule = {
+					...baseRule,
+					sourcepackage: packageName
+				}
+				const filter: RuleFilter = new SourcePackageFilter([]);
+				expect((filter as any).getRuleValues(rule), 'Source Package').to.eql([packageName]);
+			});
+		});
+
+		describe('matchesRuleGroup', () => {
+			describe('CategoryFilter', () => {
+				const baseRuleGroup = {
+					engine: null,
+					paths: null
+				}
+
+				const ruleGroup1 = {
+					...baseRuleGroup,
+					name: TRIMMED_FILTERS[0]
+				};
+
+				const ruleGroup2 = {
+					...baseRuleGroup,
+					name: TRIMMED_FILTERS[1]
+				};
+
+				const ruleGroup3 = {
+					...baseRuleGroup,
+					name: 'no-match-1'
+				};
+
+				const ruleGroup4 = {
+					...baseRuleGroup,
+					name: 'no-match-2'
+				};
+
+				it ('Positive Filters', () => {
+					const filter: RuleFilter = new CategoryFilter(POSITIVE_FILTERS);
+					expect (filter.matchesRuleGroup(ruleGroup1), ruleGroup1.name).to.be.true;
+					expect (filter.matchesRuleGroup(ruleGroup2), ruleGroup2.name).to.be.true;
+					expect (filter.matchesRuleGroup(ruleGroup3), ruleGroup3.name).to.be.false;
+					expect (filter.matchesRuleGroup(ruleGroup4), ruleGroup3.name).to.be.false;
+				});
+
+				it ('Negated Filters', () => {
+					const filter: RuleFilter = new CategoryFilter(NEGATIVE_FILTERS);
+					expect (filter.matchesRuleGroup(ruleGroup1), ruleGroup1.name).to.be.false;
+					expect (filter.matchesRuleGroup(ruleGroup2), ruleGroup2.name).to.be.false;
+					expect (filter.matchesRuleGroup(ruleGroup3), ruleGroup3.name).to.be.true;
+					expect (filter.matchesRuleGroup(ruleGroup4), ruleGroup3.name).to.be.true;
+				});
+			});
+		});
+
+		describe('matchesRule', () => {
+			describe('CategoryFilter', () => {
+				const baseRule = {
+					engine: null,
+					sourcepackage: null,
+					name: null,
+					description: null,
+					rulesets: null,
+					languages: null,
+					defaultEnabled: true
+				};
+
+				const rule1 = {
+					...baseRule,
+					categories: [TRIMMED_FILTERS[0]]
+				};
+
+				const rule2 = {
+					...baseRule,
+					defaultEnabled: false,
+					categories: [TRIMMED_FILTERS[1]]
+				};
+
+				const rule3 = {
+					...baseRule,
+					categories: ['no-match-1']
+				};
+
+				const rule4 = {
+					...baseRule,
+					defaultEnabled: false,
+					categories: ['no-match-2']
+				};
+
+				it ('Positive Filters', () => {
+					const filter: RuleFilter = new CategoryFilter(POSITIVE_FILTERS);
+					expect (filter.matchesRule(rule1), rule1.name).to.be.true;
+					expect (filter.matchesRule(rule2), rule2.name).to.be.true;
+					expect (filter.matchesRule(rule3), rule3.name).to.be.false;
+					expect (filter.matchesRule(rule4), rule4.name).to.be.false;
+				});
+
+				it ('Negated Filters', () => {
+					const filter: RuleFilter = new CategoryFilter(NEGATIVE_FILTERS);
+					expect (filter.matchesRule(rule1), rule1.name).to.be.false;
+					expect (filter.matchesRule(rule2), rule2.name).to.be.false;
+					expect (filter.matchesRule(rule3), rule3.name).to.be.true;
+					// This should not match because defaultEnabled='false'
+					expect (filter.matchesRule(rule4), rule4.name).to.be.false;
+				});
+			});
+		});
+	});
+	describe('Negative Cases', () => {
+		it('Negated values for Positive Filter throws Exception', () => {
+			assertNegativeFilterThrows(() => new EngineFilter(NEGATIVE_FILTERS), 'Engine');
+			assertNegativeFilterThrows(() => new LanguageFilter(NEGATIVE_FILTERS), 'Language');
+			assertNegativeFilterThrows(() => new RulenameFilter(NEGATIVE_FILTERS), 'Rule Name');
+			assertNegativeFilterThrows(() => new RulesetFilter(NEGATIVE_FILTERS), 'Ruleset');
+			assertNegativeFilterThrows(() => new SourcePackageFilter(NEGATIVE_FILTERS), 'Source Package');
+		});
+
+		it('Mixed types throws Exception', () => {
+			assertMixedFilterThrows(() => new CategoryFilter(MIXED_FILTERS), 'Category');
+		});
+	});
+});

--- a/test/lib/services/LocalCatalog.test.ts
+++ b/test/lib/services/LocalCatalog.test.ts
@@ -1,0 +1,349 @@
+import Sinon = require('sinon');
+import * as TestOverrides from '../../test-related-lib/TestOverrides';
+import * as TestUtils from '../../TestUtils';
+import { RuleCatalog } from '../../../src/lib/services/RuleCatalog';
+import { CategoryFilter, EngineFilter, LanguageFilter, RuleFilter, RulesetFilter } from '../../../src/lib/RuleFilter';
+import { ENGINE, LANGUAGE } from '../../../src/Constants';
+import { Rule, RuleGroup } from '../../../src/types';
+import LocalCatalog from '../../../src/lib/services/LocalCatalog';
+import { expect } from 'chai';
+
+TestOverrides.initializeTestSetup();
+
+describe('LocalCatalog', () => {
+	let catalog: RuleCatalog;
+
+	beforeEach(async () => {
+		TestUtils.stubCatalogFixture()
+		catalog = new LocalCatalog();
+		await catalog.init();
+	});
+
+	afterEach(() => {
+		Sinon.restore();
+	});
+
+	describe('getRuleGroupsMatchingFilters', () => {
+        const LANGUAGE_ECMASCRIPT = 'ecmascript';
+        /**
+         * Return a map of key=<engine.name>:<ruleGroup.name>, value=RuleGroup
+         */
+		const mapRuleGroups = (ruleGroups: RuleGroup[]): Map<string, RuleGroup> => {
+			const map = new Map<string, RuleGroup>();
+
+			ruleGroups.forEach(ruleGroup => {
+				const key = `${ruleGroup.engine}:${ruleGroup.name}`;
+				expect(map.has(key), key).to.be.false;
+				map.set(key, ruleGroup);
+			});
+
+			return map;
+        }
+
+		const validatePmdRuleGroup = (mappedRuleGroups: Map<string, RuleGroup>, name: string, languages: string[], type: string): void => {
+			const ruleGroup = mappedRuleGroups.get(`${ENGINE.PMD}:${name}`);
+			expect(ruleGroup).to.not.be.undefined;
+            expect(ruleGroup.name).to.equal(name);
+            expect(ruleGroup.engine).to.equal(ENGINE.PMD);
+            expect(ruleGroup.paths, TestUtils.prettyPrint(ruleGroup.paths)).to.be.lengthOf(languages.length);
+            const paths = [];
+            for (const language of languages) {
+				const fileName = name.toLowerCase().replace(' ', '');
+                paths.push(`${type}/${language}/${fileName}.xml`);
+			}
+			// Not concerned about order
+            expect(ruleGroup.paths, TestUtils.prettyPrint(ruleGroup.paths)).to.have.members(paths);
+		}
+
+		const validatePmdCategory = (mappedRuleGroups: Map<string, RuleGroup>, name: string, languages: string[]): void => {
+			validatePmdRuleGroup(mappedRuleGroups, name, languages, 'category');
+        }
+
+        const validatePmdRuleset = (mappedRuleGroups: Map<string, RuleGroup>, name: string, languages: string[]): void => {
+			validatePmdRuleGroup(mappedRuleGroups, name, languages, 'rulesets');
+        }
+
+		describe('RulesetFilter', () => {
+			it ('Single Value', async () => {
+				const filter: RuleFilter = new RulesetFilter(['Braces']);
+				const ruleGroups: RuleGroup[] = catalog.getRuleGroupsMatchingFilters([filter]);
+				expect(ruleGroups, TestUtils.prettyPrint(ruleGroups)).to.be.lengthOf(1);
+				const mappedRuleGroups = mapRuleGroups(ruleGroups);
+                validatePmdRuleset(mappedRuleGroups, 'Braces', [LANGUAGE_ECMASCRIPT, LANGUAGE.APEX]);
+			});
+
+			it ('Multiple Values', async () => {
+				const filter: RuleFilter = new RulesetFilter(['Security', 'Braces']);
+				const ruleGroups: RuleGroup[] = catalog.getRuleGroupsMatchingFilters([filter]);
+				expect(ruleGroups, TestUtils.prettyPrint(ruleGroups)).to.be.lengthOf(2);
+				const mappedRuleGroups = mapRuleGroups(ruleGroups);
+                validatePmdRuleset(mappedRuleGroups, 'Braces', [LANGUAGE_ECMASCRIPT, LANGUAGE.APEX]);
+                validatePmdRuleset(mappedRuleGroups, 'Security', [LANGUAGE.APEX, LANGUAGE.VISUALFORCE]);
+			});
+
+            // Multiple Filters: Not tested
+            // The #getRuleGroupsMatchingFilters method does not prevent the caller from passing multiple
+            // instances of RulesetFilters. However in practice this does not occur.
+		});
+
+		describe('CategoryFilter', () => {
+			const validateEslintBestPractices = (mappedRuleGroups: Map<string, RuleGroup>): void => {
+				for (const engine of [ENGINE.ESLINT, ENGINE.ESLINT_TYPESCRIPT]) {
+					const ruleGroup = mappedRuleGroups.get(`${engine}:Best Practices`);
+					expect(ruleGroup.name).to.equal('Best Practices');
+					expect(ruleGroup.engine).to.equal(engine);
+					expect(ruleGroup.paths, TestUtils.prettyPrint(ruleGroup.paths)).to.be.lengthOf(2);
+					expect(ruleGroup.paths).to.eql(['https://eslint.org/docs/rules/no-implicit-globals', 'https://eslint.org/docs/rules/no-implicit-coercion']);
+				}
+			}
+
+			const validateEslintPossibleErrors = (mappedRuleGroups: Map<string, RuleGroup>): void => {
+				for (const engine of [ENGINE.ESLINT, ENGINE.ESLINT_TYPESCRIPT]) {
+					const ruleGroup = mappedRuleGroups.get(`${engine}:Possible Errors`);
+					expect(ruleGroup).to.not.be.undefined;
+					expect(ruleGroup.name).to.equal('Possible Errors');
+					expect(ruleGroup.engine).to.equal(engine);
+					expect(ruleGroup.paths, TestUtils.prettyPrint(ruleGroup.paths)).to.be.lengthOf(1);
+					expect(ruleGroup.paths).to.eql(['https://eslint.org/docs/rules/no-inner-declarations']);
+				}
+			}
+
+			describe ('Positive', () => {
+				it ('Single Value', async () => {
+					const filter: RuleFilter = new CategoryFilter(['Best Practices']);
+					const ruleGroups: RuleGroup[] = catalog.getRuleGroupsMatchingFilters([filter]);
+					expect(ruleGroups, TestUtils.prettyPrint(ruleGroups)).to.be.lengthOf(3);
+					const mappedRuleGroups = mapRuleGroups(ruleGroups);
+
+					validateEslintBestPractices(mappedRuleGroups);
+					validatePmdCategory(mappedRuleGroups, 'Best Practices', [LANGUAGE_ECMASCRIPT, LANGUAGE.APEX]);
+				});
+
+				it ('Multiple Values', async () => {
+					const filter: RuleFilter = new CategoryFilter(['Best Practices', 'Possible Errors']);
+					const ruleGroups: RuleGroup[] = catalog.getRuleGroupsMatchingFilters([filter]);
+					expect(ruleGroups, 'Rule Groups').to.be.lengthOf(5);
+					const mappedRuleGroups = mapRuleGroups(ruleGroups);
+					validateEslintPossibleErrors(mappedRuleGroups);
+					validateEslintBestPractices(mappedRuleGroups);
+					validatePmdCategory(mappedRuleGroups, 'Best Practices', [LANGUAGE.APEX, LANGUAGE_ECMASCRIPT]);
+				});
+
+                // Multiple Filters: Not tested
+                // The #getRuleGroupsMatchingFilters method does not prevent the caller from passing multiple
+                // instances of CategoryFilter. However in practice this does not occur.
+            });
+
+            // RulesetFilter and CategoryFilter Combination: Not tested
+            // There is a known issue with filtering by Category and Ruleset. The two are mutually exclusive,
+            // invoking #getRuleGroupsMatchingFilters with this combination results in no rules being returned.
+            // It is on the roadmap to remove Ruleset support and only support categories.
+
+			describe ('Negated', () => {
+				it ('Single Value', async () => {
+					const filter: RuleFilter = new CategoryFilter(['!Best Practices']);
+					const ruleGroups: RuleGroup[] = catalog.getRuleGroupsMatchingFilters([filter]);
+					expect(ruleGroups, TestUtils.prettyPrint(ruleGroups)).to.be.lengthOf(4);
+					const mappedRuleGroups = mapRuleGroups(ruleGroups);
+
+					validateEslintPossibleErrors(mappedRuleGroups);
+					validatePmdCategory(mappedRuleGroups, 'Design', [LANGUAGE.APEX, LANGUAGE_ECMASCRIPT]);
+					validatePmdCategory(mappedRuleGroups, 'Error Prone', [LANGUAGE.APEX, LANGUAGE_ECMASCRIPT]);
+				});
+
+				it ('Multiple Values', async () => {
+					const filter: RuleFilter = new CategoryFilter(['!Best Practices', '!Design']);
+					const ruleGroups: RuleGroup[] = catalog.getRuleGroupsMatchingFilters([filter]);
+					expect(ruleGroups, TestUtils.prettyPrint(ruleGroups)).to.be.lengthOf(3);
+					const mappedRuleGroups = mapRuleGroups(ruleGroups);
+
+					validateEslintPossibleErrors(mappedRuleGroups);
+					validatePmdCategory(mappedRuleGroups, 'Error Prone', [LANGUAGE.APEX, LANGUAGE_ECMASCRIPT]);
+				});
+
+                // Multiple Filters: Not tested
+                // The #getRuleGroupsMatchingFilters method does not prevent the caller from passing multiple
+                // instances of CategoryFilter. However in practice this does not occur.
+			});
+		});
+	});
+
+	describe ('getRulesMatchingFilters', () => {
+		const mapRules = (rules: Rule[]): Map<string, Rule> => {
+			const map = new Map<string, Rule>();
+
+			rules.forEach(rule => {
+				const key = `${rule.engine}:${rule.name}`;
+				expect(map.has(key), key).to.be.false;
+				map.set(key, rule);
+			});
+
+			return map;
+		}
+
+		const validateRule = (mappedRules: Map<string, Rule>, names: string[], categories: string[], languages: string[], engines: ENGINE[]): void => {
+			for (const engine of engines) {
+				for (const name of names) {
+					const rule = mappedRules.get(`${engine}:${name}`);
+					expect(rule).to.not.be.undefined;
+					expect(rule.name).to.equal(name);
+					expect(rule.engine).to.equal(engine);
+					expect(rule.categories).to.have.members(categories);
+					expect(rule.languages).to.have.members(languages);
+				}
+			}
+		}
+
+		const validatePmdRule = (mappedRules: Map<string, Rule>, names: string[], categories: string[], languages: string[]): void => {
+			validateRule(mappedRules, names, categories, languages, [ENGINE.PMD]);
+		}
+
+		const validateEslintRule = (mappedRules: Map<string, Rule>, names: string[], categories: string[], engines=[ENGINE.ESLINT, ENGINE.ESLINT_TYPESCRIPT]): void => {
+			for (const engine of engines) {
+				const languages = engine === ENGINE.ESLINT ? [LANGUAGE.JAVASCRIPT] : [LANGUAGE.TYPESCRIPT];
+				validateRule(mappedRules, names, categories, languages, [engine]);
+			}
+		}
+
+		describe('CategoryFilter', () => {
+			describe ('Positive', () => {
+				it ('Single Value', async () => {
+					const filter: RuleFilter = new CategoryFilter(['Possible Errors']);
+					const rules: Rule[] = catalog.getRulesMatchingFilters([filter]);
+					expect(rules, TestUtils.prettyPrint(rules)).to.be.lengthOf(4);
+					const mappedRules = mapRules(rules);
+
+					validateEslintRule(mappedRules, ['no-unreachable', 'no-inner-declarations'], ['Possible Errors']);
+				});
+
+				it ('Multiple Values', async () => {
+					const filter: RuleFilter = new CategoryFilter(['Possible Errors', 'Design']);
+					const rules: Rule[] = catalog.getRulesMatchingFilters([filter]);
+					expect(rules, TestUtils.prettyPrint(rules)).to.be.lengthOf(6);
+					const mappedRules = mapRules(rules);
+
+					validateEslintRule(mappedRules, ['no-unreachable', 'no-inner-declarations'], ['Possible Errors']);
+					validatePmdRule(mappedRules, ['AvoidDeeplyNestedIfStmts', 'ExcessiveClassLength'], ['Design'], [LANGUAGE.APEX]);
+				});
+
+                // Multiple Filters: Not tested
+                // The #getRuleGroupsMatchingFilters method does not prevent the caller from passing multiple
+                // instances of CategoryFilter. However in practice this does not occur.
+			});
+
+			describe ('Negative', () => {
+				it ('Single Value', async () => {
+					const filter: RuleFilter = new CategoryFilter(['!Possible Errors']);
+					const rules: Rule[] = catalog.getRulesMatchingFilters([filter]);
+					expect(rules, TestUtils.prettyPrint(rules)).to.be.lengthOf(7);
+					const mappedRules = mapRules(rules);
+
+					validatePmdRule(mappedRules, ['AvoidDeeplyNestedIfStmts', 'ExcessiveClassLength'], ['Design'], [LANGUAGE.APEX]);
+					validatePmdRule(mappedRules, ['AvoidWithStatement', 'ConsistentReturn'], ['Best Practices'], [LANGUAGE.JAVASCRIPT]);
+					validatePmdRule(mappedRules, ['ForLoopsMustUseBraces', 'IfElseStmtsMustUseBraces', 'IfStmtsMustUseBraces'], ['Code Style'], [LANGUAGE.JAVASCRIPT]);
+				});
+
+				it ('Multiple Values', async () => {
+					const filter: RuleFilter = new CategoryFilter(['!Possible Errors', '!Code Style']);
+					const rules: Rule[] = catalog.getRulesMatchingFilters([filter]);
+					expect(rules, TestUtils.prettyPrint(rules)).to.be.lengthOf(4);
+					const mappedRules = mapRules(rules);
+
+					validatePmdRule(mappedRules, ['AvoidDeeplyNestedIfStmts', 'ExcessiveClassLength'], ['Design'], [LANGUAGE.APEX]);
+					validatePmdRule(mappedRules, ['AvoidWithStatement', 'ConsistentReturn'], ['Best Practices'], [LANGUAGE.JAVASCRIPT]);
+				});
+			});
+		});
+
+		describe('Multiple Heterogenous Filters', () => {
+			describe('Positive', () => {
+				/**
+				 * User's can specify multiple filter parameters. A rule must match at least one parameter from each
+				 * filter in order to be returned. The #getRulesMatchingFilters method would accept multiple filters of
+				 * the same type, but in practice this could not happen. Each CLI flag is converted into a single filter.
+				 *
+				 * For example:
+				 * sfdx scanner:rule:list --language 'apex,javascript' --engine 'eslint,pmd' --category 'Best Practices,Security'
+				 *
+				 * Results in the expression:
+				 * (rule.language === 'apex' || rule.language === 'javascript') &&
+				 * (rule.engine === 'eslint' || rule.engine === 'pmd') &&
+				 * (rule.categories.includes('Best Practices') || rule.categories.includes('Security'))
+				 */
+				describe('Rules must match a parameter from each filter when multiple filters are specified', () => {
+					it ('Two Filters - Single Parameter', async () => {
+						const categoryFilter: RuleFilter = new CategoryFilter(['Best Practices']);
+						const engineFilter: RuleFilter = new EngineFilter([ENGINE.PMD]);
+						const rules: Rule[] = catalog.getRulesMatchingFilters([categoryFilter, engineFilter]);
+						expect(rules, TestUtils.prettyPrint(rules)).to.be.lengthOf(2);
+						const mappedRules = mapRules(rules);
+
+						validatePmdRule(mappedRules, ['AvoidWithStatement', 'ConsistentReturn'], ['Best Practices'], [LANGUAGE.JAVASCRIPT]);
+					});
+
+					it ('Two Filters - Single/Multiple Parameters', async () => {
+						const categoryFilter: RuleFilter = new CategoryFilter(['Best Practices']);
+						const engineFilter: RuleFilter = new EngineFilter([ENGINE.ESLINT, ENGINE.PMD]);
+						const rules: Rule[] = catalog.getRulesMatchingFilters([categoryFilter, engineFilter]);
+						expect(rules, TestUtils.prettyPrint(rules)).to.be.lengthOf(4);
+						const mappedRules = mapRules(rules);
+
+						validateEslintRule(mappedRules, ['no-implicit-coercion', 'no-implicit-globals'], ['Best Practices'], [ENGINE.ESLINT]);
+						validatePmdRule(mappedRules, ['AvoidWithStatement', 'ConsistentReturn'], ['Best Practices'], [LANGUAGE.JAVASCRIPT]);
+					});
+
+					it ('Two Filters - Multiple/Multiple Parameters', async () => {
+						const categoryFilter: RuleFilter = new CategoryFilter(['Best Practices', 'Design']);
+						const engineFilter: RuleFilter = new EngineFilter([ENGINE.ESLINT, ENGINE.PMD]);
+						const rules: Rule[] = catalog.getRulesMatchingFilters([categoryFilter, engineFilter]);
+						expect(rules, TestUtils.prettyPrint(rules)).to.be.lengthOf(6);
+						const mappedRules = mapRules(rules);
+
+						validateEslintRule(mappedRules, ['no-implicit-coercion', 'no-implicit-globals'], ['Best Practices'], [ENGINE.ESLINT]);
+						validatePmdRule(mappedRules, ['AvoidWithStatement', 'ConsistentReturn'], ['Best Practices'], [LANGUAGE.JAVASCRIPT]);
+						validatePmdRule(mappedRules, ['AvoidDeeplyNestedIfStmts', 'ExcessiveClassLength'], ['Design'], [LANGUAGE.APEX]);
+					});
+
+					it ('Three Filters - Multiple/Multiple/Single Parameters', async () => {
+						const categoryFilter: RuleFilter = new CategoryFilter(['Best Practices', 'Design']);
+						const engineFilter: RuleFilter = new EngineFilter([ENGINE.ESLINT, ENGINE.PMD]);
+						// Missing LANGUAGE.APEX will exclude the PMD Design category
+						const languageFilter: RuleFilter = new LanguageFilter([LANGUAGE.JAVASCRIPT]);
+						const rules: Rule[] = catalog.getRulesMatchingFilters([categoryFilter, engineFilter, languageFilter]);
+						expect(rules, TestUtils.prettyPrint(rules)).to.be.lengthOf(4);
+						const mappedRules = mapRules(rules);
+
+						validateEslintRule(mappedRules, ['no-implicit-coercion', 'no-implicit-globals'], ['Best Practices'], [ENGINE.ESLINT]);
+						validatePmdRule(mappedRules, ['AvoidWithStatement', 'ConsistentReturn'], ['Best Practices'], [LANGUAGE.JAVASCRIPT]);
+					});
+
+					it ('Three Filters - Multiple/Multiple/Single Parameters', async () => {
+						const categoryFilter: RuleFilter = new CategoryFilter(['Best Practices', 'Design']);
+						const engineFilter: RuleFilter = new EngineFilter([ENGINE.ESLINT, ENGINE.PMD]);
+						// Adding LANGUAGE.APEX will add the PMD Design category
+						const languageFilter: RuleFilter = new LanguageFilter([LANGUAGE.JAVASCRIPT, LANGUAGE.APEX]);
+						const rules: Rule[] = catalog.getRulesMatchingFilters([categoryFilter, engineFilter, languageFilter]);
+						expect(rules, TestUtils.prettyPrint(rules)).to.be.lengthOf(6);
+						const mappedRules = mapRules(rules);
+
+						validateEslintRule(mappedRules, ['no-implicit-coercion', 'no-implicit-globals'], ['Best Practices'], [ENGINE.ESLINT]);
+						validatePmdRule(mappedRules, ['AvoidWithStatement', 'ConsistentReturn'], ['Best Practices'], [LANGUAGE.JAVASCRIPT]);
+						validatePmdRule(mappedRules, ['AvoidDeeplyNestedIfStmts', 'ExcessiveClassLength'], ['Design'], [LANGUAGE.APEX]);
+					});
+				});
+			});
+		});
+
+		describe('Mixed Positive and Negative', () => {
+			it ('Multiple Positive and Negative Values', async () => {
+				const categoryFilter: RuleFilter = new CategoryFilter(['!Possible Errors', '!Code Style']);
+				const languageFilter: RuleFilter = new LanguageFilter([LANGUAGE.APEX]);
+				const rules: Rule[] = catalog.getRulesMatchingFilters([categoryFilter, languageFilter]);
+				expect(rules, TestUtils.prettyPrint(rules)).to.be.lengthOf(2);
+				const mappedRules = mapRules(rules);
+
+				validatePmdRule(mappedRules, ['AvoidDeeplyNestedIfStmts', 'ExcessiveClassLength'], ['Design'], [LANGUAGE.APEX]);
+			});
+		});
+	});
+});

--- a/test/lib/util/PrettyPrinter.test.ts
+++ b/test/lib/util/PrettyPrinter.test.ts
@@ -1,18 +1,25 @@
 import {expect} from 'chai';
-import {FilterType, RuleFilter} from '../../../src/lib/RuleFilter';
+import {CategoryFilter, RuleFilter, RulenameFilter} from '../../../src/lib/RuleFilter';
 import * as PrettyPrinter from '../../../src/lib/util/PrettyPrinter';
 import {Rule} from '../../../src/types';
 
 
-function createRuleFilter(filterType: FilterType): {ruleFilter: RuleFilter; expectedRuleFilterString: string} {
-	const expectedRuleFilterString = `RuleFilter[filterType=${filterType}, filterValues=Rule1,Rule2]`;
-	const ruleFilter = new RuleFilter(filterType, ['Rule1', 'Rule2']);
+function createRulenameFilter(): {ruleFilter: RuleFilter; expectedRuleFilterString: string} {
+	const expectedRuleFilterString = `RuleFilter[filterType=RulenameFilter, filterValues=Rule1,Rule2, negated=false]`;
+	const ruleFilter = new RulenameFilter(['Rule1', 'Rule2']);
 	return {ruleFilter, expectedRuleFilterString};
 }
 
+function createCategoryFilter(): {ruleFilter: RuleFilter; expectedRuleFilterString: string} {
+	const expectedRuleFilterString = `RuleFilter[filterType=CategoryFilter, filterValues=Rule3,Rule4, negated=false]`;
+	const ruleFilter = new CategoryFilter(['Rule3', 'Rule4']);
+	return {ruleFilter, expectedRuleFilterString};
+}
+
+
 function createRuleFilters(): {ruleFilters: RuleFilter[]; expectedRuleFiltersString: string} {
-	const ruleFilter1 = createRuleFilter(FilterType.RULENAME);
-	const ruleFilter2 = createRuleFilter(FilterType.LANGUAGE);
+	const ruleFilter1 = createRulenameFilter();
+	const ruleFilter2 = createCategoryFilter();
 	const ruleFilters: RuleFilter[] = [ruleFilter1.ruleFilter, ruleFilter2.ruleFilter];
 	const expectedRuleFiltersString = `[${ruleFilter1.expectedRuleFilterString},${ruleFilter2.expectedRuleFilterString}]`;
 	return {ruleFilters, expectedRuleFiltersString};
@@ -84,7 +91,7 @@ describe(('PrettyPrinter tests'), () => {
 	});
 
 	it('should print a RuleFilter', () => {
-		const {ruleFilter, expectedRuleFilterString} = createRuleFilter(FilterType.CATEGORY);
+		const {ruleFilter, expectedRuleFilterString} = createCategoryFilter();
 		expect(PrettyPrinter.stringifyRuleFilter(ruleFilter)).equals(expectedRuleFilterString);
 	});
 


### PR DESCRIPTION
scanner:run and scanner:rule:list will accept negative values such as '!Documentation,!Stylistic Issues'. Positive and negative category filters can't be combined.

Modified RuleFilters to be strongly typed and to encapsulate the filtering.

Removed unused code in run.ts

Moved some tests out of run.test.ts into run.filters.test.ts