### PR TITLE
@W-8559396@ TargetPatterns should not include custom engines unless requested

### DIFF
--- a/src/Controller.ts
+++ b/src/Controller.ts
@@ -64,12 +64,12 @@ export const Controller = {
 		return engines;
 	},
 
-	getEnabledEngines: async (): Promise<RuleEngine[]> => {
+	getEnabledEngines: async (engineOptions: Map<string,string> = new Map()): Promise<RuleEngine[]> => {
 		const allEngines: RuleEngine[] = await Controller.getAllEngines();
 		const engines: RuleEngine[] = [];
 
 		for (const engine of allEngines) {
-			if (await engine.isEnabled()) {
+			if (await engine.isEnabled() && engine.isEngineRequested([/*no filter values*/], engineOptions)) {
 				engines.push(engine);
 			}
 		}

--- a/src/commands/scanner/rule/describe.ts
+++ b/src/commands/scanner/rule/describe.ts
@@ -40,7 +40,7 @@ export default class Describe extends ScannerCommand {
 		// It's possible for this line to throw an error, but that's fine because the error will be an SfdxError that we can
 		// allow to boil over.
 		const ruleManager = await Controller.createRuleManager();
-		const rules = await ruleManager.getRulesMatchingOnlyExplicitCriteria(ruleFilters);
+		const rules = ruleManager.getRulesMatchingOnlyExplicitCriteria(ruleFilters);
 		if (rules.length === 0) {
 			// If we couldn't find any rules that fit the criteria, we'll let the user know. We'll use .warn() instead of .log()
 			// so it's immediately obvious.

--- a/src/lib/DefaultRuleManager.ts
+++ b/src/lib/DefaultRuleManager.ts
@@ -58,8 +58,8 @@ export class DefaultRuleManager implements RuleManager {
 	 * Returns rules that match only the provided filters, completely ignoring any implicit filtering.
 	 * @param filters
 	 */
-	getRulesMatchingOnlyExplicitCriteria(filters: RuleFilter[]): Promise<Rule[]> {
-		return Promise.resolve(this.catalog.getRulesMatchingFilters(filters));
+	getRulesMatchingOnlyExplicitCriteria(filters: RuleFilter[]): Rule[] {
+		return this.catalog.getRulesMatchingFilters(filters);
 	}
 
 	async runRulesMatchingCriteria(filters: RuleFilter[], targets: string[], format: OUTPUT_FORMAT, engineOptions: Map<string, string>): Promise<RecombinedRuleResults> {

--- a/src/lib/RuleManager.ts
+++ b/src/lib/RuleManager.ts
@@ -23,7 +23,7 @@ export interface RuleManager {
 	 * Returns rules that match only the provided filters, completely ignoring any implicit filtering.
 	 * @param filters
 	 */
-	getRulesMatchingOnlyExplicitCriteria(filters: RuleFilter[]): Promise<Rule[]>;
+	getRulesMatchingOnlyExplicitCriteria(filters: RuleFilter[]): Rule[];
 
 	/**
 	 * @param engineOptions - see RuleEngine#run

--- a/src/lib/eslint/BaseEslintEngine.ts
+++ b/src/lib/eslint/BaseEslintEngine.ts
@@ -7,6 +7,7 @@ import {Config} from '../util/Config';
 import {Controller} from '../../Controller';
 import {deepCopy} from '../../lib/util/Utils';
 import {StaticDependencies, EslintProcessHelper, ProcessRuleViolationType} from './EslintCommons';
+import * as engineUtils from '../util/CommonEngineUtils';
 
 // TODO: DEFAULT_ENV_VARS is part of a fix for W-7791882 that was known from the beginning to be a sub-optimal solution.
 //       During the 3.0 release cycle, an alternate fix should be implemented that doesn't leak the abstraction. If this
@@ -163,10 +164,7 @@ export abstract class BaseEslintEngine implements RuleEngine {
 
 	isEngineRequested(filterValues: string[], engineOptions: Map<string, string>): boolean {
 		return !this.helper.isCustomRun(engineOptions)
-		/* eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars */
-		&& (filterValues.length === 0 || filterValues.some((value, index, array) => {
-			return value === this.getName();
-		}));
+		&& engineUtils.isFilterEmptyOrNameInFilter(this.getName(), filterValues);
 	}
 
 	async run(ruleGroups: RuleGroup[], rules: Rule[], targets: RuleTarget[], engineOptions: Map<string, string>): Promise<RuleResult[]> {

--- a/src/lib/eslint/BaseEslintEngine.ts
+++ b/src/lib/eslint/BaseEslintEngine.ts
@@ -164,9 +164,9 @@ export abstract class BaseEslintEngine implements RuleEngine {
 	isEngineRequested(filterValues: string[], engineOptions: Map<string, string>): boolean {
 		return !this.helper.isCustomRun(engineOptions)
 		/* eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars */
-		&& filterValues.some((value, index, array) => {
+		&& (filterValues.length === 0 || filterValues.some((value, index, array) => {
 			return value === this.getName();
-		});
+		}));
 	}
 
 	async run(ruleGroups: RuleGroup[], rules: Rule[], targets: RuleTarget[], engineOptions: Map<string, string>): Promise<RuleResult[]> {

--- a/src/lib/eslint/CustomEslintEngine.ts
+++ b/src/lib/eslint/CustomEslintEngine.ts
@@ -4,7 +4,7 @@ import {CUSTOM_CONFIG, ENGINE, EngineBase} from '../../Constants';
 import {EslintProcessHelper, StaticDependencies, ProcessRuleViolationType} from './EslintCommons';
 import {Logger, SfdxError} from '@salesforce/core';
 import { EventCreator } from '../util/EventCreator';
-
+import * as engineUtils from '../util/CommonEngineUtils';
 
 
 export class CustomEslintEngine implements RuleEngine {
@@ -24,10 +24,7 @@ export class CustomEslintEngine implements RuleEngine {
 
 	isEngineRequested(filterValues: string[], engineOptions: Map<string, string>): boolean {
 		return this.helper.isCustomRun(engineOptions)
-		/* eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars */
-		&& (filterValues.length === 0 || filterValues.some((value, index, array) => {
-			return value.startsWith(EngineBase.ESLINT);
-		}));
+		&& engineUtils.isFilterEmptyOrFilterValueStartsWith(EngineBase.ESLINT, filterValues);
 	}
 
 	async init(dependencies = new StaticDependencies()): Promise<void> {

--- a/src/lib/eslint/CustomEslintEngine.ts
+++ b/src/lib/eslint/CustomEslintEngine.ts
@@ -25,9 +25,9 @@ export class CustomEslintEngine implements RuleEngine {
 	isEngineRequested(filterValues: string[], engineOptions: Map<string, string>): boolean {
 		return this.helper.isCustomRun(engineOptions)
 		/* eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars */
-		&& filterValues.some((value, index, array) => {
+		&& (filterValues.length === 0 || filterValues.some((value, index, array) => {
 			return value.startsWith(EngineBase.ESLINT);
-		});
+		}));
 	}
 
 	async init(dependencies = new StaticDependencies()): Promise<void> {

--- a/src/lib/eslint/EslintCommons.ts
+++ b/src/lib/eslint/EslintCommons.ts
@@ -3,6 +3,8 @@ import * as path from 'path';
 import { CUSTOM_CONFIG } from '../../Constants';
 import { RuleResult, RuleViolation, ESMessage, ESRule, ESReport } from '../../types';
 import { FileHandler } from '../util/FileHandler';
+import * as engineUtils from '../util/CommonEngineUtils';
+
 
 // Defining a function signature that will be returned by EslintStrategy.processRuleViolation()
 // This provides a safe way to pass around the callback function
@@ -31,7 +33,7 @@ export class StaticDependencies {
 export class EslintProcessHelper {
 
 	isCustomRun(engineOptions: Map<string, string>): boolean {
-		return engineOptions.has(CUSTOM_CONFIG.EslintConfig);
+		return engineUtils.isCustomRun(CUSTOM_CONFIG.EslintConfig, engineOptions);
 	}
 
 	addRuleResultsFromReport(

--- a/src/lib/pmd/PmdEngine.ts
+++ b/src/lib/pmd/PmdEngine.ts
@@ -10,6 +10,8 @@ import PmdWrapper from './PmdWrapper';
 import {uxEvents} from "../ScannerEvents";
 import { FileHandler } from '../util/FileHandler';
 import { EventCreator } from '../util/EventCreator';
+import * as engineUtils from '../util/CommonEngineUtils';
+
 
 Messages.importMessagesDirectory(__dirname);
 const eventMessages = Messages.loadMessages("@salesforce/sfdx-scanner", "EventKeyTemplates");
@@ -253,8 +255,8 @@ abstract class BasePmdEngine implements RuleEngine {
 	}
 }
 
-function isCustomConfig(engineOptions: Map<string, string>): boolean {
-	return engineOptions.has(CUSTOM_CONFIG.PmdConfig);
+function isCustomRun(engineOptions: Map<string, string>): boolean {
+	return engineUtils.isCustomRun(CUSTOM_CONFIG.PmdConfig, engineOptions);
 }
 
 export class PmdEngine extends BasePmdEngine {
@@ -274,17 +276,14 @@ export class PmdEngine extends BasePmdEngine {
 		rules: Rule[],
 		target: RuleTarget[],
 		engineOptions: Map<string, string>): boolean {
-		return !isCustomConfig(engineOptions)
+		return !isCustomRun(engineOptions)
 			&& (ruleGroups.length > 0); // TODO: there's a bug in DefaultRuleManager that's populating Rules instead of RuleGroups when --engine filter is used
 		//TODO: targetPaths count should be ideally included here
 	}
 
 	isEngineRequested(filterValues: string[], engineOptions: Map<string, string>): boolean {
-		return !isCustomConfig(engineOptions)
-		/* eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars */
-		&& (filterValues.length === 0 || filterValues.some((value, index, array) => {
-			return value === this.getName();
-		}));
+		return !isCustomRun(engineOptions)
+		&& engineUtils.isFilterEmptyOrNameInFilter(this.getName(), filterValues);
 	}
 
 	/**
@@ -332,16 +331,13 @@ export class CustomPmdEngine extends BasePmdEngine {
 		rules: Rule[],
 		target: RuleTarget[],
 		engineOptions: Map<string, string>): boolean {
-		return isCustomConfig(engineOptions);
+		return isCustomRun(engineOptions);
 		//TODO: targetPaths count should be ideally included here
 	}
 
 	isEngineRequested(filterValues: string[], engineOptions: Map<string, string>): boolean {
-		return isCustomConfig(engineOptions)
-		/* eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars */
-		&& (filterValues.length === 0 || filterValues.some((value, index, array) => {
-			return value.startsWith(EngineBase.PMD);
-		}));
+		return isCustomRun(engineOptions)
+		&& engineUtils.isFilterEmptyOrFilterValueStartsWith(EngineBase.PMD, filterValues);
 	}
 
 	/* eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars */

--- a/src/lib/pmd/PmdEngine.ts
+++ b/src/lib/pmd/PmdEngine.ts
@@ -282,9 +282,9 @@ export class PmdEngine extends BasePmdEngine {
 	isEngineRequested(filterValues: string[], engineOptions: Map<string, string>): boolean {
 		return !isCustomConfig(engineOptions)
 		/* eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars */
-		&& filterValues.some((value, index, array) => {
+		&& (filterValues.length === 0 || filterValues.some((value, index, array) => {
 			return value === this.getName();
-		});
+		}));
 	}
 
 	/**
@@ -339,9 +339,9 @@ export class CustomPmdEngine extends BasePmdEngine {
 	isEngineRequested(filterValues: string[], engineOptions: Map<string, string>): boolean {
 		return isCustomConfig(engineOptions)
 		/* eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars */
-		&& filterValues.some((value, index, array) => {
+		&& (filterValues.length === 0 || filterValues.some((value, index, array) => {
 			return value.startsWith(EngineBase.PMD);
-		});
+		}));
 	}
 
 	/* eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars */

--- a/src/lib/retire-js/RetireJsEngine.ts
+++ b/src/lib/retire-js/RetireJsEngine.ts
@@ -6,6 +6,7 @@ import {Catalog, Rule, RuleGroup, RuleResult, RuleTarget} from '../../types';
 import {ENGINE} from '../../Constants';
 import {StaticResourceHandler, StaticResourceType} from '../util/StaticResourceHandler';
 import {FileHandler} from '../util/FileHandler';
+import * as engineUtils from '../util/CommonEngineUtils';
 import cspawn = require('cross-spawn');
 import path = require('path');
 import StreamZip = require('node-stream-zip');
@@ -111,10 +112,7 @@ export class RetireJsEngine implements RuleEngine {
 
 	/* eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars */
 	isEngineRequested(filterValues: string[], engineOptions: Map<string, string>): boolean {
-		/* eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars */
-		return filterValues.some((value, index, array) => {
-			return value === this.getName();
-		});
+		return engineUtils.isValueInFilter(this.getName(), filterValues);
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/require-await, no-unused-vars

--- a/src/lib/util/CommonEngineUtils.ts
+++ b/src/lib/util/CommonEngineUtils.ts
@@ -1,0 +1,30 @@
+/*
+ * Functions reused by various engines
+ */
+
+export function isValueInFilter(value: string, filterValues: string[]): boolean {
+	/* eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars */
+	return filterValues.some((myValue, index, array) => {
+		return myValue === value;
+	});
+}
+
+export function anyFilterValueStartsWith(startsWith: string, filterValues: string[]): boolean {
+	/* eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars */
+	return filterValues.some((value, index, array) => {
+		return value.startsWith(startsWith);
+	})
+}
+
+export function isFilterEmptyOrNameInFilter(value: string, filterValues: string[]): boolean {
+	return filterValues.length === 0 || isValueInFilter(value, filterValues);
+}
+
+export function isFilterEmptyOrFilterValueStartsWith(startsWith: string, filterValues: string[]): boolean {
+	return filterValues.length === 0 || anyFilterValueStartsWith(startsWith, filterValues);
+}
+
+export function isCustomRun(configName: string, engineOptions: Map<string, string>): boolean {
+	return engineOptions.has(configName);
+}
+

--- a/test/TestUtils.ts
+++ b/test/TestUtils.ts
@@ -44,8 +44,11 @@ export function stubCatalogFixture(): void {
  * 		expect(ctx.stdout).to.contain('No rule violations found.');
  * 	});
  */
-export const setupCommandTest = test
+const setupCommandTest = test
 	.do(() => TestOverrides.initializeTestSetup())
 	.stdout()
 	.stderr();
+
+export {setupCommandTest};
+
 

--- a/test/TestUtils.ts
+++ b/test/TestUtils.ts
@@ -44,11 +44,9 @@ export function stubCatalogFixture(): void {
  * 		expect(ctx.stdout).to.contain('No rule violations found.');
  * 	});
  */
-const setupCommandTest = test
+export const setupCommandTest = test
 	.do(() => TestOverrides.initializeTestSetup())
 	.stdout()
 	.stderr();
-
-export {setupCommandTest};
 
 

--- a/test/commands/scanner/rule/describe.test.ts
+++ b/test/commands/scanner/rule/describe.test.ts
@@ -7,12 +7,14 @@ describe('scanner:rule:describe', () => {
 		describe('Test Case: No matching rules', () => {
 			const formattedWarning = messages.output.noMatchingRules.replace('{0}', 'DefinitelyFakeRule');
 			setupCommandTest
+				.timeout(10000)
 				.command(['scanner:rule:describe', '--rulename', 'DefinitelyFakeRule'])
 				.it('Correct warning is displayed', ctx => {
 					expect(ctx.stderr).to.contain('WARNING: ' + formattedWarning, 'Warning message should match');
 				});
 
 			setupCommandTest
+				.timeout(10000)
 				.command(['scanner:rule:describe', '--rulename', 'DefinitelyFakeRule', '--json'])
 				.it('--json flag yields correct results', ctx => {
 					const ctxJson = JSON.parse(ctx.stdout);

--- a/test/commands/scanner/rule/describe.test.ts
+++ b/test/commands/scanner/rule/describe.test.ts
@@ -7,14 +7,12 @@ describe('scanner:rule:describe', () => {
 		describe('Test Case: No matching rules', () => {
 			const formattedWarning = messages.output.noMatchingRules.replace('{0}', 'DefinitelyFakeRule');
 			setupCommandTest
-				.timeout(10000)
 				.command(['scanner:rule:describe', '--rulename', 'DefinitelyFakeRule'])
 				.it('Correct warning is displayed', ctx => {
 					expect(ctx.stderr).to.contain('WARNING: ' + formattedWarning, 'Warning message should match');
 				});
 
 			setupCommandTest
-				.timeout(10000)
 				.command(['scanner:rule:describe', '--rulename', 'DefinitelyFakeRule', '--json'])
 				.it('--json flag yields correct results', ctx => {
 					const ctxJson = JSON.parse(ctx.stdout);

--- a/test/commands/scanner/run.filters.test.ts
+++ b/test/commands/scanner/run.filters.test.ts
@@ -44,7 +44,8 @@ describe('scanner:run tests that result in the use of RuleFilters', function () 
 
 	describe('--category and --engine flag', () => {
 		describe('Eslint Javascript Engine --category flag', () => {
-			const category = 'Stylistic Issues';
+			const category = 'Possible Errors';
+			const expectedViolationCount = 4;
 			setupCommandTest
 				.command(['scanner:run',
 					'--target', path.join('test', 'code-fixtures', 'projects', 'app', 'force-app', 'main', 'default', 'aura', 'dom_parser', 'dom_parserController.js'),
@@ -57,7 +58,7 @@ describe('scanner:run tests that result in the use of RuleFilters', function () 
 					const output = JSON.parse(stdout.slice(stdout.indexOf('['), stdout.lastIndexOf(']') + 1));
 					expect(output.length).to.equal(1, 'Should only be violations from one file');
 					expect(output[0].engine).to.equal('eslint');
-					expect(output[0].violations, TestUtils.prettyPrint(output[0].violations)).to.be.lengthOf(55);
+					expect(output[0].violations, TestUtils.prettyPrint(output[0].violations)).to.be.lengthOf(expectedViolationCount);
 
 					// Make sure only violations are returned for the requested category
 					for (const v of output[0].violations) {

--- a/test/lib/Controller.test.ts
+++ b/test/lib/Controller.test.ts
@@ -27,15 +27,54 @@ describe('Controller.ts tests', () => {
 		expect(names).to.contain(ENGINE.RETIRE_JS);
 	});
 
-	it('getEnabledEngines returns only enabled engines', async() => {
+	it('getEnabledEngines returns only non-custom enabled engines when engineOptions is empty', async() => {
 		const engines: RuleEngine[] = await Controller.getEnabledEngines();
 		const names: string[] = engines.map(e => e.getName());
 
-		expect(engines.length).to.equal(5);
+		expect(engines.length).to.equal(3);
 		expect(names).to.contain(ENGINE.ESLINT);
 		expect(names).to.contain(ENGINE.ESLINT_TYPESCRIPT);
+		expect(names).to.contain(ENGINE.PMD);
+	});
+
+	it('getEnabledEngines returns PMD_CUSTOM when engineOptions contains pmdconfig', async () => {
+		const engineOptions = new Map<string, string>([
+			[CUSTOM_CONFIG.PmdConfig, "/some/path"]
+		]);
+
+		const engines: RuleEngine[] = await Controller.getEnabledEngines(engineOptions);
+		const names: string[] = engines.map(e => e.getName());
+
+		expect(engines.length).to.equal(3);
+		expect(names).to.contain(ENGINE.ESLINT);
+		expect(names).to.contain(ENGINE.ESLINT_TYPESCRIPT);
+		expect(names).to.contain(ENGINE.PMD_CUSTOM);
+	});
+
+	it('getEnabledEngines returns ESLINT_CUSTOM when engineOptions contains eslintconfig', async () => {
+		const engineOptions = new Map<string, string>([
+			[CUSTOM_CONFIG.EslintConfig, "/some/path"]
+		]);
+
+		const engines: RuleEngine[] = await Controller.getEnabledEngines(engineOptions);
+		const names: string[] = engines.map(e => e.getName());
+
+		expect(engines.length).to.equal(2);
 		expect(names).to.contain(ENGINE.ESLINT_CUSTOM);
 		expect(names).to.contain(ENGINE.PMD);
+	});
+
+	it('getEnabledEngines returns PMD_CUSTOM, ESLINT_CUSTOM when engineOptions contains pmdconfig and eslintconfig', async () => {
+		const engineOptions = new Map<string, string>([
+			[CUSTOM_CONFIG.EslintConfig, "/some/path"],
+			[CUSTOM_CONFIG.PmdConfig, "/some/other/path"]
+		]);
+
+		const engines: RuleEngine[] = await Controller.getEnabledEngines(engineOptions);
+		const names: string[] = engines.map(e => e.getName());
+
+		expect(engines.length).to.equal(2);
+		expect(names).to.contain(ENGINE.ESLINT_CUSTOM);
 		expect(names).to.contain(ENGINE.PMD_CUSTOM);
 	});
 

--- a/test/lib/RuleManager.test.ts
+++ b/test/lib/RuleManager.test.ts
@@ -244,6 +244,17 @@ describe('RuleManager', () => {
 					expect(parsedRes).to.be.an("array").that.has.length(1);
 					Sinon.assert.callCount(uxSpy, 0);
 				});
+
+				it('Single target file does not match', async () => {
+					const invalidTarget = ['does-not-exist.js'];
+					// No filters
+					const filters = [];
+
+					const {results} = await ruleManager.runRulesMatchingCriteria(filters, invalidTarget, OUTPUT_FORMAT.JSON, EMPTY_ENGINE_OPTIONS);
+
+					expect(results).to.equal('');
+					Sinon.assert.calledWith(uxSpy, 'warning-always', `Target: '${invalidTarget.join(', ')}' was not processed by any engines.`);
+				});
 			});
 
 			describe('Test Case: Run by category', () => {

--- a/test/lib/eslint/BaseEslintEngine.test.ts
+++ b/test/lib/eslint/BaseEslintEngine.test.ts
@@ -391,6 +391,22 @@ describe('Tests for BaseEslintEngine', () => {
 
 			expect(isEngineRequested).to.be.true;
 		});
+
+		it('should return true when custom config is not present and filter is empty', () => {
+			const filteredNames = [];
+
+			const isEngineRequested = engine.isEngineRequested(filteredNames, emptyEngineOptions);
+
+			expect(isEngineRequested).to.be.true;	
+		});
+
+		it('should return false when custom eslint config is present and filter is empty', () => {
+			const filteredNames = [];
+
+			const isEngineRequested = engine.isEngineRequested(filteredNames, engineOptionsWithEslintCustom);
+
+			expect(isEngineRequested).to.be.false;	
+		});
 	});
 });
 

--- a/test/lib/eslint/CustomEslintEngine.test.ts
+++ b/test/lib/eslint/CustomEslintEngine.test.ts
@@ -114,6 +114,21 @@ describe("Tests for CustomEslintEngine", () => {
 			expect(isEngineRequested).to.be.false;
 		});
 
+		it('should return false when filter is empty and engineOptions is empty', () => {
+			const filteredValues = [];
+
+			const isEngineRequested = engine.isEngineRequested(filteredValues, emptyEngineOptions);
+
+			expect(isEngineRequested).to.be.false;
+		});
+
+		it('should return true when filter is empty and engineOptions contains eslintconfig', () => {
+			const filteredValues = [];
+
+			const isEngineRequested = engine.isEngineRequested(filteredValues, engineOptionsWithEslintCustom);
+
+			expect(isEngineRequested).to.be.true;
+		});
 
 	});
 

--- a/test/lib/pmd/PmdEngine.test.ts
+++ b/test/lib/pmd/PmdEngine.test.ts
@@ -216,5 +216,21 @@ describe('Tests for BasePmdEngine and PmdEngine implementation', () => {
 
 			expect(isEngineRequested).to.be.true;
 		});
+
+		it('should return false when custom config exists and filter is empty', () => {
+			const filteredNames = [];
+
+			const isEngineRequested = engine.isEngineRequested(filteredNames, engineOptionsWithPmdCustom);
+
+			expect(isEngineRequested).to.be.false;
+		});
+
+		it('should return true when custom config is not present and filter is empty', () => {
+			const filteredNames = [];
+
+			const isEngineRequested = engine.isEngineRequested(filteredNames, emptyEngineOptions);
+
+			expect(isEngineRequested).to.be.true;
+		});
 	});
 });

--- a/test/lib/util/CommonEngineUtils.test.ts
+++ b/test/lib/util/CommonEngineUtils.test.ts
@@ -1,0 +1,84 @@
+import { expect } from 'chai';
+import * as engineUtils from '../../../src/lib/util/CommonEngineUtils';
+
+describe('Tests for CommonEngineUtils', () => {
+	describe('#isValueInFilter', () => {
+		it('should detect if value is present in filter values', () => {
+			const value = 'value1';
+			const filterValues = ['value3', 'value1', 'value2'];
+			expect(engineUtils.isValueInFilter(value, filterValues)).is.true;
+		});
+
+		it('should detect if value is not present in filter values', () => {
+			const value = 'value5';
+			const filterValues = ['value3', 'value1', 'value2'];
+			expect(engineUtils.isValueInFilter(value, filterValues)).is.false;
+		});
+	});
+
+	describe('#anyFilterValueStartsWith', () => {
+		it('should detect if filter values starts with a given string', () => {
+			const value = 'abc';
+			const filterValues = ['xyz5', 'abc67', 'pqr89'];
+			expect(engineUtils.anyFilterValueStartsWith(value, filterValues)).is.true;
+		});
+
+		it('should detect if none of the filter values start with a given string', () => {
+			const value = 'hijk';
+			const filterValues = ['xyz5', 'abc67', 'pqr89'];
+			expect(engineUtils.isValueInFilter(value, filterValues)).is.false;
+		});
+	});
+
+	describe('#isFilterEmptyOrNameInFilter', () => {
+		it('should always return true if filter values list is empty', () => {
+			const value = 'value1';
+			const filterValues = [];
+			expect(engineUtils.isFilterEmptyOrNameInFilter(value, filterValues)).is.true;
+		});
+
+		it('should check if value is present in the list if list is non empty', () => {
+			const value1 = 'value1';
+			const value2 = 'value2'
+			const filterValues = ['value1', 'value3'];
+			expect(engineUtils.isFilterEmptyOrNameInFilter(value1, filterValues)).is.true;
+			expect(engineUtils.isFilterEmptyOrNameInFilter(value2, filterValues)).is.false;
+		});
+	});
+
+	describe('#isFilterEmptyOrFilterValueStartsWith', () => {
+		it('should always return true if filter values list is empty', () => {
+			const value = 'abc';
+			const filterValues = [];
+			expect(engineUtils.isFilterEmptyOrFilterValueStartsWith(value, filterValues)).is.true;
+		});
+
+		it('should check if any of the filter values start with given string in the list if list is non empty', () => {
+			const value1 = 'abc';
+			const value2 = 'xyz'
+			const filterValues = ['abc123', 'pqr678'];
+			expect(engineUtils.isFilterEmptyOrFilterValueStartsWith(value1, filterValues)).is.true;
+			expect(engineUtils.isFilterEmptyOrFilterValueStartsWith(value2, filterValues)).is.false;
+		});
+	});
+
+	describe('#isCustomRun', () => {
+		it('should return true of value exists in map', () => {
+			const config = 'some config';
+			const engineOptions = new Map<string, string>([
+				['some config', 'configvalue']
+			]);
+
+			expect(engineUtils.isCustomRun(config, engineOptions)).is.true;
+		});
+
+		it('should return true of value exists in map', () => {
+			const config = 'not me';
+			const engineOptions = new Map<string, string>([
+				['some config', 'configvalue']
+			]);
+
+			expect(engineUtils.isCustomRun(config, engineOptions)).is.false;
+		});
+	});
+});


### PR DESCRIPTION
Same as changes in https://github.com/forcedotcom/sfdx-scanner/pull/313
+ Removed duplicated code between engines
+ Fixed scanner:run category test that failed only in my Windows machine