### PR TITLE
@W-8553897@ Add sarif formatter

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1,6 +1,13 @@
 import os = require('os');
 import path = require('path');
 
+export const PMD_VERSION = '6.31.0';
+export const CATALOG_FILE = 'Catalog.json';
+export const CUSTOM_PATHS_FILE = 'CustomPaths.json';
+export const CONFIG_FILE = 'Config.json';
+export const PMD_CATALOG_FILE = 'PmdCatalog.json';
+export const INTERNAL_ERROR_CODE = 500;
+
 export interface EnvOverridable {
 	getSfdxScannerPath(): string;
 }
@@ -10,11 +17,6 @@ export class ProdOverrides implements EnvOverridable {
 		return path.join(os.homedir(), '.sfdx-scanner');
 	}
 }
-
-export const CATALOG_FILE = 'Catalog.json';
-export const CUSTOM_PATHS_FILE = 'CustomPaths.json';
-export const CONFIG_FILE = 'Config.json';
-export const PMD_CATALOG_FILE = 'PmdCatalog.json';
 
 export enum ENGINE {
 	PMD = 'pmd',
@@ -63,8 +65,6 @@ export const Services = {
 	RulePathManager: "RulePathManager",
 	EnvOverridable: "EnvOverridable"
 };
-
-export const INTERNAL_ERROR_CODE = 500;
 
 export enum CUSTOM_CONFIG {
 	EslintConfig = "EslintConfig",

--- a/src/Controller.ts
+++ b/src/Controller.ts
@@ -5,8 +5,9 @@ import {container} from "tsyringe";
 import {Config} from './lib/util/Config';
 import {EnvOverridable, Services, AllowedEngineFilters} from './Constants';
 import {RuleManager} from './lib/RuleManager';
-import {RuleEngine} from './lib/services/RuleEngine'
+import {RuleEngine} from './lib/services/RuleEngine';
 import {RulePathManager} from './lib/RulePathManager';
+import {RuleCatalog} from './lib/services/RuleCatalog';
 
 /**
  * Converts an array of RuleEngines to a sorted, comma delimited
@@ -19,6 +20,12 @@ function enginesToString(engines: RuleEngine[]): string {
 // TODO: This is probably more appropriately called a Factory
 export const Controller = {
 	container,
+
+	getCatalog: async (): Promise<RuleCatalog> => {
+		const catalog = container.resolve<RuleCatalog>(Services.RuleCatalog);
+		await catalog.init();
+		return catalog;
+	},
 
 	getConfig: async (): Promise<Config> => {
 		const config = container.resolve<Config>(Services.Config);

--- a/src/commands/scanner/run.ts
+++ b/src/commands/scanner/run.ts
@@ -67,7 +67,7 @@ export default class Run extends ScannerCommand {
 			char: 'f',
 			description: messages.getMessage('flags.formatDescription'),
 			longDescription: messages.getMessage('flags.formatDescriptionLong'),
-			options: [OUTPUT_FORMAT.CSV, OUTPUT_FORMAT.HTML, OUTPUT_FORMAT.JSON, OUTPUT_FORMAT.JUNIT, OUTPUT_FORMAT.TABLE, OUTPUT_FORMAT.XML]
+			options: [OUTPUT_FORMAT.CSV, OUTPUT_FORMAT.HTML, OUTPUT_FORMAT.JSON, OUTPUT_FORMAT.JUNIT, OUTPUT_FORMAT.SARIF, OUTPUT_FORMAT.TABLE, OUTPUT_FORMAT.XML]
 		}),
 		outfile: flags.string({
 			char: 'o',
@@ -218,6 +218,7 @@ export default class Run extends ScannerCommand {
 				case OUTPUT_FORMAT.CSV:
 				case OUTPUT_FORMAT.HTML:
 				case OUTPUT_FORMAT.JSON:
+				case OUTPUT_FORMAT.SARIF:
 				case OUTPUT_FORMAT.XML:
 					return fileExtension;
 				default:

--- a/src/lib/DefaultRuleManager.ts
+++ b/src/lib/DefaultRuleManager.ts
@@ -5,7 +5,7 @@ import {inject, injectable} from 'tsyringe';
 import {RecombinedRuleResults, Rule, RuleGroup, RuleResult, RuleTarget} from '../types';
 import {isEngineFilter, RuleFilter} from './RuleFilter';
 import {OUTPUT_FORMAT, RuleManager} from './RuleManager';
-import {RuleResultRecombinator} from './RuleResultRecombinator';
+import {RuleResultRecombinator} from './formatter/RuleResultRecombinator';
 import {RuleCatalog} from './services/RuleCatalog';
 import {RuleEngine} from './services/RuleEngine';
 import {FileHandler} from './util/FileHandler';

--- a/src/lib/RuleManager.ts
+++ b/src/lib/RuleManager.ts
@@ -6,6 +6,7 @@ export enum OUTPUT_FORMAT {
 	HTML = 'html',
 	JSON = 'json',
 	JUNIT = 'junit',
+	SARIF = 'sarif',
 	TABLE = 'table',
 	XML = 'xml'
 }

--- a/src/lib/eslint/EslintCommons.ts
+++ b/src/lib/eslint/EslintCommons.ts
@@ -83,8 +83,8 @@ export class EslintProcessHelper {
 
 	addRuleResultsFromReport(
 		engineName: string,
-		results: RuleResult[], 
-		report: ESReport, 
+		results: RuleResult[],
+		report: ESReport,
 		ruleMap: Map<string, ESRule>,
 		processRuleViolation: (fileName: string, ruleViolation: RuleViolation) => void): void {
 			for (const r of report.results) {
@@ -97,8 +97,8 @@ export class EslintProcessHelper {
 
 	toRuleResult(
 		engineName: string,
-		fileName: string, 
-		messages: ESMessage[], 
+		fileName: string,
+		messages: ESMessage[],
 		ruleMap: Map<string, ESRule>,
 		processRuleViolation: (fileName: string, ruleViolation: RuleViolation) => void): RuleResult {
 		return {

--- a/src/lib/eslint/TypescriptEslintStrategy.ts
+++ b/src/lib/eslint/TypescriptEslintStrategy.ts
@@ -182,9 +182,11 @@ export class TypescriptEslintStrategy implements EslintStrategy {
 			if (message.startsWith('Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser.\nThe file does not match your project config') &&
 				message.endsWith('The file must be included in at least one of the projects provided.')) {
 				ruleViolation.message = messages.getMessage('FileNotIncludedByTsConfig', [fileName, TS_CONFIG]);
+				ruleViolation.exception = true;
 			} else if (message.startsWith('Parsing error:')) {
 				ruleViolation.ruleName = HARDCODED_RULES.FILES_MUST_COMPILE.name;
 				ruleViolation.category = HARDCODED_RULES.FILES_MUST_COMPILE.category;
+				ruleViolation.exception = true;
 			}
 		}
 	}

--- a/src/lib/formatter/SarifFormatter.ts
+++ b/src/lib/formatter/SarifFormatter.ts
@@ -1,0 +1,247 @@
+import { deepCopy } from '../util/Utils';
+import { ENGINE, PMD_VERSION } from '../../Constants';
+import { Rule, RuleResult, RuleViolation } from '../../types';
+import * as url from 'url';
+import { RuleCatalog } from '../services/RuleCatalog';
+import { Controller } from '../../Controller';
+import { CLIEngine } from 'eslint';
+import * as retire from 'retire';
+
+const ERROR = 'error';
+const WARNING = 'warning';
+
+/**
+ * Formatter based on https://docs.oasis-open.org/sarif/sarif/v2.0/csprd02/sarif-v2.0-csprd02.html
+ */
+abstract class SarifFormatter {
+	private readonly ruleMap: Map<string, number>;
+	private ruleIndex: number;
+	private readonly jsonTemplate: unknown;
+	protected readonly engine: string;
+
+	constructor(engine: string, toolJson: unknown) {
+		this.engine = engine;
+		this.jsonTemplate = deepCopy(toolJson);
+		this.jsonTemplate['results'] = [];
+		this.jsonTemplate['invocations'] = [];
+		this.ruleIndex = 0;
+		this.ruleMap = new Map<string, number>();
+	}
+
+	protected abstract getLevel(violation: RuleViolation): string;
+
+	private getLocation(r: RuleResult): unknown {
+		return {
+			physicalLocation: {
+				artifactLocation: {
+					uri: url.pathToFileURL(r.fileName)
+				}
+			}
+		};
+	}
+
+	private populateRuleMap(catalog: RuleCatalog, ruleResults: RuleResult[]): unknown[] {
+		const rules = [];
+		for (const r of ruleResults) {
+			for (const v of r.violations) {
+				// Exceptions aren't tied to a rule
+				if (v.exception) {
+					continue;
+				}
+				if (!this.ruleMap.has(v.ruleName)) {
+					const vRule: Rule = catalog.getRule(r.engine, v.ruleName);
+					// v.Rule may be undefined if there was an error
+					const description: string = vRule?.description ? vRule.description : v.message;
+					this.ruleMap.set(v.ruleName, this.ruleIndex++);
+					const rule = {
+						id: v.ruleName,
+						shortDescription: {
+							// Replace newline at beginning and end of line
+							text: description.trim().replace(/^\n/, '').replace(/\n$/, '')
+						},
+						properties: {
+							category: v.category,
+							severity: v.severity
+						}
+					};
+					if (v.url) {
+						rule['helpUri'] = v.url;
+					}
+					rules.push(rule);
+				}
+			}
+		}
+		return rules;
+	}
+
+	public format(catalog: RuleCatalog, ruleResults: RuleResult[]): unknown {
+		const runJson = deepCopy(this.jsonTemplate);
+		const results = runJson.results;
+		const invocation = {
+			executionSuccessful: true,
+			toolExecutionNotifications: []
+		}
+
+		runJson.tool.driver.rules.push(...this.populateRuleMap(catalog, ruleResults));
+
+		for (const r of ruleResults) {
+			for (const v of r.violations) {
+				// Create a new location for each violation, it may contain region specific information
+				const location = this.getLocation(r);
+
+				if (v.exception) {
+					invocation.executionSuccessful = false;
+					invocation.toolExecutionNotifications.push({
+						locations: [location],
+						message: {
+							text: v.message.replace(/\n/g, '')
+						}
+					});
+				} else {
+					// W-8881776: line and column are sometimes strings, but the schema requires them to be numbers
+					const region = {
+						startLine: parseInt(`${v.line}`),
+						startColumn: parseInt(`${v.column}`)
+					};
+
+					for (const k of ['endLine', 'endColumn']) {
+						if (v[k]) {
+							region[k] = parseInt(v[k]);
+						}
+					}
+
+					location['physicalLocation']['region'] = region;
+
+					const result = {
+						level: this.getLevel(v),
+						ruleId: v.ruleName,
+						ruleIndex: this.ruleMap.get(v.ruleName),
+						message: {
+							text: v.message.replace(/\n/g, '')
+						},
+						locations: [location]
+					};
+
+					results.push(result);
+				}
+			}
+		}
+
+		runJson['invocations'].push(invocation);
+
+		return runJson;
+	}
+}
+
+class ESLintSarifFormatter extends SarifFormatter {
+	constructor(engine: string) {
+		super(engine,
+			{
+				tool: {
+					driver: {
+						name: engine,
+						version: CLIEngine.version,
+						informationUri: 'https://eslint.org',
+						rules: []
+					}
+				}
+			}
+		);
+	}
+
+	protected getLevel(ruleViolation: RuleViolation): string {
+		return ruleViolation.severity === 2 ? ERROR : WARNING;
+	}
+}
+
+class PMDSarifFormatter extends SarifFormatter {
+	constructor(engine: string) {
+		super(engine,
+			{
+				tool: {
+					driver: {
+						name: ENGINE.PMD,
+						version: PMD_VERSION,
+						informationUri: 'https://pmd.github.io/pmd',
+						rules: []
+					}
+				}
+			}
+		);
+	}
+
+	protected getLevel(ruleViolation: RuleViolation): string {
+		return ruleViolation.severity === 1 ? ERROR : WARNING;
+	}
+}
+
+class RetireJsSarifFormatter extends SarifFormatter {
+	constructor(engine: string) {
+		super(engine,
+			{
+				tool: {
+					driver: {
+						name: 'Retire.js',
+						version: retire.version,
+						informationUri: 'https://retirejs.github.io/retire.js',
+						rules: []
+					}
+				}
+			}
+		);
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	protected getLevel(ignored: RuleViolation): string {
+		// All violations are errors
+		return ERROR;
+	}
+}
+
+const getSarifFormatter = (engine: string): SarifFormatter => {
+	if (engine === ENGINE.ESLINT_CUSTOM) {
+		// Expose the eslint-custom engine as eslint
+		return new ESLintSarifFormatter(ENGINE.ESLINT);
+	} else if (engine.startsWith(ENGINE.ESLINT)) {
+		// All other eslint engines are exposed as-is
+		return new ESLintSarifFormatter(engine);
+	} else if (engine.startsWith(ENGINE.PMD)) {
+		// Use the same formatter for pmd and pmd-custom
+		return new PMDSarifFormatter(ENGINE.PMD);
+	} else if (engine === ENGINE.RETIRE_JS) {
+		return new RetireJsSarifFormatter(engine);
+	} else {
+		throw new Error(`Developer error. Unknown engine '${engine}'`);
+	}
+}
+
+const constructSarif = async (results: RuleResult[]): Promise<string> => {
+	// Obtain the catalog and pass it in, this avoids multiple initializations
+	// when waiting for promises in parallel
+	const catalog: RuleCatalog = await Controller.getCatalog();
+	const sarif = {
+		version: '2.1.0',
+		$schema: 'http://json.schemastore.org/sarif-2.1.0',
+		runs: [
+		]
+	};
+
+	// Map of engine->RuleResult[]
+	const filteredResults: Map<string, RuleResult[]> = new Map<string, RuleResult[]>();
+	for (const r of results) {
+		if (!filteredResults.has(r.engine)) {
+			filteredResults.set(r.engine, []);
+		}
+		filteredResults.get(r.engine).push(r);
+	}
+
+	for (const [engine, ruleResults] of filteredResults.entries()) {
+		const formatter: SarifFormatter = getSarifFormatter(engine);
+		sarif.runs.push(formatter.format(catalog, ruleResults));
+	}
+
+	return JSON.stringify(sarif);
+}
+
+
+export { constructSarif };

--- a/src/lib/pmd/PmdCatalogWrapper.ts
+++ b/src/lib/pmd/PmdCatalogWrapper.ts
@@ -6,11 +6,11 @@ import * as PrettyPrinter from '../util/PrettyPrinter';
 import * as JreSetupManager from './../JreSetupManager';
 import {OutputProcessor} from './OutputProcessor';
 import * as PmdLanguageManager from './PmdLanguageManager';
-import {PMD_LIB, PMD_VERSION, PmdSupport} from './PmdSupport';
+import {PMD_LIB, PmdSupport} from './PmdSupport';
 import path = require('path');
 import {uxEvents} from '../ScannerEvents';
 import { Controller } from '../../Controller';
-import { PMD_CATALOG_FILE } from '../../Constants';
+import { PMD_CATALOG_FILE, PMD_VERSION } from '../../Constants';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/sfdx-scanner', 'EventKeyTemplates');

--- a/src/lib/pmd/PmdEngine.ts
+++ b/src/lib/pmd/PmdEngine.ts
@@ -94,7 +94,7 @@ abstract class BasePmdEngine implements RuleEngine {
 	public abstract shouldEngineRun(ruleGroups: RuleGroup[], rules: Rule[], target: RuleTarget[], engineOptions: Map<string, string>): boolean;
 
 	public abstract run(ruleGroups: RuleGroup[], rules: Rule[], target: RuleTarget[], engineOptions: Map<string, string>): Promise<RuleResult[]>;
-	
+
 	public abstract isEnabled(): Promise<boolean>;
 
 	public abstract isEngineRequested(filterValues: string[], engineOptions: Map<string, string>): boolean;
@@ -124,7 +124,7 @@ abstract class BasePmdEngine implements RuleEngine {
 				return [];
 			}
 			this.logger.trace(`About to run PMD rules. Targets: ${targetPaths.length}, Selected rules: ${selectedRules}`);
-			
+
 			const selectedTargets = targetPaths.join(',');
 			const stdout = await PmdWrapper.execute(selectedTargets, selectedRules);
 			const results = this.processStdOut(stdout);
@@ -284,7 +284,8 @@ abstract class BasePmdEngine implements RuleEngine {
 				severity: hardcodedDetails.severity,
 				ruleName: hardcodedDetails.base.name,
 				category: hardcodedDetails.base.category,
-				message: hardcodedDetails.msgFormatter(element)
+				message: hardcodedDetails.msgFormatter(element),
+				exception: true
 			}]
 		};
 	}
@@ -445,9 +446,9 @@ export class CustomPmdEngine extends BasePmdEngine {
 
 	/* eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars */
 	public async run(
-		ruleGroups: RuleGroup[], 
-		rules: Rule[], 
-		targets: RuleTarget[], 
+		ruleGroups: RuleGroup[],
+		rules: Rule[],
+		targets: RuleTarget[],
 		engineOptions: Map<string, string>): Promise<RuleResult[]> {
 
 		const selectedRules = await this.getCustomConfig(engineOptions);

--- a/src/lib/pmd/PmdSupport.ts
+++ b/src/lib/pmd/PmdSupport.ts
@@ -5,7 +5,7 @@ import {Controller} from '../../Controller';
 import {PmdEngine} from './PmdEngine';
 import cspawn = require('cross-spawn');
 
-export const PMD_VERSION = '6.31.0';
+
 // Here, current dir __dirname = <base_dir>/sfdx-scanner/src/lib/pmd
 export const PMD_LIB = path.join(__dirname, '..', '..', '..', 'dist', 'pmd', 'lib');
 

--- a/src/lib/services/LocalCatalog.ts
+++ b/src/lib/services/LocalCatalog.ts
@@ -21,6 +21,7 @@ export default class LocalCatalog implements RuleCatalog {
 
 	private engines: RuleEngine[];
 	private initialized: boolean;
+	private ruleMap: Map<string, Rule>;
 
 	async init(): Promise<void> {
 		if (this.initialized) {
@@ -128,8 +129,20 @@ export default class LocalCatalog implements RuleCatalog {
 			this.logger.trace(`Populating Catalog JSON.`);
 			await this.rebuildCatalogIfNecessary();
 			this.catalog = await this.readCatalogJson();
+			this.ruleMap = new Map<string, Rule>();
+			this.catalog.rules.forEach(r => {
+				this.ruleMap.set(`${r.engine}:${r.name}`, r);
+			});
 		}
 		return this.catalog;
+	}
+
+	/**
+	 * More efficient mechanism to get a rule by engine/name without
+	 * iterating via a RuleFilter
+	 */
+	public getRule(engine: string, ruleName: string): Rule {
+		return this.ruleMap.get(`${engine}:${ruleName}`);
 	}
 
 	private async rebuildCatalogIfNecessary(): Promise<[boolean, string]> {
@@ -159,6 +172,7 @@ export default class LocalCatalog implements RuleCatalog {
 	private static catalogIsStale(): boolean {
 		// TODO: Pretty soon, we'll want to add sophisticated logic to determine whether the catalog is stale. But for now,
 		//  we'll just return true so we always rebuild the catalog.
+		// Revisit #getRule when this changes
 		return true;
 	}
 

--- a/src/lib/services/RuleCatalog.ts
+++ b/src/lib/services/RuleCatalog.ts
@@ -14,4 +14,6 @@ export interface RuleCatalog {
 	getRuleGroupsMatchingFilters(filters: RuleFilter[]): RuleGroup[];
 
 	getRulesMatchingFilters(filters: RuleFilter[]): Rule[];
+
+	getRule(engine: string, ruleName: string): Rule;
 }

--- a/src/lib/util/RunOutputProcessor.ts
+++ b/src/lib/util/RunOutputProcessor.ts
@@ -113,11 +113,12 @@ export class RunOutputProcessor {
 		// Prepare the format mismatch message in case we need it later.
 		const msg = `Invalid combination of format ${format} and output type ${typeof results}`;
 		switch (format) {
-			case OUTPUT_FORMAT.JSON:
 			case OUTPUT_FORMAT.CSV:
-			case OUTPUT_FORMAT.XML:
-			case OUTPUT_FORMAT.JUNIT:
 			case OUTPUT_FORMAT.HTML:
+			case OUTPUT_FORMAT.JSON:
+			case OUTPUT_FORMAT.JUNIT:
+			case OUTPUT_FORMAT.SARIF:
+			case OUTPUT_FORMAT.XML:
 				// All of these formats should be represented as giant strings.
 				if (typeof results !== 'string') {
 					throw new SfdxError(msg, null, null, this.getInternalErrorCode());

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -61,6 +61,7 @@ export type RuleViolation = {
 	message: string;
 	category: string;
 	url?: string;
+	exception?: boolean;
 };
 
 export type Catalog = {

--- a/test/lib/RuleManager.test.ts
+++ b/test/lib/RuleManager.test.ts
@@ -379,6 +379,10 @@ describe('RuleManager', () => {
 		// In order to do that, we'll also need a very basic implementation of RuleCatalog to give to the constructor.
 		// That way, we can sidestep any need to mess with the controller or IoC.
 		class DummyCatalog implements RuleCatalog {
+			getRule(engine: string, ruleName: string): Rule {
+				throw new Error('Method not implemented.');
+			}
+
 			getRuleGroupsMatchingFilters(filters: RuleFilter[]): RuleGroup[] {
 				return [];
 			}

--- a/test/lib/formatter/RuleResultRecombinator.test.ts
+++ b/test/lib/formatter/RuleResultRecombinator.test.ts
@@ -1,10 +1,13 @@
 import {expect} from 'chai';
-import {RuleResult, RuleViolation} from '../../src/types';
-import {RuleResultRecombinator} from '../../src/lib/RuleResultRecombinator';
-import {OUTPUT_FORMAT} from '../../src/lib/RuleManager';
+import {RuleResult, RuleViolation} from '../../../src/types';
+import {RuleResultRecombinator} from '../../../src/lib/formatter/RuleResultRecombinator';
+import {OUTPUT_FORMAT} from '../../../src/lib/RuleManager';
 import path = require('path');
 import * as csvParse from 'csv-parse';
 import {parseString} from 'xml2js';
+import * as TestOverrides from '../../test-related-lib/TestOverrides';
+import { ENGINE, PMD_VERSION } from '../../../src/Constants';
+import { fail } from 'assert';
 
 const sampleFile1 = path.join('Users', 'SomeUser', 'samples', 'sample-file1.js');
 const sampleFile2 = path.join('Users', 'SomeUser', 'samples', 'sample-file2.js');
@@ -95,7 +98,8 @@ const allFakeRuleResults: RuleResult[] = [
 			"message": "'unusedVar' is assigned a value but never used.",
 			"ruleName": "no-unused-vars",
 			"category": "Variables",
-			"url": "https://eslint.org/docs/rules/no-unused-vars"
+			"url": "https://eslint.org/docs/rules/no-unused-vars",
+			"exception": true
 		}]
 	},
 	{
@@ -107,9 +111,9 @@ const allFakeRuleResults: RuleResult[] = [
 			"endLine": 2,
 			"endColumn": 57,
 			"severity": 4,
-			"ruleName": "UnusedImports",
+			"ruleName": "ApexAssertionsShouldIncludeMessage",
 			"category": "Best Practices",
-			"url": "https://pmd.github.io/pmd-6.22.0/pmd_rules_java_bestpractices.html#unusedimports",
+			"url": "https://pmd.github.io/pmd-6.22.0/pmd_rules_java_bestpractices.html#apexassertionsshouldincludemessage",
 			"message": "\nAvoid unused imports such as 'sfdc.sfdx.scanner.messaging.SfdxMessager'\n"
 		}, {
 			"line": 4,
@@ -117,9 +121,9 @@ const allFakeRuleResults: RuleResult[] = [
 			"endLine": 56,
 			"endColumn": 1,
 			"severity": 3,
-			"ruleName": "CommentRequired",
+			"ruleName": "ApexDoc",
 			"category": "Documentation",
-			"url": "https://pmd.github.io/pmd-6.22.0/pmd_rules_java_documentation.html#commentrequired",
+			"url": "https://pmd.github.io/pmd-6.22.0/pmd_rules_java_documentation.html#apexdoc",
 			"message": "\nEnum comments are required\n"
 		}, {
 			"line": 5,
@@ -127,8 +131,8 @@ const allFakeRuleResults: RuleResult[] = [
 			"endLine": 5,
 			"endColumn": 2,
 			"severity": 3,
-			"ruleName": "CommentSize",
-			"category": "Documentation",
+			"ruleName": "ApexUnitTestClassShouldHaveAsserts",
+			"category": "Best Practices",
 			"url": "https://pmd.github.io/pmd-6.22.0/pmd_rules_java_documentation.html#commentsize",
 			"message": "\nComment is too large: Line too long\n"
 		}]
@@ -156,6 +160,8 @@ function validateJson(ruleResult: RuleResult, expectedResults: RuleResult[], exp
 }
 
 describe('RuleResultRecombinator', () => {
+	beforeEach(() => TestOverrides.initializeTestSetup());
+
 	describe('#recombineAndReformatResults()', () => {
 		describe('Output Format: JUnit', () => {
 			// This is a function for validating JUnit-formatted XMLs.
@@ -259,6 +265,126 @@ describe('RuleResultRecombinator', () => {
 					expect(summaryMap.get('pmd')).to.deep.equal({fileCount: 1, violationCount: 3}, 'PMD summary should be correct');
 					expect(summaryMap.get('eslint')).to.deep.equal({fileCount: 2, violationCount: 3}, 'ESLint summary should be correct');
 				}
+			});
+		});
+
+		describe('Output Format: Sarif', () => {
+			function validateEslintSarif(run: unknown): void {
+				const driver = run['tool']['driver'];
+				expect(driver.name).to.equal('eslint');
+				expect(driver.version).to.equal('6.8.0');
+				expect(driver.informationUri).to.equal('https://eslint.org');
+
+				// tool.driver.rules
+				expect(driver['rules']).to.have.lengthOf(1, 'Rules');
+				const rule = driver['rules'][0];
+				expect(rule.id).to.equal('no-unused-vars');
+				expect(rule.shortDescription.text).to.equal('disallow unused variables');
+				expect(rule.properties.category).to.equal('Variables');
+				expect(rule.properties.severity).to.equal(2);
+				expect(rule.helpUri).to.equal('https://eslint.org/docs/rules/no-unused-vars');
+
+				// one of the violations has 'exception=2'. It will end up in the toolExecutionNotifications node
+				expect(run['results']).to.have.lengthOf(2, 'Results');
+				const results = run['results'];
+				for (let i=0; i<results.length; i++) {
+					const result = results[i];
+					expect(result.ruleId).to.equal('no-unused-vars');
+					expect(result.ruleIndex).to.equal(0);
+					expect(result.locations[0].physicalLocation.artifactLocation.uri).to.satisfy(l => l.startsWith('file://'));
+				}
+
+				let result = results[0];
+				expect(result.level).to.equal('error');
+				expect(result.message.text).to.equal(`'unusedParam1' is defined but never used.`);
+				expect(result.locations).to.have.lengthOf(1, 'Locations');
+				expect(result.locations[0].physicalLocation.artifactLocation.uri).to.satisfy(l => l.endsWith('Users/SomeUser/samples/sample-file1.js'));
+				expect(result.locations[0].physicalLocation.region.startLine).to.equal(2);
+				expect(result.locations[0].physicalLocation.region.startColumn).to.equal(11);
+
+				result = results[1];
+				expect(result.level).to.equal('warning');
+				expect(result.message.text).to.equal(`'unusedParam2' is defined but never used.`);
+				expect(result.locations).to.have.lengthOf(1, 'Locations');
+				expect(result.locations[0].physicalLocation.artifactLocation.uri).to.satisfy(l => l.endsWith('Users/SomeUser/samples/sample-file2.js'));
+				expect(result.locations[0].physicalLocation.region.startLine).to.equal(4);
+				expect(result.locations[0].physicalLocation.region.startColumn).to.equal(11);
+
+				// invocations. any violations with exception=true will show up here
+				expect(run['invocations']).to.have.lengthOf(1, 'Invocations');
+				const invocation = run['invocations'][0];
+				expect(invocation.executionSuccessful).to.be.false;
+				expect(invocation.toolExecutionNotifications).to.have.lengthOf(1, 'Tool Execution');
+				const toolExecution = invocation.toolExecutionNotifications[0];
+				expect(toolExecution.message.text).to.equal(`'unusedVar' is assigned a value but never used.`);
+				expect(toolExecution.locations).to.have.lengthOf(1, 'Locations');
+				expect(toolExecution.locations[0].physicalLocation.artifactLocation.uri).to.satisfy(l => l.startsWith('file://'));
+				expect(toolExecution.locations[0].physicalLocation.artifactLocation.uri).to.satisfy(l => l.endsWith('Users/SomeUser/samples/sample-file2.js'));
+			}
+
+			function validatePMDSarif(run: unknown): void {
+				const driver = run['tool']['driver'];
+				expect(driver.name).to.equal('pmd');
+				expect(driver.version).to.equal(PMD_VERSION);
+				expect(driver.informationUri).to.equal('https://pmd.github.io/pmd');
+
+				// tool.driver.rules
+				expect(driver['rules']).to.have.lengthOf(3, 'Rules');
+				expect(run['results']).to.have.lengthOf(3, 'Results');
+				expect(run['tool']['driver']['rules']).to.have.lengthOf(3, 'Rules');
+
+				let rule = driver['rules'][0];
+				expect(rule.id).to.equal('ApexAssertionsShouldIncludeMessage');
+				expect(rule.shortDescription.text).to.equal(`The second parameter of System.assert/third parameter of System.assertEquals/System.assertNotEquals is a message.\nHaving a second/third parameter provides more information and makes it easier to debug the test failure and\nimproves the readability of test output.`);
+				expect(rule.properties.category).to.equal('Best Practices');
+				expect(rule.properties.severity).to.equal(4);
+				expect(rule.helpUri).to.equal('https://pmd.github.io/pmd-6.22.0/pmd_rules_java_bestpractices.html#apexassertionsshouldincludemessage');
+
+				rule = driver['rules'][1];
+				expect(rule.id).to.equal('ApexDoc');
+				expect(rule.shortDescription.text).to.satisfy(r => r.startsWith('This rule validates that:\n\n* ApexDoc comments'));
+				expect(rule.properties.category).to.equal('Documentation');
+				expect(rule.properties.severity).to.equal(3);
+				expect(rule.helpUri).to.equal('https://pmd.github.io/pmd-6.22.0/pmd_rules_java_documentation.html#apexdoc');
+
+				rule = driver['rules'][2];
+				expect(rule.id).to.equal('ApexUnitTestClassShouldHaveAsserts');
+				expect(rule.shortDescription.text).to.satisfy(r => r.startsWith(`Apex unit tests should include at least one assertion.`));
+				expect(rule.properties.category).to.equal('Best Practices');
+				expect(rule.properties.severity).to.equal(3);
+				expect(rule.helpUri).to.equal('https://pmd.github.io/pmd-6.22.0/pmd_rules_java_documentation.html#commentsize');
+
+				// Deep validation of results and rules is skipped. The code is the same as that tested in the eslint method above.
+
+				// invocations
+				expect(run['invocations']).to.have.lengthOf(1, 'Invocations');
+				const invocation = run['invocations'][0];
+				expect(invocation.executionSuccessful).to.be.true;
+				expect(invocation.toolExecutionNotifications).to.have.lengthOf(0, 'Tool Execution');
+			}
+
+			it ('Happy Path', async () => {
+				const {minSev, results, summaryMap} = await RuleResultRecombinator.recombineAndReformatResults(allFakeRuleResults, OUTPUT_FORMAT.SARIF, new Set(['eslint', 'pmd']));
+				const sarifResults: unknown[] = JSON.parse(results as string);
+				expect(sarifResults['runs']).to.have.lengthOf(2, 'Runs');
+				const runs = sarifResults['runs'];
+
+				for (let i=0; i<runs.length; i++) {
+					const run = runs[i];
+					const engine = run['tool']['driver']['name'];
+					if (engine === ENGINE.ESLINT) {
+						validateEslintSarif(run);
+					} else if (engine === ENGINE.PMD) {
+						validatePMDSarif(run);
+					} else {
+						fail(`Unexpected engine: ${engine}`);
+					}
+				}
+
+				expect(minSev).to.equal(1, 'Most severe problem');
+				expect(summaryMap.size).to.equal(2, 'Each supposedly executed engine needs a summary');
+				expect(summaryMap.get('pmd')).to.deep.equal({fileCount: 1, violationCount: 3}, 'PMD summary should be correct');
+				expect(summaryMap.get('eslint')).to.deep.equal({fileCount: 2, violationCount: 3}, 'ESLint summary should be correct');
 			});
 		});
 

--- a/test/lib/formatter/RuleResultRecombinator.test.ts
+++ b/test/lib/formatter/RuleResultRecombinator.test.ts
@@ -354,7 +354,19 @@ describe('RuleResultRecombinator', () => {
 				expect(rule.properties.severity).to.equal(3);
 				expect(rule.helpUri).to.equal('https://pmd.github.io/pmd-6.22.0/pmd_rules_java_documentation.html#commentsize');
 
-				// Deep validation of results and rules is skipped. The code is the same as that tested in the eslint method above.
+				// Deep validation of results and rules is skipped, the only thing different from the eslint results
+				// is that the ruleIndex should be different for each violation
+				expect(run['results']).to.have.lengthOf(3, 'Results');
+				const results = run['results'];
+
+				let result = results[0];
+				expect(result.ruleIndex).to.equal(0);
+
+				result = results[1];
+				expect(result.ruleIndex).to.equal(1);
+
+				result = results[2];
+				expect(result.ruleIndex).to.equal(2);
 
 				// invocations
 				expect(run['invocations']).to.have.lengthOf(1, 'Invocations');

--- a/test/lib/pmd/PmdCatalogWrapper.test.ts
+++ b/test/lib/pmd/PmdCatalogWrapper.test.ts
@@ -1,12 +1,11 @@
 import {PmdCatalogWrapper} from '../../../src/lib/pmd/PmdCatalogWrapper';
-import {PMD_VERSION} from '../../../src/lib/pmd/PmdSupport';
 import {PmdEngine} from '../../../src/lib/pmd/PmdEngine';
 import {CustomRulePathManager} from '../../../src/lib/CustomRulePathManager';
 import {Config} from '../../../src/lib/util/Config';
 import {expect} from 'chai';
 import Sinon = require('sinon');
 import path = require('path');
-import {ENGINE,LANGUAGE} from '../../../src/Constants';
+import {ENGINE,LANGUAGE,PMD_VERSION} from '../../../src/Constants';
 import {FileHandler} from '../../../src/lib/util/FileHandler';
 import {uxEvents} from '../../../src/lib/ScannerEvents';
 import { after } from 'mocha';


### PR DESCRIPTION
This formatter is based on the spec at https://docs.oasis-open.org/sarif/sarif/v2.0/csprd02/sarif-v2.0-csprd02.html and influenced by @microsoft/eslint-formatter-sarif and the PMD sarif format. The differences below are meant to make the different results more consistent.

Differences from @microsoft/eslint-formatter-sarif:
    Does not contain the optional 'artifacts' property
    Rule properties:
        Added severity
    invocations node is always present

Differences from PMD sarif formatter:
    Rule properties:
        Uses category/severity instead of ruleset/priority
    Location uri is prefixed with file://

Other changes:
    Moved PMD_VERSION to avoid circular references
    Created new formatter directory