### PR TITLE
@W-8902730@: RetireJS violations within a ZIP are now associated with…

### DIFF
--- a/src/lib/retire-js/RetireJsEngine.ts
+++ b/src/lib/retire-js/RetireJsEngine.ts
@@ -429,11 +429,16 @@ export class RetireJsEngine implements RuleEngine {
 				zip.on('error', rej);
 
 				zip.on('ready', () => {
-					// Before we do the extraction, we want to map the aliased JS files within the ZIP back to the ZIP itself,
-					// since the ZIP is the real original file.
+					// Before we do the extraction, we want to give each zipped JS file an alias corresponding to its
+					// location within the ZIP. That way, each file will produce unique violations, instead of all files
+					// within the ZIP producing identical violations.
 					for (const {name} of Object.values(zip.entries())) {
 						if (path.extname(name).toLowerCase() === '.js') {
-							this.originalFilesByAlias.set(path.join(zipDst, name), zipSrc);
+							const aliasPath = path.join(zipDst, name);
+							// The "original path" will be the ZIP's original path, suffixed with the file's relative path
+							// within the ZIP.
+							const originalPath = `${zipSrc}:${name}`;
+							this.originalFilesByAlias.set(aliasPath, originalPath);
 						}
 					}
 					// Passing null as the first parameter to this method causes it to extract the entire ZIP.

--- a/test/lib/retire-js/RetireJsEngine.test.ts
+++ b/test/lib/retire-js/RetireJsEngine.test.ts
@@ -146,13 +146,18 @@ describe('RetireJsEngine', () => {
 			// Verify that files were actually extracted from AngularJS.zip, and that every JS file has the expected alias.
 			const extractedAngular = await globby(normalize(path.join(tmpDir, '**', 'AngularJS-extracted', '**', '*')));
 			expect(extractedAngular.length).to.be.greaterThan(0, 'Should be some copied Angular files');
+
 			for (const subpath of extractedAngular) {
 				if (path.extname(subpath).toLowerCase() === '.js') {
-					// We want to make sure that each file in the ZIP was aliased back to its relative position within the ZIP.
-					// We'll use everything after AngularJS-extracted to build the expected directories.
+					// The paths returned by globby are normalized, but the aliases are denormalized.
+					const denormedPath = subpath.replace(/\//g, path.sep);
+
+					// The path to the ZIP is denormalized, but the supplemental relative path after that is normalized.
+					// Create that normalized path segment so we can use it to generate the expected output.
 					const relativeRoot = `AngularJS-extracted`;
 					const relativeRootStartPoint = subpath.lastIndexOf(relativeRoot) + relativeRoot.length + 1;
-					expect(testEngine.dealiasFile(subpath)).to.equal(`${angularPath}:${subpath.slice(relativeRootStartPoint)}`);
+					const expectedTruePath = `${angularPath}:${subpath.slice(relativeRootStartPoint)}`;
+					expect(testEngine.dealiasFile(denormedPath)).to.equal(expectedTruePath);
 				}
 			}
 
@@ -161,9 +166,15 @@ describe('RetireJsEngine', () => {
 			expect(extractedLeaflet.length).to.be.greaterThan(0, 'Should be some copied Leaflet files');
 			for (const subpath of extractedLeaflet) {
 				if (path.extname(subpath).toLowerCase() === '.js') {
+					// The paths returned by globby are normalized, but the aliases are denormalized.
+					const denormedPath = subpath.replace(/\//g, path.sep);
+
+					// The path to the ZIP is denormalized, but the supplemental relative path after that is normalized.
+					// Create that normalized path segment so we can use it to generate the expected output.
 					const relativeRoot = `leaflet-extracted`;
 					const relativeRootStartPoint = subpath.lastIndexOf(relativeRoot) + relativeRoot.length + 1;
-					expect(testEngine.dealiasFile(subpath)).to.equal(`${leafletPath}:${subpath.slice(relativeRootStartPoint)}`);
+					const expectedTruePath = `${leafletPath}:${subpath.slice(relativeRootStartPoint)}`;
+					expect(testEngine.dealiasFile(denormedPath)).to.equal(expectedTruePath);
 				}
 			}
 			// Nothing should be extracted from RandomMeme, because it's a picture.

--- a/test/lib/retire-js/RetireJsEngine.test.ts
+++ b/test/lib/retire-js/RetireJsEngine.test.ts
@@ -147,8 +147,10 @@ describe('RetireJsEngine', () => {
 			const extractedAngular = await globby(normalize(path.join(tmpDir, '**', 'AngularJS-extracted', '**', '*')));
 			expect(extractedAngular.length).to.be.greaterThan(0, 'Should be some copied Angular files');
 
+			let fileCounter = 0;
 			for (const subpath of extractedAngular) {
 				if (path.extname(subpath).toLowerCase() === '.js') {
+					fileCounter += 1;
 					// The paths returned by globby are normalized, but the aliases are denormalized.
 					const denormedPath = subpath.replace(/\//g, path.sep);
 
@@ -160,12 +162,15 @@ describe('RetireJsEngine', () => {
 					expect(testEngine.dealiasFile(denormedPath)).to.equal(expectedTruePath);
 				}
 			}
+			expect(fileCounter).to.be.at.least(1, 'At least one JS file should be pulled from AngularJS');
 
 			// Same verification as above.
+			fileCounter = 0;
 			const extractedLeaflet = await globby(normalize(path.join(tmpDir, '**', 'leaflet-extracted', '**', '*')));
 			expect(extractedLeaflet.length).to.be.greaterThan(0, 'Should be some copied Leaflet files');
 			for (const subpath of extractedLeaflet) {
 				if (path.extname(subpath).toLowerCase() === '.js') {
+					fileCounter += 1;
 					// The paths returned by globby are normalized, but the aliases are denormalized.
 					const denormedPath = subpath.replace(/\//g, path.sep);
 
@@ -177,6 +182,7 @@ describe('RetireJsEngine', () => {
 					expect(testEngine.dealiasFile(denormedPath)).to.equal(expectedTruePath);
 				}
 			}
+			expect(fileCounter).to.be.at.least(1, 'At least one JS file is pulled from leaflet');
 			// Nothing should be extracted from RandomMeme, because it's a picture.
 			const extractedRandomMeme = await globby(normalize(path.join(tmpDir, '**', 'RandomMeme-extracted', '**', '*')));
 			expect(extractedRandomMeme.length).to.equal(0, 'Somehow extracted files from a PNG');


### PR DESCRIPTION
… specific files instead of the ZIP as a whole, eliminating seemingly duplicated violations.