### PR TITLE
@W-9266722@ Update fingerprint used for certificate pinning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,6 +231,9 @@ jobs:
           tag: latest
           use_tarfile: true
       - release-management/create-github-release
+    environment:
+      # Fingerprint for developer.salesforce.com
+      SFDX_DEVELOPER_TRUSTED_FINGERPRINT: "3E:6C:CA:83:EA:88:92:E0:6C:7C:5C:ED:43:A6:0A:6C:33:74:5E:7F"
 
 workflows:
   version: 2.1


### PR DESCRIPTION
SFDX_DEVELOPER_TRUSTED_FINGERPRINT is used by the sfdx-trust plugin to pin the developer.salesforce.com certificate. This
change updates the value to match the latest certificate.

Based on instructions here
https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-job
https://circleci.com/docs/2.0/configuration-reference/#environment