### PR TITLE
@W-8063535@ Changes to severity-threshold message + fixing related tests

### DIFF
--- a/messages/run.js
+++ b/messages/run.js
@@ -46,7 +46,8 @@ module.exports = {
 		"engineSummaryTemplate": "Executed %s, found %s violation(s) across %s file(s).",
 		"writtenToOutFile": "Rule violations have been written to %s.",
 		"writtenToConsole": "Rule violations logged to console above.",
-		"sevDetectionSummary": "Detected rule violations of severity %s or more severe.",
+		"sevDetectionSummary": "Detected rule violations of severity %s or lower.",
+		"sevThresholdSummary": "Detected rule violations of severity %s or more severe.",
 		"pleaseSeeAbove": "Please see the logs above.",
 		"filtersIgnoredCustom": "Rule filters will be ignored by engines that are run with custom config (using --pmdconfig or --eslintconfig flags). Please modify your config file to reflect the filtering you need."
 	},

--- a/src/lib/util/RunOutputProcessor.ts
+++ b/src/lib/util/RunOutputProcessor.ts
@@ -110,9 +110,16 @@ export class RunOutputProcessor {
 			msgParts = [...msgParts, ...summaryMsgs];
 		}
 		// If we're supposed to throw an exception in response to violations, we need an extra piece of summary.
-		if ((minSev > 0 && this.opts.violationsCauseException) || (this.shouldErrorForSeverity(minSev, this.opts.severityForError))) {
+		// Handles deprecated flag --violations-cause-error
+		if (minSev > 0 && this.opts.violationsCauseException) {
 			msgParts.push(runMessages.getMessage('output.sevDetectionSummary', [minSev]));
 		}
+
+		// Summary to print with --severity-threshold flag
+		if (this.shouldErrorForSeverity(minSev, this.opts.severityForError)) {
+			msgParts.push(runMessages.getMessage('output.sevThresholdSummary', [this.opts.severityForError]));
+		}
+
 		return msgParts;
 	}
 

--- a/test/commands/scanner/run.severity.test.ts
+++ b/test/commands/scanner/run.severity.test.ts
@@ -21,7 +21,7 @@ describe('scanner:run', function () {
 				])
 				.it('When no violations are found, no error is thrown', ctx => {
 					expect(ctx.stdout).to.contain(runMessages.getMessage('output.noViolationsDetected', ['pmd']));
-					expect(ctx.stderr).to.not.contain(runMessages.getMessage('output.sevDetectionSummary', ['3']), 'Error should not be present');
+					expect(ctx.stderr).to.not.contain(runMessages.getMessage('output.sevThresholdSummary', ['3']), 'Error should not be present');
 				});
 
 			setupCommandTest
@@ -40,7 +40,7 @@ describe('scanner:run', function () {
                         }
                     }
 
-                    expect(ctx.stderr).not.to.contain(runMessages.getMessage('output.sevDetectionSummary', ['1']));
+                    expect(ctx.stderr).not.to.contain(runMessages.getMessage('output.sevThresholdSummary', ['1']));
                 
 				});
 
@@ -59,7 +59,7 @@ describe('scanner:run', function () {
                             expect(output[i].violations[j].normalizedSeverity).to.equal(3);
                         }
                     }
-                    expect(ctx.stderr).to.contain(runMessages.getMessage('output.sevDetectionSummary', ['3']));
+                    expect(ctx.stderr).to.contain(runMessages.getMessage('output.sevThresholdSummary', ['3']));
 
 				});
 

--- a/test/lib/util/RunOutputProcessor.test.ts
+++ b/test/lib/util/RunOutputProcessor.test.ts
@@ -217,7 +217,7 @@ ${runMessages.getMessage('output.writtenToConsole')}`;
 						Sinon.assert.callCount(logSpy, 0);
 						const expectedTableSummary = `${runMessages.getMessage('output.engineSummaryTemplate', ['pmd', 1, 1])}
 ${runMessages.getMessage('output.engineSummaryTemplate', ['eslint-typescript', 2, 1])}
-${runMessages.getMessage('output.sevDetectionSummary', [1])}
+${runMessages.getMessage('output.sevThresholdSummary', [1])}
 ${runMessages.getMessage('output.writtenToConsole')}`;
 						expect(e.message).to.equal(expectedTableSummary, 'Exception message incorrectly formed');
 					}
@@ -247,7 +247,7 @@ ${runMessages.getMessage('output.writtenToConsole')}`;
 					expect(output).to.equal(FAKE_CSV_OUTPUT, 'CSV should be returned as a string');
 				});
 
-				it('Throws exception on request when violations are found', async () => {
+				it('Throws severity-based exception on request', async () => {
 					const opts: RunOutputOptions = {
 						format: OUTPUT_FORMAT.CSV,
 						severityForError: 2,
@@ -264,11 +264,11 @@ ${runMessages.getMessage('output.writtenToConsole')}`;
 						Sinon.assert.callCount(tableSpy, 0);
 						Sinon.assert.callCount(logSpy, 1);
 						Sinon.assert.calledWith(logSpy, FAKE_CSV_OUTPUT);
-						expect(e.message).to.equal(runMessages.getMessage('output.sevDetectionSummary', [1]), 'Exception message incorrectly formed');
+						expect(e.message).to.equal(runMessages.getMessage('output.sevThresholdSummary', [2]), 'Exception message incorrectly formed');
 					}
 				});
 
-				it('Throws severity-based exception on request', async () => {
+				it('Throws exception on request when violations are found', async () => {
 					const opts: RunOutputOptions = {
 						format: OUTPUT_FORMAT.CSV,
 						violationsCauseException: true
@@ -350,7 +350,7 @@ ${runMessages.getMessage('output.writtenToConsole')}`;
 						Sinon.assert.callCount(tableSpy, 0);
 						Sinon.assert.callCount(logSpy, 1);
 						Sinon.assert.calledWith(logSpy, FAKE_JSON_OUTPUT);
-						expect(e.message).to.equal(runMessages.getMessage('output.sevDetectionSummary', [1]), 'Exception message incorrectly formed');
+						expect(e.message).to.equal(runMessages.getMessage('output.sevThresholdSummary', [1]), 'Exception message incorrectly formed');
 					}
 				});
 			});
@@ -455,7 +455,7 @@ ${runMessages.getMessage('output.writtenToOutFile', [fakeFilePath])}`;
 						expect(fakeFiles[0]).to.deep.equal({path: fakeFilePath, data: FAKE_CSV_OUTPUT}, 'File-write expectations defied');
 						const expectedCsvSummary = `${runMessages.getMessage('output.engineSummaryTemplate', ['pmd', 1, 1])}
 ${runMessages.getMessage('output.engineSummaryTemplate', ['eslint-typescript', 2, 1])}
-${runMessages.getMessage('output.sevDetectionSummary', [1])}
+${runMessages.getMessage('output.sevThresholdSummary', [1])}
 ${runMessages.getMessage('output.writtenToOutFile', [fakeFilePath])}`;
 						expect(e.message).to.equal(expectedCsvSummary, 'Summary was wrong');
 					}


### PR DESCRIPTION
1. Reverting error message of `--violations-cause-error` to the original value
2. Including input flag value as a part of output message for `--severity-threshold` 
3. Fixing related tests