### PR TITLE
@W-9625690@: Added github action to run heartbeat script against production plugin.

### DIFF
--- a/.github/workflows/production-heartbeat.yml
+++ b/.github/workflows/production-heartbeat.yml
@@ -1,0 +1,94 @@
+name: production-heartbeat
+on:
+  schedule:
+    # Times are UTC
+    - cron: '45 1,5,9,13,17,21 * * *'
+jobs:
+  production-heartbeat:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [{vm: ubuntu-latest, exe: .sh}, {vm: windows-2019, exe: .cmd}]
+        node: ['lts/*']
+    runs-on: ${{ matrix.os.vm }}
+    steps:
+      # === Setup. We need to get the code, set up nodejs, and create the results directory. ===
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+      - run: mkdir smoke-test-results
+      # === Make three attempts to install sfdx through npm ===
+      - name: SFDX install first try
+        id: sfdx_first_try
+        continue-on-error: true # Retry after first failure
+        run: npm install -g sfdx-cli
+      - name: SFDX install second try
+        if: ${{ steps.sfdx_first_try.outcome == 'failure' }}
+        id: sfdx_second_try
+        continue-on-error: true # Retry after second failure
+        run: npm install -g sfdx-cli
+      - name: SFDX install third try
+        if: ${{ steps.sfdx_second_try.outcome == 'failure' }}
+        id: sfdx_third_try
+        run: npm install -g sfdx-cli
+
+      # === Make three attempts to install the scanner plugin ===
+      - name: Scanner install first try
+        id: scanner_first_try
+        continue-on-error: true # Retry after first failure
+        run: echo y | sfdx plugins:install @salesforce/sfdx-scanner
+      - name: Scanner install second try
+        if: ${{ steps.scanner_first_try.outcome == 'failure' }}
+        id: scanner_second_try
+        continue-on-error: true # Retry after second failure
+        run: echo y | sfdx plugins:install @salesforce/sfdx-scanner
+      - name: Scanner install third try
+        if: ${{ steps.scanner_second_try.outcome == 'failure' }}
+        id: scanner_third_try
+        run: echo y | sfdx plugins:install @salesforce/sfdx-scanner
+
+      # === Make three attempts to execute the smoke tests ===
+      - name: Smoke test first try
+        id: smoke_test_first_try
+        continue-on-error: true # Retry after first failure
+        run: smoke-tests/smoke-test${{ matrix.os.exe }} sfdx
+      - name: Smoke test second try
+        if: ${{ steps.smoke_test_first_try.outcome == 'failure' }}
+        id: smoke_test_second_try
+        continue-on-error: true # Retry after second failure
+        run: smoke-tests/smoke-test${{ matrix.os.exe }} sfdx
+      - name: Smoke test third try
+        if: ${{ steps.smoke_test_second_try.outcome == 'failure' }}
+        id: smoke_test_third_try
+        run: smoke-tests/smoke-test${{ matrix.os.exe }} sfdx
+
+      # === Report any failures ===
+      - name: Report failures
+        if: ${{ failure() }}
+        shell: bash
+        env:
+          # True if any of the SFDX install attempts have a status of "success"
+          SFDX_STATUS: ${{ steps.sfdx_first_try.outcome == 'success' || steps.sfdx_second_try.outcome == 'success' || steps.sfdx_third_try.outcome == 'success' }}
+          # True if any of the scanner install attempts have a status of "success"
+          SCANNER_STATUS: ${{ steps.scanner_first_try.outcome == 'success' || steps.scanner_second_try.outcome == 'success' || steps.scanner_third_try.outcome == 'success' }}
+          # True if any of the smoke test attempts have a status of "success"
+          SMOKE_TEST_STATUS: ${{ steps.smoke_test_first_try.outcome == 'success' || steps.smoke_test_second_try.outcome == 'success' || steps.smoke_test_third_try.outcome == 'success' }}
+          # A link to this run
+          RUN_LINK: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          curl --request POST \
+          --data '{"payload": {
+            "summary": "Production heartbeat script failed on ${{ runner.os }}",
+            "source": "Github Actions",
+            "severity": "critical",
+            "custom_details": "SFDX install succeeded: ${{ env.SFDX_STATUS }}. Scanner install succeeded: ${{ env.SCANNER_STATUS }}. Smoke test run succeeded: ${{ env.SMOKE_TEST_STATUS }}"
+          },
+          "links": [{
+            "href": "${{ env.RUN_LINK }}",
+            "text": "Link to action execution"
+          }],
+          "event_action": "trigger",
+          "routing_key": "${{ secrets.PAGERDUTY_HEARTBEAT_KEY }}"
+          }' \
+          https://events.pagerduty.com/v2/enqueue

--- a/.github/workflows/production-heartbeat.yml
+++ b/.github/workflows/production-heartbeat.yml
@@ -64,6 +64,14 @@ jobs:
         id: smoke_test_third_try
         run: smoke-tests/smoke-test${{ matrix.os.exe }} sfdx
 
+      # === Upload the smoke-test-results folder as an artifact ===
+      - name: Upload smoke-test-results folder as artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: smoke-test-results-${{ runner.os }}
+          path: smoke-test-results
+
       # === Report any failures ===
       - name: Report failures
         if: ${{ failure() }}

--- a/.github/workflows/production-heartbeat.yml
+++ b/.github/workflows/production-heartbeat.yml
@@ -22,20 +22,18 @@ jobs:
       # === Make three attempts to install sfdx through npm ===
       - name: Install SFDX
         id: sfdx_install
-        # Sleep for 5 seconds between attempts, since it's possible that problems are network-related.
-        run: npm install -g sfdx-cli || (sleep 5 && npm install -g sfdx-cli) || (sleep 5 && npm install -g sfdx-cli)
+        # If the first attempt fails, wait a minute and try again. After a second failure, wait 5 minutes then try again. Then give up.
+        run: npm install -g sfdx-cli || (sleep 60 && npm install -g sfdx-cli) || (sleep 300 && npm install -g sfdx-cli)
 
-      # === Make three attempts to install the scanner plugin ===
+      # === Attempt to install the scanner plugin ===
       - name: Install Scanner Plugin
         id: scanner_install
-        # Sleep for 5 seconds between attempts, since it's possible that problems are network-related.
-        run: sfdx plugins:install @salesforce/sfdx-scanner || (sleep 5 && sfdx plugins:install @salesforce/sfdx-scanner) || (sleep 5 && sfdx plugins:install @salesforce/sfdx-scanner)
+        run: sfdx plugins:install @salesforce/sfdx-scanner
 
-      # === Make three attempts to execute the smoke tests ===
+      # === Attempt to execute the smoke tests ===
       - name: Run smoke tests
         id: smoke_tests
-        # Sleep for 5 seconds between attempts, since it's possible that problems are network-related.
-        run: smoke-tests/smoke-test${{ matrix.os.exe }} sfdx || (sleep 5 && smoke-tests/smoke-test${{ matrix.os.exe }} sfdx) || (sleep 5 && smoke-tests/smoke-test${{ matrix.os.exe }} sfdx)
+        run: smoke-tests/smoke-test${{ matrix.os.exe }} sfdx
 
       # === Upload the smoke-test-results folder as an artifact ===
       - name: Upload smoke-test-results folder as artifact
@@ -45,26 +43,28 @@ jobs:
           name: smoke-test-results-${{ runner.os }}
           path: smoke-test-results
 
+# This part is commented out for now, so we can run the script for a day or two without risking blowing up PagerDuty.
+# Once we've seen that it works properly, we'll re-enable the alerts.
       # === Report any failures ===
-      - name: Report failures
-        if: ${{ failure() }}
-        shell: bash
-        env:
-          # A link to this run
-          RUN_LINK: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          curl --request POST \
-          --data '{"payload": {
-            "summary": "Production heartbeat script failed on ${{ runner.os }}",
-            "source": "Github Actions",
-            "severity": "critical",
-            "custom_details": "SFDX install: ${{ steps.sfdx_install.outcome }}. Scanner install: ${{ steps.scanner_install.outcome }}. Smoke tests: ${{ steps.smoke_tests.outcome }}"
-          },
-          "links": [{
-            "href": "${{ env.RUN_LINK }}",
-            "text": "Link to action execution"
-          }],
-          "event_action": "trigger",
-          "routing_key": "${{ secrets.PAGERDUTY_HEARTBEAT_KEY }}"
-          }' \
-          https://events.pagerduty.com/v2/enqueue
+#      - name: Report failures
+#        if: ${{ failure() }}
+#        shell: bash
+#        env:
+#          # A link to this run
+#          RUN_LINK: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+#        run: |
+#          curl --request POST \
+#          --data '{"payload": {
+#            "summary": "Production heartbeat script failed on ${{ runner.os }}",
+#            "source": "Github Actions",
+#            "severity": "critical",
+#            "custom_details": "SFDX install: ${{ steps.sfdx_install.outcome }}. Scanner install: ${{ steps.scanner_install.outcome }}. Smoke tests: ${{ steps.smoke_tests.outcome }}"
+#          },
+#          "links": [{
+#            "href": "${{ env.RUN_LINK }}",
+#            "text": "Link to action execution"
+#          }],
+#          "event_action": "trigger",
+#          "routing_key": "${{ secrets.PAGERDUTY_HEARTBEAT_KEY }}"
+#          }' \
+#          https://events.pagerduty.com/v2/enqueue

--- a/.github/workflows/production-heartbeat.yml
+++ b/.github/workflows/production-heartbeat.yml
@@ -20,49 +20,22 @@ jobs:
           node-version: ${{ matrix.node }}
       - run: mkdir smoke-test-results
       # === Make three attempts to install sfdx through npm ===
-      - name: SFDX install first try
-        id: sfdx_first_try
-        continue-on-error: true # Retry after first failure
-        run: npm install -g sfdx-cli
-      - name: SFDX install second try
-        if: ${{ steps.sfdx_first_try.outcome == 'failure' }}
-        id: sfdx_second_try
-        continue-on-error: true # Retry after second failure
-        run: npm install -g sfdx-cli
-      - name: SFDX install third try
-        if: ${{ steps.sfdx_second_try.outcome == 'failure' }}
-        id: sfdx_third_try
-        run: npm install -g sfdx-cli
+      - name: Install SFDX
+        id: sfdx_install
+        # Sleep for 5 seconds between attempts, since it's possible that problems are network-related.
+        run: npm install -g sfdx-cli || (sleep 5 && npm install -g sfdx-cli) || (sleep 5 && npm install -g sfdx-cli)
 
       # === Make three attempts to install the scanner plugin ===
-      - name: Scanner install first try
-        id: scanner_first_try
-        continue-on-error: true # Retry after first failure
-        run: echo y | sfdx plugins:install @salesforce/sfdx-scanner
-      - name: Scanner install second try
-        if: ${{ steps.scanner_first_try.outcome == 'failure' }}
-        id: scanner_second_try
-        continue-on-error: true # Retry after second failure
-        run: echo y | sfdx plugins:install @salesforce/sfdx-scanner
-      - name: Scanner install third try
-        if: ${{ steps.scanner_second_try.outcome == 'failure' }}
-        id: scanner_third_try
-        run: echo y | sfdx plugins:install @salesforce/sfdx-scanner
+      - name: Install Scanner Plugin
+        id: scanner_install
+        # Sleep for 5 seconds between attempts, since it's possible that problems are network-related.
+        run: sfdx plugins:install @salesforce/sfdx-scanner || (sleep 5 && sfdx plugins:install @salesforce/sfdx-scanner) || (sleep 5 && sfdx plugins:install @salesforce/sfdx-scanner)
 
       # === Make three attempts to execute the smoke tests ===
-      - name: Smoke test first try
-        id: smoke_test_first_try
-        continue-on-error: true # Retry after first failure
-        run: smoke-tests/smoke-test${{ matrix.os.exe }} sfdx
-      - name: Smoke test second try
-        if: ${{ steps.smoke_test_first_try.outcome == 'failure' }}
-        id: smoke_test_second_try
-        continue-on-error: true # Retry after second failure
-        run: smoke-tests/smoke-test${{ matrix.os.exe }} sfdx
-      - name: Smoke test third try
-        if: ${{ steps.smoke_test_second_try.outcome == 'failure' }}
-        id: smoke_test_third_try
-        run: smoke-tests/smoke-test${{ matrix.os.exe }} sfdx
+      - name: Run smoke tests
+        id: smoke_tests
+        # Sleep for 5 seconds between attempts, since it's possible that problems are network-related.
+        run: smoke-tests/smoke-test${{ matrix.os.exe }} sfdx || (sleep 5 && smoke-tests/smoke-test${{ matrix.os.exe }} sfdx) || (sleep 5 && smoke-tests/smoke-test${{ matrix.os.exe }} sfdx)
 
       # === Upload the smoke-test-results folder as an artifact ===
       - name: Upload smoke-test-results folder as artifact
@@ -77,12 +50,9 @@ jobs:
         if: ${{ failure() }}
         shell: bash
         env:
-          # True if any of the SFDX install attempts have a status of "success"
-          SFDX_STATUS: ${{ steps.sfdx_first_try.outcome == 'success' || steps.sfdx_second_try.outcome == 'success' || steps.sfdx_third_try.outcome == 'success' }}
-          # True if any of the scanner install attempts have a status of "success"
-          SCANNER_STATUS: ${{ steps.scanner_first_try.outcome == 'success' || steps.scanner_second_try.outcome == 'success' || steps.scanner_third_try.outcome == 'success' }}
-          # True if any of the smoke test attempts have a status of "success"
-          SMOKE_TEST_STATUS: ${{ steps.smoke_test_first_try.outcome == 'success' || steps.smoke_test_second_try.outcome == 'success' || steps.smoke_test_third_try.outcome == 'success' }}
+          SFDX_STATUS: ${{ steps.sfdx_install.outcome == 'success' }}
+          SCANNER_STATUS: ${{ steps.scanner_install.outcome == 'success' }}
+          SMOKE_TEST_STATUS: ${{ steps.smoke_tests.outcome == 'success' }}
           # A link to this run
           RUN_LINK: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |

--- a/.github/workflows/production-heartbeat.yml
+++ b/.github/workflows/production-heartbeat.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   production-heartbeat:
     strategy:
+      # By default, if any job in a matrix fails, all other jobs are immediately cancelled. This makes the jobs run to completion instead.
       fail-fast: false
       matrix:
         os: [{vm: ubuntu-latest, exe: .sh}, {vm: windows-2019, exe: .cmd}]

--- a/.github/workflows/production-heartbeat.yml
+++ b/.github/workflows/production-heartbeat.yml
@@ -50,9 +50,6 @@ jobs:
         if: ${{ failure() }}
         shell: bash
         env:
-          SFDX_STATUS: ${{ steps.sfdx_install.outcome == 'success' }}
-          SCANNER_STATUS: ${{ steps.scanner_install.outcome == 'success' }}
-          SMOKE_TEST_STATUS: ${{ steps.smoke_tests.outcome == 'success' }}
           # A link to this run
           RUN_LINK: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
@@ -61,7 +58,7 @@ jobs:
             "summary": "Production heartbeat script failed on ${{ runner.os }}",
             "source": "Github Actions",
             "severity": "critical",
-            "custom_details": "SFDX install succeeded: ${{ env.SFDX_STATUS }}. Scanner install succeeded: ${{ env.SCANNER_STATUS }}. Smoke test run succeeded: ${{ env.SMOKE_TEST_STATUS }}"
+            "custom_details": "SFDX install: ${{ steps.sfdx_install.outcome }}. Scanner install: ${{ steps.scanner_install.outcome }}. Smoke tests: ${{ steps.smoke_tests.outcome }}"
           },
           "links": [{
             "href": "${{ env.RUN_LINK }}",

--- a/smoke-tests/SmokeTestGenerator.js
+++ b/smoke-tests/SmokeTestGenerator.js
@@ -51,6 +51,7 @@ function generateScriptBody(isBash, delim) {
 
 	// Declare an array with all of the commands we intend to execute.
 	const commands = [
+		`echo "====== STARTING SMOKE TEST ======"`,
 		`echo "==== List all rules w/out filters ===="`,
 		`${exeName} scanner:rule:list`,
 		`echo "==== Filter rules by engine ===="`,
@@ -82,7 +83,7 @@ function generateScriptBody(isBash, delim) {
 	// In a cmd script, you need to prepend everything with "call" in order to make sure that the script continues,
 	// and you need to postfix it with another snippet to make it actually exit when an error is encountered.
 	if (!isBash) {
-		for (let i = 1; i < commands.length; i += 2) {
+		for (let i = 2; i < commands.length; i += 2) {
 			commands[i] = "call " + commands[i] + " || exit /b 1";
 		}
 	}

--- a/smoke-tests/smoke-test.cmd
+++ b/smoke-tests/smoke-test.cmd
@@ -6,6 +6,7 @@ REM the plugin is approximately stable.
 REM DO NOT EDIT THIS SCRIPT DIRECTLY! INSTEAD, MAKE CHANGES IN ./smoke-tests/SmokeTestGenerator.js AND RERUN THAT SCRIPT
 REM FROM THE PROJECT ROOT!
 SET EXE_NAME=%1
+echo "====== STARTING SMOKE TEST ======"
 echo "==== List all rules w/out filters ===="
 call %EXE_NAME% scanner:rule:list || exit /b 1
 echo "==== Filter rules by engine ===="

--- a/smoke-tests/smoke-test.sh
+++ b/smoke-tests/smoke-test.sh
@@ -7,6 +7,7 @@
 # FROM THE PROJECT ROOT!
 set -e
 EXE_NAME=$1
+echo "====== STARTING SMOKE TEST ======"
 echo "==== List all rules w/out filters ===="
 $EXE_NAME scanner:rule:list
 echo "==== Filter rules by engine ===="


### PR DESCRIPTION
My testing was done in a separate PR, #471, configured to run the script on command instead of on a schedule, and to send alerts to my personal PagerDuty service.

[This](https://github.com/forcedotcom/sfdx-scanner/actions/runs/1057107799) is a link to a run where everything ran properly and no alerts were created.

[This](https://github.com/forcedotcom/sfdx-scanner/actions/runs/1057255237) is a link to a run where the first attempt to install sfdx was replaced with `exit 1`, forcing that attempt to fail. The second attempt succeeds, the test proceeds as normal, and no alerts are created.

[This](https://github.com/forcedotcom/sfdx-scanner/actions/runs/1057231745) is a link to a run where all three attempts to install sfdx were replaced with `exit 1`, forcing that step to fail, and here's a screenshot of the alerts that were created.
![Screen Shot 2021-07-22 at 1 38 36 PM (2)](https://user-images.githubusercontent.com/4054488/126692024-54cb0ea9-ad36-47b6-868c-b4cc394c53f4.png)

[This](https://github.com/forcedotcom/sfdx-scanner/actions/runs/1057272439) is a link to a run where only `smoke-test.cmd` has been changed to always throw an error, and here's a screenshot of the alert that was created.
![Screen Shot 2021-07-22 at 1 58 58 PM (2)](https://user-images.githubusercontent.com/4054488/126694534-4325c6eb-9234-4898-b59d-693ce4472910.png)

[This](https://github.com/forcedotcom/sfdx-scanner/actions/runs/1057296033) is a link to a run where only `smoke-test.sh` has been changed to always throw an error, and here's a screenshot of the alert that was created.
![Screen Shot 2021-07-22 at 2 03 58 PM (2)](https://user-images.githubusercontent.com/4054488/126695178-7516987f-858b-49e8-888e-38998524a5dc.png)

[This](https://github.com/forcedotcom/sfdx-scanner/actions/runs/1057360016) is a link to a run after I started storing the `smoke-test-results` folder as an artifact. The jobs' artifacts have distinct names, and the Linux artifact only has one of the result files since it fails on the second `scanner:run` command.