### PR TITLE
@W-10079694@: Remove dependency on NPX, thereby fixing failing tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,6 +244,12 @@ jobs:
                 os: windows
                 lts: false
 
+      # The `setup` job is in a Unix environment. Calling `yarn` in that context adds bash files to `node_modules/.bin`,
+      # but Windows also requires `.cmd` files. So we re-run `yarn` here before running our tests.
+      # NOTE: This is only required for the Windows unit tests, not the tarball test, because the latter already has
+      # everything it needs in the tarball.
+      - run: yarn --ignore-scripts
+
       - run: mkdir test-results
 
       # Unit tests

--- a/package.json
+++ b/package.json
@@ -110,8 +110,8 @@
 		"build": "./gradlew build",
 		"prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
 		"postpack": "rm -f oclif.manifest.json",
-		"lint": "npx eslint ./src --ext .ts",
-		"test": "./gradlew test && npx --always-spawn nyc mocha --timeout 10000 --retries 5 \"./test/**/*.test.ts\"",
+		"lint": "eslint ./src --ext .ts",
+		"test": "./gradlew test && nyc mocha --timeout 10000 --retries 5 \"./test/**/*.test.ts\"",
 		"coverage": "nyc report --reporter text",
 		"version": "oclif-dev readme && git add README.md"
 	}


### PR DESCRIPTION
This PR does the following:
- Adds a `yarn --ignore-scripts` call to the `windows-unit-tests` CircleCI job, so that our `yarn` scripts can succeed without requiring the use of `npx`.
[This](https://app.circleci.com/pipelines/github/forcedotcom/sfdx-scanner/2067/workflows/7e1ab193-9e49-4ccb-ae16-3d4e02fbc822) is a link to a CircleCI build that was modified to run `windows-unit-tests` with both `current` and `lts` node versions, and since both test flows passed, we can be confident that this change fixes the failures without introducing any new problems.