### PR TITLE
@W-10302014@: Updated heartbeat GHA with support for env-vars to auto-fail script

### DIFF
--- a/.github/workflows/production-heartbeat.yml
+++ b/.github/workflows/production-heartbeat.yml
@@ -84,8 +84,7 @@ jobs:
       # === Attempt to execute the smoke tests ===
       - name: Run smoke tests
         id: smoke_tests
-        run: |
-          smoke-tests/smoke-test${{ matrix.os.exe }} sfdx
+        run: smoke-tests/smoke-test${{ matrix.os.exe }} sfdx
 
       # === Upload the smoke-test-results folder as an artifact ===
       - name: Upload smoke-test-results folder as artifact
@@ -116,7 +115,7 @@ jobs:
           # A link to this run, so the PagerDuty assignee can quickly get here.
           RUN_LINK: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          # GHA env-vars don't have robust conditional logic, so we'll use these if-else branches to define some bash env-vars.
+          # GHA env-vars don't have robust conditional logic, so we'll use this if-else branch to define some bash env-vars.
           if [[ ${{ env.IS_CRITICAL }} == true ]]; then
             ALERT_SEV="critical"
             ALERT_SUMMARY="Production heartbeat script failed on ${{ runner.os }}"
@@ -133,7 +132,7 @@ jobs:
             "summary": "${ALERT_SUMMARY}",
             "source": "Github Actions",
             "severity": "${ALERT_SEV}",
-            "custom_details": "SFDX install: ${{ env.CLI_INSTALL_STATUS }}. Scanner install: ${{ env.SCANNER_INSTALL_STATUS }}. Smoke tests: ${{ env.SMOKE_TESTS_STATUS }} ."
+            "custom_details": "SFDX install: ${{ env.CLI_INSTALL_STATUS }}. Scanner install: ${{ env.SCANNER_INSTALL_STATUS }}. Smoke tests: ${{ env.SMOKE_TESTS_STATUS }}."
           },
           "links": [{
             "href": "${{ env.RUN_LINK }}",

--- a/.github/workflows/production-heartbeat.yml
+++ b/.github/workflows/production-heartbeat.yml
@@ -26,15 +26,53 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - run: mkdir smoke-test-results
+
+      # === Set our environment variables, either using default values or the repo's secrets ===
+      - name: Set environment variables
+        id: env_var_setup
+        # We'll want to use bash for this, to avoid any cross-platform shenanigans
+        shell: bash
+        run: |
+          # In the following script, the use of the `echo "name=value" >> $GITHUB_ENV` structure is used to set/update
+          # environment variables. Such updates are visible to all subsequent steps.
+          #
+          # If the CLI_VERSION repo secret is set, we want to install that version of sfdx-cli, otherwise we should
+          # default to latest.
+          # Note: This can be used to intentionally fail the GHA by providing an invalid version number.
+          if [[ -z "${{ secrets.CLI_VERSION }}" ]]; then
+            echo "CLI_VERSION=latest" >> $GITHUB_ENV
+          else
+            echo "CLI_VERSION=${{ secrets.CLI_VERSION }}" >> $GITHUB_ENV
+          fi
+          # If the SCANNER_VERSION repo secret is set, we want to install that version of sfdx-scanner, otherwise we should
+          # default to latest.
+          # Note: This can be used to intentionally fail the GHA by providing an invalid version number.
+          if [[ -z "${{ secrets.SCANNER_VERSION }}" ]]; then
+            echo "SCANNER_VERSION=latest" >> $GITHUB_ENV
+          else
+            echo "SCANNER_VERSION=${{ secrets.SCANNER_VERSION }}" >> $GITHUB_ENV
+          fi
+          # If the FAIL_SMOKE_TESTS repo secret is set to ANY value, we should use 'true' and spoof a command that will
+          # forcibly fail the smoke tests. Otherwise, we should use false and a safe command.
+          # Note: This serves no purpose aside from providing a way to simulate a smoke test failure.
+          if [[ -z "${{ secrets.FAIL_SMOKE_TESTS }}" ]]; then
+            echo "FAIL_SMOKE_TESTS=false" >> $GITHUB_ENV
+            echo "PRE_SMOKE_COMMAND=echo Proceeding As Normal" >> $GITHUB_ENV
+          else
+            echo "FAIL_SMOKE_TESTS=true" >> $GITHUB_ENV
+            echo "PRE_SMOKE_COMMAND=exit 1" >> $GITHUB_ENV
+          fi
+
+
       # === Make three attempts to install sfdx through npm ===
       - name: Install SFDX
         id: sfdx_install
         # If the first attempt fails, wait a minute and try again. After a second failure, wait 5 minutes then try again. Then give up.
         # Set an output parameter, `retry_count`, indicating the number of retry attempts that were made.
         run: |
-          (echo "::set-output name=retry_count::0" && npm install -g sfdx-cli) ||
-          (echo "::set-output name=retry_count::1" && sleep 60 && npm install -g sfdx-cli) ||
-          (echo "::set-output name=retry_count::2" && sleep 300 && npm install -g sfdx-cli)
+          (echo "::set-output name=retry_count::0" && npm install -g sfdx-cli@${{ env.CLI_VERSION }}) ||
+          (echo "::set-output name=retry_count::1" && sleep 60 && npm install -g sfdx-cli@${{ env.CLI_VERSION }}) ||
+          (echo "::set-output name=retry_count::2" && sleep 300 && npm install -g sfdx-cli@${{ env.CLI_VERSION }})
 
       # === Make three attempts to install the scanner plugin through sfdx ===
       - name: Install Scanner Plugin
@@ -42,9 +80,9 @@ jobs:
         # If the first attempt fails, wait a minute and try again. After a second failure, wait 5 minutes then try again. Then give up.
         # Set an output parameter, `retry_count`, indicating the number of retry attempts that were made.
         run: |
-          (echo "::set-output name=retry_count::0" && sfdx plugins:install @salesforce/sfdx-scanner) ||
-          (echo "::set-output name=retry_count::1" && sleep 60 && sfdx plugins:install @salesforce/sfdx-scanner) ||
-          (echo "::set-output name=retry_count::2" && sleep 300 && sfdx plugins:install @salesforce/sfdx-scanner)
+          (echo "::set-output name=retry_count::0" && sfdx plugins:install @salesforce/sfdx-scanner@${{ env.SCANNER_VERSION }}) ||
+          (echo "::set-output name=retry_count::1" && sleep 60 && sfdx plugins:install @salesforce/sfdx-scanner@${{ env.SCANNER_VERSION }}) ||
+          (echo "::set-output name=retry_count::2" && sleep 300 && sfdx plugins:install @salesforce/sfdx-scanner@${{ env.SCANNER_VERSION }})
 
       # === Log the installed plugins for easier debugging ===
       - name: Log plugins
@@ -53,7 +91,10 @@ jobs:
       # === Attempt to execute the smoke tests ===
       - name: Run smoke tests
         id: smoke_tests
-        run: smoke-tests/smoke-test${{ matrix.os.exe }} sfdx
+        run: |
+          # Run the pre-smoke-command, which will either be an echo indicating that it's fine to proceed, or an early exit.
+          ${{ env.PRE_SMOKE_COMMAND }}
+          smoke-tests/smoke-test${{ matrix.os.exe }} sfdx
 
       # === Upload the smoke-test-results folder as an artifact ===
       - name: Upload smoke-test-results folder as artifact
@@ -84,13 +125,18 @@ jobs:
           # A link to this run, so the PagerDuty assignee can quickly get here.
           RUN_LINK: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          # GHA env-vars don't have robust conditional logic, so we'll use this if-else to define some bash env-vars.
+          # GHA env-vars don't have robust conditional logic, so we'll use these if-else branches to define some bash env-vars.
           if [[ ${{ env.IS_CRITICAL }} == true ]]; then
             ALERT_SEV="critical"
             ALERT_SUMMARY="Production heartbeat script failed on ${{ runner.os }}"
           else
             ALERT_SEV="info"
             ALERT_SUMMARY="Production heartbeat script succeeded with retries on ${{ runner.os }}"
+          fi
+          if [[ ${{ env.FAIL_SMOKE_TESTS }} == true ]]; then
+            SMOKE_TESTS_STATUS="${{ env.SMOKE_TESTS_STATUS }}, with use of FAIL_SMOKE_TESTS environment variable"
+          else
+            SMOKE_TESTS_STATUS=${{ env.SMOKE_TESTS_STATUS }}
           fi
           # Define a helper function to create our POST request's data, to sidestep issues with nested quotations.
           generate_post_data() {
@@ -101,7 +147,7 @@ jobs:
             "summary": "${ALERT_SUMMARY}",
             "source": "Github Actions",
             "severity": "${ALERT_SEV}",
-            "custom_details": "SFDX install: ${{ env.CLI_INSTALL_STATUS }}. Scanner install: ${{ env.SCANNER_INSTALL_STATUS }}. Smoke tests: ${{ env.SMOKE_TESTS_STATUS }}."
+            "custom_details": "SFDX install: target version ${{ env.CLI_VERSION }}; ${{ env.CLI_INSTALL_STATUS }}. Scanner install: target version ${{ env.SCANNER_VERSION }}; ${{ env.SCANNER_INSTALL_STATUS }}. Smoke tests: ${SMOKE_TESTS_STATUS}."
           },
           "links": [{
             "href": "${{ env.RUN_LINK }}",

--- a/.github/workflows/production-heartbeat.yml
+++ b/.github/workflows/production-heartbeat.yml
@@ -48,15 +48,12 @@ jobs:
           if [[ -n "${{ secrets.SCANNER_VERSION }}" ]]; then
             echo "SCANNER_VERSION=@${{ secrets.SCANNER_VERSION }}" >> $GITHUB_ENV
           fi
-          # If the FAIL_SMOKE_TESTS repo secret is set to ANY value, we should use 'true' and spoof a command that will
-          # forcibly fail the smoke tests. Otherwise, we should use false and a safe command.
+          # If the FAIL_SMOKE_TESTS repo secret is set to ANY value, we should respond by deleting the `test/test-jars`
+          # folder. The smoke tests expect this folder's contents to exist, so an invocation of `scanner:rule:add` should
+          # fail, thereby failing the smoke tests as a whole.
           # Note: This serves no purpose aside from providing a way to simulate a smoke test failure.
-          if [[ -z "${{ secrets.FAIL_SMOKE_TESTS }}" ]]; then
-            echo "FAIL_SMOKE_TESTS=false" >> $GITHUB_ENV
-            echo "PRE_SMOKE_COMMAND=echo Proceeding As Normal" >> $GITHUB_ENV
-          else
-            echo "FAIL_SMOKE_TESTS=true" >> $GITHUB_ENV
-            echo "PRE_SMOKE_COMMAND=exit 1" >> $GITHUB_ENV
+          if [[ -n "${{ secrets.FAIL_SMOKE_TESTS }}" ]]; then
+            rm -rf ./test/test-jars
           fi
 
 
@@ -88,8 +85,6 @@ jobs:
       - name: Run smoke tests
         id: smoke_tests
         run: |
-          # Run the pre-smoke-command, which will either be an echo indicating that it's fine to proceed, or an early exit.
-          ${{ env.PRE_SMOKE_COMMAND }}
           smoke-tests/smoke-test${{ matrix.os.exe }} sfdx
 
       # === Upload the smoke-test-results folder as an artifact ===
@@ -129,21 +124,6 @@ jobs:
             ALERT_SEV="info"
             ALERT_SUMMARY="Production heartbeat script succeeded with retries on ${{ runner.os }}"
           fi
-          if [[ ${{ env.FAIL_SMOKE_TESTS }} == true ]]; then
-            SMOKE_TESTS_STATUS="${{ env.SMOKE_TESTS_STATUS }}, with use of FAIL_SMOKE_TESTS environment variable"
-          else
-            SMOKE_TESTS_STATUS=${{ env.SMOKE_TESTS_STATUS }}
-          fi
-          if [[ -n "${{ env.CLI_VERSION }}" ]]; then
-            CLI_VERSION="explicitly ${{ env.CLI_VERSION }}"
-          else
-            CLI_VERSION="implicitly latest"
-          fi
-          if [[ -n "${{ env.SCANNER_VERSION }}" ]]; then
-            SCANNER_VERSION="explicitly ${{ env.SCANNER_VERSION }}"
-          else
-            SCANNER_VERSION="implicitly latest"
-          fi
           # Define a helper function to create our POST request's data, to sidestep issues with nested quotations.
           generate_post_data() {
           # This is known as a HereDoc, and it lets us declare multi-line input ending when the specified limit string,
@@ -153,7 +133,7 @@ jobs:
             "summary": "${ALERT_SUMMARY}",
             "source": "Github Actions",
             "severity": "${ALERT_SEV}",
-            "custom_details": "SFDX install: target version ${CLI_VERSION}; ${{ env.CLI_INSTALL_STATUS }}. Scanner install: target version ${SCANNER_VERSION}; ${{ env.SCANNER_INSTALL_STATUS }}. Smoke tests: ${SMOKE_TESTS_STATUS}."
+            "custom_details": "SFDX install: ${{ env.CLI_INSTALL_STATUS }}. Scanner install: ${{ env.SCANNER_INSTALL_STATUS }}. Smoke tests: ${{ env.SMOKE_TESTS_STATUS }} ."
           },
           "links": [{
             "href": "${{ env.RUN_LINK }}",

--- a/.github/workflows/production-heartbeat.yml
+++ b/.github/workflows/production-heartbeat.yml
@@ -36,21 +36,17 @@ jobs:
           # In the following script, the use of the `echo "name=value" >> $GITHUB_ENV` structure is used to set/update
           # environment variables. Such updates are visible to all subsequent steps.
           #
-          # If the CLI_VERSION repo secret is set, we want to install that version of sfdx-cli, otherwise we should
-          # default to latest.
+          # If the CLI_VERSION repo secret is set, we want to install that version of sfdx-cli, so we set an environment
+          # variable. Otherwise, we leave the environment variable unset, so it implicitly defaults to `latest`.
           # Note: This can be used to intentionally fail the GHA by providing an invalid version number.
-          if [[ -z "${{ secrets.CLI_VERSION }}" ]]; then
-            echo "CLI_VERSION=latest" >> $GITHUB_ENV
-          else
-            echo "CLI_VERSION=${{ secrets.CLI_VERSION }}" >> $GITHUB_ENV
+          if [[ -n "${{ secrets.CLI_VERSION }}" ]]; then
+            echo "CLI_VERSION=@${{ secrets.CLI_VERSION}}" >> $GITHUB_ENV
           fi
-          # If the SCANNER_VERSION repo secret is set, we want to install that version of sfdx-scanner, otherwise we should
-          # default to latest.
+          # If the SCANNER_VERSION repo secret is set, we want to install that version of sfdx-scanner, so we set an
+          # environment variable. Otherwise, we leave the environment variable unset, so it implicitly defaults to `latest`.
           # Note: This can be used to intentionally fail the GHA by providing an invalid version number.
-          if [[ -z "${{ secrets.SCANNER_VERSION }}" ]]; then
-            echo "SCANNER_VERSION=latest" >> $GITHUB_ENV
-          else
-            echo "SCANNER_VERSION=${{ secrets.SCANNER_VERSION }}" >> $GITHUB_ENV
+          if [[ -n "${{ secrets.SCANNER_VERSION }}" ]]; then
+            echo "SCANNER_VERSION=@${{ secrets.SCANNER_VERSION }}" >> $GITHUB_ENV
           fi
           # If the FAIL_SMOKE_TESTS repo secret is set to ANY value, we should use 'true' and spoof a command that will
           # forcibly fail the smoke tests. Otherwise, we should use false and a safe command.
@@ -70,9 +66,9 @@ jobs:
         # If the first attempt fails, wait a minute and try again. After a second failure, wait 5 minutes then try again. Then give up.
         # Set an output parameter, `retry_count`, indicating the number of retry attempts that were made.
         run: |
-          (echo "::set-output name=retry_count::0" && npm install -g sfdx-cli@${{ env.CLI_VERSION }}) ||
-          (echo "::set-output name=retry_count::1" && sleep 60 && npm install -g sfdx-cli@${{ env.CLI_VERSION }}) ||
-          (echo "::set-output name=retry_count::2" && sleep 300 && npm install -g sfdx-cli@${{ env.CLI_VERSION }})
+          (echo "::set-output name=retry_count::0" && npm install -g sfdx-cli${{ env.CLI_VERSION }}) ||
+          (echo "::set-output name=retry_count::1" && sleep 60 && npm install -g sfdx-cli${{ env.CLI_VERSION }}) ||
+          (echo "::set-output name=retry_count::2" && sleep 300 && npm install -g sfdx-cli${{ env.CLI_VERSION }})
 
       # === Make three attempts to install the scanner plugin through sfdx ===
       - name: Install Scanner Plugin
@@ -80,9 +76,9 @@ jobs:
         # If the first attempt fails, wait a minute and try again. After a second failure, wait 5 minutes then try again. Then give up.
         # Set an output parameter, `retry_count`, indicating the number of retry attempts that were made.
         run: |
-          (echo "::set-output name=retry_count::0" && sfdx plugins:install @salesforce/sfdx-scanner@${{ env.SCANNER_VERSION }}) ||
-          (echo "::set-output name=retry_count::1" && sleep 60 && sfdx plugins:install @salesforce/sfdx-scanner@${{ env.SCANNER_VERSION }}) ||
-          (echo "::set-output name=retry_count::2" && sleep 300 && sfdx plugins:install @salesforce/sfdx-scanner@${{ env.SCANNER_VERSION }})
+          (echo "::set-output name=retry_count::0" && sfdx plugins:install @salesforce/sfdx-scanner${{ env.SCANNER_VERSION }}) ||
+          (echo "::set-output name=retry_count::1" && sleep 60 && sfdx plugins:install @salesforce/sfdx-scanner${{ env.SCANNER_VERSION }}) ||
+          (echo "::set-output name=retry_count::2" && sleep 300 && sfdx plugins:install @salesforce/sfdx-scanner${{ env.SCANNER_VERSION }})
 
       # === Log the installed plugins for easier debugging ===
       - name: Log plugins
@@ -138,6 +134,16 @@ jobs:
           else
             SMOKE_TESTS_STATUS=${{ env.SMOKE_TESTS_STATUS }}
           fi
+          if [[ -n "${{ env.CLI_VERSION }}" ]]; then
+            CLI_VERSION="explicitly ${{ env.CLI_VERSION }}"
+          else
+            CLI_VERSION="implicitly latest"
+          fi
+          if [[ -n "${{ env.SCANNER_VERSION }}" ]]; then
+            SCANNER_VERSION="explicitly ${{ env.SCANNER_VERSION }}"
+          else
+            SCANNER_VERSION="implicitly latest"
+          fi
           # Define a helper function to create our POST request's data, to sidestep issues with nested quotations.
           generate_post_data() {
           # This is known as a HereDoc, and it lets us declare multi-line input ending when the specified limit string,
@@ -147,7 +153,7 @@ jobs:
             "summary": "${ALERT_SUMMARY}",
             "source": "Github Actions",
             "severity": "${ALERT_SEV}",
-            "custom_details": "SFDX install: target version ${{ env.CLI_VERSION }}; ${{ env.CLI_INSTALL_STATUS }}. Scanner install: target version ${{ env.SCANNER_VERSION }}; ${{ env.SCANNER_INSTALL_STATUS }}. Smoke tests: ${SMOKE_TESTS_STATUS}."
+            "custom_details": "SFDX install: target version ${CLI_VERSION}; ${{ env.CLI_INSTALL_STATUS }}. Scanner install: target version ${SCANNER_VERSION}; ${{ env.SCANNER_INSTALL_STATUS }}. Smoke tests: ${SMOKE_TESTS_STATUS}."
           },
           "links": [{
             "href": "${{ env.RUN_LINK }}",


### PR DESCRIPTION
This PR does the following:
- Adds support for three new env vars, `CLI_VERSION`, `SCANNER_VERSION`, and `FAIL_SMOKE_TESTS`.
   - If there's a repo secret with the name `CLI_VERSION`, then that value will be used as the version property for installing `sfdx-cli`, i.e. `sfdx-cli@XXXXX`. Otherwise, we'll use the default value of `latest`.
   - `SCANNER_VERSION` works the same as `CLI_VERSION`, except it applies to the `sfdx-scanner` plugin.
   - `FAIL_SMOKE_TESTS` is different. If the repo secret exists and has any non-empty value, then the smoke test step will always fail.

NOTES ABOUT TESTING:
Tests were done by using the "run workflow" button on the Actions tab to run the production script against this branch's version, with various settings of the new secrets.

Running the GHA with a nonsensical `CLI_VERSION` created these PagerDuty alerts:
- https://salesforce.pagerduty.com/incidents/Q2OHP10J2R2PGX
Instead of two incidents with one alert each, there's one incident with two alerts. I believe this is because of timing, since this scenario causes the Windows and Linux flows to fail at basically the same time.

Running the GHA with a nonsensical `SCANNER_VERSION` created these PagerDuty alerts:
- https://salesforce.pagerduty.com/incidents/Q1I0ZNRLXHYKHK (Linux)
- https://salesforce.pagerduty.com/incidents/Q1BTXYHYFTN306 (Windows)
There are two incidents because Windows takes much longer to fail than Linux does.

Running the GHA with a non-null `FAIL_SMOKE_TESTS` created these PagerDuty alerts:
- https://salesforce.pagerduty.com/incidents/Q1MNJFO22Q896X (Linux)
- https://salesforce.pagerduty.com/incidents/Q0IOQISVB6V9KZ (Windows)
There are two incidents because Windows takes much longer to fail than Linux does.

In order to verify the retry logic, I used [this version of the heartbeat script](https://github.com/forcedotcom/sfdx-scanner/blob/d/W-10302014-dev-2/.github/workflows/production-heartbeat.yml), hardcoded to fail the `sfdx-cli` install twice and succeed on the third try. A diff with this branch's version will reveal that this is the only difference. That created these two PagerDuty alerts:
- https://salesforce.pagerduty.com/incidents/Q0Q1TZT4H19WFP (Linux)
- https://salesforce.pagerduty.com/incidents/Q2UC2TWCP10JOF (Windows)
There are two incidents because Windows takes much longer than Linux does.