### PR TITLE
@W-8885529@ Excluding transitive dependency on junit and hamcrest

### DIFF
--- a/pmd-cataloger/build.gradle.kts
+++ b/pmd-cataloger/build.gradle.kts
@@ -54,7 +54,9 @@ tasks.register<Copy>("installPmd") {
 }
 
 dependencies {
-  implementation ("com.googlecode.json-simple:json-simple:1.1.1")
+  implementation ("com.googlecode.json-simple:json-simple:1.1.1") {
+    exclude("junit")
+  }
   implementation("com.google.code.gson:gson:2.3")
   implementation("com.google.guava:guava:28.0-jre")
   testImplementation("org.mockito:mockito-core:1.+")


### PR DESCRIPTION
This PR excludes test-related dependencies from pmd-cataloger jar file.

Gradle dependency tree before this change:
```
default - Configuration for default artifacts.
+--- com.googlecode.json-simple:json-simple:1.1.1
|    \--- junit:junit:4.10
|         \--- org.hamcrest:hamcrest-core:1.1
+--- com.google.code.gson:gson:2.3
\--- com.google.guava:guava:28.0-jre
     +--- com.google.guava:failureaccess:1.0.1
     +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
     +--- com.google.code.findbugs:jsr305:3.0.2
     +--- org.checkerframework:checker-qual:2.8.1
     +--- com.google.errorprone:error_prone_annotations:2.3.2
     +--- com.google.j2objc:j2objc-annotations:1.3
     \--- org.codehaus.mojo:animal-sniffer-annotations:1.17
```

Gradle dependency tree after the change:

```
default - Configuration for default artifacts.
+--- com.googlecode.json-simple:json-simple:1.1.1
+--- com.google.code.gson:gson:2.3
\--- com.google.guava:guava:28.0-jre
     +--- com.google.guava:failureaccess:1.0.1
     +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
     +--- com.google.code.findbugs:jsr305:3.0.2
     +--- org.checkerframework:checker-qual:2.8.1
     +--- com.google.errorprone:error_prone_annotations:2.3.2
     +--- com.google.j2objc:j2objc-annotations:1.3
     \--- org.codehaus.mojo:animal-sniffer-annotations:1.17
```