### PR TITLE
@W-10459697@: Added release pipeline for 3.x, with latest-pilot-rc and latest-pilot tags.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,10 @@ commands:
 
   # Purpose: Install SFDX, and the release candidate version of the plugin.
   install_release_candidate:
+    parameters:
+      rc-tag: &rc_tag_param # Define an anchor here, since we'll want to use this parameter again elsewhere.
+        description: The tag pointing to the release candidate
+        type: string
     steps:
       - run:
           name: "Install SFDX cli"
@@ -118,7 +122,7 @@ commands:
 
       - run:
           name: "Install release candidate"
-          command: sfdx plugins:install @salesforce/sfdx-scanner@latest-rc
+          command: sfdx plugins:install @salesforce/sfdx-scanner@<< parameters.rc-tag >>
 
       - run:
           name: "Log installed plugins"
@@ -424,6 +428,8 @@ jobs:
   # promote it to an actual release.
   linux-rc-test:
     <<: *defaults
+    parameters:
+      rc-tag: *rc_tag_param
     steps:
       - auth_and_checkout
 
@@ -432,7 +438,8 @@ jobs:
           os: linux
 
       # Prepare the release candidate for running.
-      - install_release_candidate
+      - install_release_candidate:
+          rc-tag: << parameters.rc-tag >>
 
       - run:
           # Run through our sanity test script against the installed version of the plugin. If all of these pass, we can
@@ -452,6 +459,8 @@ jobs:
       name: win/default # executor type
       size: "medium"
     working_directory: C:\repo
+    parameters:
+      rc-tag: *rc_tag_param
 
     steps:
       - run:
@@ -465,7 +474,8 @@ jobs:
           os: windows
 
       # Prepare the release candidate for running.
-      - install_release_candidate
+      - install_release_candidate:
+          rc-tag: << parameters.rc-tag >>
 
       - run:
           # Run through our sanity test script against the installed version of the plugin. If all of these pass, we can
@@ -480,14 +490,14 @@ jobs:
 workflows:
   version: 2.1
   # Purpose: Run unit tests and smoke tests against a branch.
-  # Triggered by: Pull requests from any branch whose name is NOT `v2-X-Y` where X and Y are numbers.
+  # Triggered by: Pull requests from any branch whose name is NOT `v3-X-Y` where X and Y are numbers.
   test:
     jobs:
       # Step 1: Set up the test environment.
       - setup:
           filters: &testing_filters # Declare these filters as an anchor so we can reuse them.
             branches:
-              ignore: /^v2-\d+-\d+$/
+              ignore: /^v3-\d+-\d+$/
       # Step 2: Run the tests. Linux and Windows each have unit tests and a tarball test, and we also do a self-evaluation
       # step in Linux.
       - linux-unit-tests:
@@ -516,21 +526,21 @@ workflows:
           requires:
             - setup
   # Purpose: Publish a release based off of the specified branch.
-  # Triggered by: Pushes to branches that match the format `v2-X-Y` where X and Y are numbers.
+  # Triggered by: Pushes to branches that match the format `v3-X-Y` where X and Y are numbers.
   publish:
     jobs:
       # Step 1: Validate that the branch is an acceptable candidate for publishing.
       - validate-candidate-branch:
           filters: &publishing_filters # Declare these filters as an anchor so we can reuse them.
             branches:
-              only: /^v2-\d+-\d+$/
+              only: /^v3-\d+-\d+$/
       # Step 2: Publish the branch as a release candidate.
       - release-management/release-package:
           requires:
             - validate-candidate-branch
           sign: true
           github-release: true
-          tag: latest-rc
+          tag: latest-pilot-rc
           filters:
             <<: *publishing_filters
           context: 
@@ -542,15 +552,17 @@ workflows:
             - release-management/release-package
           filters:
             <<: *publishing_filters
+          rc-tag: latest-pilot-rc
       - windows-rc-test:
           requires:
             - release-management/release-package
           filters:
             <<: *publishing_filters
+          rc-tag: latest-pilot-rc
       # Step 4: Promote the release candidate to a full release.
       - release-management/promote-package:
-          candidate: latest-rc
-          target: latest
+          candidate: latest-pilot-rc
+          target: latest-pilot
           requires:
             - linux-rc-test
             - windows-rc-test

--- a/.circleci/validate-candidate-branch.sh
+++ b/.circleci/validate-candidate-branch.sh
@@ -6,9 +6,9 @@ set -e
 SCANNER_BRANCH=$1
 
 # First, we need to make sure that the name of the branch matches the pattern we've established.
-# i.e., `v2-X-Y`, where X and Y are numbers.
+# i.e., `v3-X-Y`, where X and Y are numbers.
 # Note: [[:digit:]] is the bash-equivalent of the \d special character.
-[[ ${SCANNER_BRANCH} =~ ^v2-[[:digit:]]+-[[:digit:]]+$ ]] || (echo "Branch must be of format 'v2-X-Y', where X and Y are numbers" && exit 1)
+[[ ${SCANNER_BRANCH} =~ ^v3-[[:digit:]]+-[[:digit:]]+$ ]] || (echo "Branch must be of format 'v3-X-Y', where X and Y are numbers" && exit 1)
 
 # Next, we need to make sure that the branch's name matches the version defined in the package.json. Do that by...
 # - Logging the package.json with `cat`
@@ -21,7 +21,7 @@ PACKAGE_STRING=v`cat package.json | jq '.version' | tr . - | xargs`
 
 # Finally, we need to make sure that the branch has all of the same commits as the `release` branch.
 # Fetch release from origin, since we might not necessarily have it yet.
-git fetch origin release
+git fetch origin release-3
 # Also fetch the branch we were given. This shouldn't be strictly necessary, but it lets us run the script against branches
 # beyond the current branch.
 git fetch origin ${SCANNER_BRANCH}
@@ -29,7 +29,7 @@ git fetch origin ${SCANNER_BRANCH}
 # Compare the commits on both branches by using the `git log` command, then pipe that into `wc` to get the character count,
 # and use xargs to trim white space.
 DIFFERENCE=`git diff release..${SCANNER_BRANCH} | wc -m | xargs`
-[[ ${DIFFERENCE} == 0 ]] || (echo "Commits on branch must exactly match those on 'release' branch." && exit 1)
+[[ ${DIFFERENCE} == 0 ]] || (echo "Commits on branch must exactly match those on 'release-3' branch." && exit 1)
 
 # If we're here, then the branch is acceptable.
 echo "The branch appears publishable."


### PR DESCRIPTION
This PR allows us to publish `v3.x` releases using the exact same process by which we publish `v2.x` releases, with the following caveats:
- Instead of `release`, use `release-3` (this branch doesn't currently exist, and should be created when we release `3.0.0`.
- The tags will be `latest-pilot-rc` and `latest-pilot` instead of `latest-rc` and `latest`.
Safeguards in place include:
- The release-candidate branch must start with `v3` instead of `v2`
- The commits must exactly match those in `release-3`
- By not merging this branch into `dev`, we make it impossible for `dev` to accidentally be released as `v3` or for `dev-3` to be accidentally released as `v2`.