### PR TITLE
@W-10459712@: Fixed configuration errors with ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,11 +3,12 @@
 	"extends": [
 		"eslint:recommended",
 		"plugin:@typescript-eslint/recommended",
-		"plugin:@typescript-eslint/eslint-recommended"
+		"plugin:@typescript-eslint/recommended-requiring-type-checking"
 	],
 	"parserOptions": {
 		"sourceType": "module",
-		"ecmaVersion": 2018
+		"ecmaVersion": 2018,
+		"project": "./tsconfig.json"
 	},
 	"plugins": [
 		"@typescript-eslint"

--- a/src/lib/eslint/CustomEslintEngine.ts
+++ b/src/lib/eslint/CustomEslintEngine.ts
@@ -81,8 +81,8 @@ export class CustomEslintEngine extends AbstractRuleEngine {
 		if (rules.length > 0) {
 			this.eventCreator.createUxInfoAlwaysMessage('info.filtersIgnoredCustom', []);
 		}
-
-		const eslint = this.dependencies.createESLint(config);
+		// The config we loaded from the file should be treated as an override for whatever default configs exist.
+		const eslint = this.dependencies.createESLint({overrideConfig: config});
 
 		const results: RuleResult[] = [];
 		for (const target of targets) {

--- a/test/code-fixtures/config/custom_eslint_config.json
+++ b/test/code-fixtures/config/custom_eslint_config.json
@@ -1,22 +1,18 @@
 {
-	"overrideConfig": {
-		"root": true,
-		"parser": "@typescript-eslint/parser",
-		"parserOptions": {
-			"project": "test/code-fixtures/projects/tsconfig.json",
-			"sourceType": "module",
-			"ecmaVersion": 2018
-		},
-		"plugins": [
-			"@typescript-eslint"
-		],
-		"rules": {
-		}
+	"root": true,
+	"parser": "@typescript-eslint/parser",
+	"parserOptions": {
+		"project": "test/code-fixtures/projects/tsconfig.json",
+		"sourceType": "module",
+		"ecmaVersion": 2018
 	},
-	"baseConfig": {
-		"extends": [
-			"plugin:@typescript-eslint/recommended",
-			"plugin:@typescript-eslint/eslint-recommended"
-		]
-	}
+	"plugins": [
+		"@typescript-eslint"
+	],
+	"rules": {
+	},
+	"extends": [
+		"plugin:@typescript-eslint/recommended",
+		"plugin:@typescript-eslint/eslint-recommended"
+	]
 }

--- a/test/code-fixtures/projects/js/.eslintrc.json
+++ b/test/code-fixtures/projects/js/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+	"root": true
 	"extends": ["eslint:recommended"],
 	"parserOptions": {
 		"sourceType": "module",

--- a/test/code-fixtures/projects/ts/.eslintrc.json
+++ b/test/code-fixtures/projects/ts/.eslintrc.json
@@ -15,5 +15,6 @@
 	"ignorePatterns": [
 		"lib/**",
 		"node_modules/**"
-	]
+	],
+	"root": true
 }


### PR DESCRIPTION
This PR does the following:
- CI should now run the full battery of ts linting rules (once we fully enable it again).
- The Custom ESLint engine now accepts config files formatted the same way as if you'd run eslint from the CLI.
- The test projects' eslintrc files have been changed to be `root = true`, so they won't cascade up into the parent folders.