### PR TITLE
@W-10909748@: RetireJS is now enabled by default.

### DIFF
--- a/src/lib/util/Config.ts
+++ b/src/lib/util/Config.ts
@@ -68,7 +68,7 @@ const DEFAULT_CONFIG: ConfigContent = {
 		{
 			name: ENGINE.RETIRE_JS,
 			targetPatterns: [],
-			disabled: true
+			disabled: false
 		},
 		{
 			name: ENGINE.CPD,

--- a/src/lib/util/VersionUpgradeManager.ts
+++ b/src/lib/util/VersionUpgradeManager.ts
@@ -34,6 +34,15 @@ upgradeScriptsByVersion.set('v2.7.0', (config: ConfigContent): Promise<void> => 
 	}
 	return Promise.resolve();
 });
+upgradeScriptsByVersion.set('v3.0.0', (config: ConfigContent): Promise<void> => {
+	// In v3.0.0, we're changing RetireJS from a supplemental engine that must be manually enabled to an enabled-byu-default
+	// engine. So we need to change its `disabled` config value from true to false.
+	const retireJsConfig: EngineConfigContent = config.engines.find(e => e.name === ENGINE.RETIRE_JS);
+	if (retireJsConfig) {
+		retireJsConfig.disabled = false;
+	}
+	return Promise.resolve();
+});
 
 
 // ================ CLASSES =====================

--- a/test/lib/util/VersionUpgradeManager.test.ts
+++ b/test/lib/util/VersionUpgradeManager.test.ts
@@ -69,20 +69,27 @@ describe('VersionUpgradeManager', () => {
 
 		// ============ TESTS ==================
 		describe('#getVersionsBetween()', () => {
+			// v2.6.1 and v4.3.2 have no upgrade scripts associated with them in this manager.
 			const strictBetween: string[] = successfulManagerAsAny.getVersionsBetween(v2_6_1, v4_3_2);
+			// v2.6.0 and v19.9.9 both have upgrade scripts in this manager.
 			const onBoundaries: string[] = successfulManagerAsAny.getVersionsBetween(v2_6_0, v19_9_9);
+			// v2.7.8 has an upgrade script in this manager.
 			const nullFrom: string[] = successfulManagerAsAny.getVersionsBetween(null, v2_7_8);
 
 			it('fromVersion param is exclusive lower bound', () => {
+				// Since v2.6.1 has no script, the next-lowest value of 2.7.0 should be used.
 				expect(strictBetween[0]).to.equal(v2_7_0, `Lower bound of ${v2_6_1} not respected`);
+				// v2.6.0 has a script, but the lower bound is exclusive, so it should use the next-lowest value of 2.7.0.
 				expect(onBoundaries[0]).to.equal(v2_7_0, `Lower bound of ${v2_6_0} not properly exclusive`);
 			});
 
 			it('toVersion param is inclusive upper bound', () => {
 				expect(strictBetween.length).to.equal(2, 'Wrong number of versions returned');
+				// v4.3.2 has no script, so the next-highest value of v2.7.8 should be used.
 				expect(strictBetween[1]).to.equal(v2_7_8, `Upper bound of ${v4_3_2} not respected`);
 
 				expect(onBoundaries.length).to.equal(3, 'Wrong number of versions returned');
+				// v19.9.9 has a script, so that value should be used.
 				expect(onBoundaries[2]).to.equal(v19_9_9, `Upper bound of ${v19_9_9} not properly inclusive`);
 			});
 


### PR DESCRIPTION
This PR does the following:
- Changes the default configuration for `retire` such that its `disabled` property is now false instead of true.
- Adds an upgrade script for `v3.0.0` that changes the `disabled` value from true to false on existing configs.
- Adds test coverage for the new upgrade script.