### PR TITLE
@W-10184957@: Implemented telemetry.

### DIFF
--- a/src/lib/RuleManager.ts
+++ b/src/lib/RuleManager.ts
@@ -11,9 +11,11 @@ export enum OUTPUT_FORMAT {
 	XML = 'xml'
 }
 
-export type OutputOptions  = {
+export type RunOptions  = {
 	format: OUTPUT_FORMAT;
 	normalizeSeverity: boolean;
+	runDfa: boolean;
+	sfdxVersion: string;
 }
 
 export interface RuleManager {
@@ -34,5 +36,5 @@ export interface RuleManager {
 	/**
 	 * @param engineOptions - see RuleEngine#run
 	 */
-	runRulesMatchingCriteria(filters: RuleFilter[], target: string[], outputOptions: OutputOptions, engineOptions: Map<string, string>, runDfa?: boolean): Promise<RecombinedRuleResults>;
+	runRulesMatchingCriteria(filters: RuleFilter[], target: string[], runOptions: RunOptions, engineOptions: Map<string, string>): Promise<RecombinedRuleResults>;
 }

--- a/src/lib/util/SfdxUtils.ts
+++ b/src/lib/util/SfdxUtils.ts
@@ -1,0 +1,48 @@
+import childProcess = require('child_process');
+/**
+ * A variable to store SFDX's version number, so we don't have to keep re-running `sfdx-v`
+ */
+let SFDX_VERSION: string;
+
+
+/**
+ * Returns the current version of SFDX installed on the machine, or "unknown" if the version cannot be determined.
+ */
+export async function getSfdxVersion(): Promise<string> {
+	// If we already have a cached value, we can just return that instead of doing anything else.
+	if (SFDX_VERSION !== undefined) {
+		return SFDX_VERSION;
+	}
+
+	// Get the output of `sfdx -v`.
+	let rawVersionString: string;
+	try {
+		rawVersionString = await new Promise<string>((res, rej) => {
+			childProcess.exec('sfdx -v', (err, stdout, stderr) => {
+				if (err) {
+					rej(stderr);
+				} else {
+					res(stdout);
+				}
+			});
+		});
+	} catch (e) {
+		// If the command fails, then we have no way of determining what the version is. So just set it to 'unknown' and
+		// be done with it.
+		SFDX_VERSION = 'unknown';
+		return SFDX_VERSION;
+	}
+
+	// The actual output for `sfdx -v` is a long-ish string that has stuff we don't want. So use this regex to just get
+	// the SFDX version part.
+	const regex = /(sfdx-cli\/\d+\.\d+\.\d+)/g;
+	const match = regex.exec(rawVersionString);
+	if (match.length > 0) {
+		SFDX_VERSION = match[0];
+	} else {
+		// Even if our regex didn't pull out the value that we expected it to, we can still use the results of the command.
+		// It'll just be more verbose than is strictly necessary, which isn't the worst thing in the world.
+		SFDX_VERSION = rawVersionString;
+	}
+	return SFDX_VERSION;
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -16,6 +16,12 @@ export type Rule = {
 	url?: string;
 }
 
+export type TelemetryData = {
+	eventName: string;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	[key: string]: any;
+}
+
 export type LooseObject = {
 	/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 	[key: string]: any;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -20,6 +20,7 @@ export type TelemetryData = {
 	eventName: string;
 	executedEnginesCount: number;
 	executedEnginesString: string;
+	sfdxVersion: string;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	[key: string]: any;
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -18,6 +18,8 @@ export type Rule = {
 
 export type TelemetryData = {
 	eventName: string;
+	executedEnginesCount: number;
+	executedEnginesString: string;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	[key: string]: any;
 }

--- a/test/lib/RuleManager.test.ts
+++ b/test/lib/RuleManager.test.ts
@@ -2,6 +2,8 @@ import {expect} from 'chai';
 import path = require('path');
 import Sinon = require('sinon');
 
+import {Lifecycle} from '@salesforce/core';
+
 import {Controller} from '../../src/Controller';
 import {Rule, RuleGroup, RuleTarget} from '../../src/types';
 
@@ -25,10 +27,12 @@ const EMPTY_ENGINE_OPTIONS = new Map<string, string>();
 
 describe('RuleManager', () => {
 	let uxSpy;
+	let telemetrySpy;
 
 	beforeEach(() => {
 		Sinon.createSandbox();
 		uxSpy = Sinon.spy(uxEvents, 'emit');
+		telemetrySpy = Sinon.spy(Lifecycle.getInstance(), 'emitTelemetry');
 	});
 
 	afterEach(() => {
@@ -194,6 +198,7 @@ describe('RuleManager', () => {
 					for (const res of parsedRes) {
 						expect(res.violations[0], `Message is ${res.violations[0].message}`).to.have.property("ruleName").that.is.not.null;
 					}
+					Sinon.assert.callCount(telemetrySpy, 1);
 				});
 
 				it('TS project files', async () => {
@@ -210,6 +215,7 @@ describe('RuleManager', () => {
 					for (const res of parsedRes) {
 						expect(res.violations[0], `Message is ${res.violations[0].message}`).to.have.property("ruleName").that.is.not.null;
 					}
+					Sinon.assert.callCount(telemetrySpy, 1);
 				});
 
 				it('App project files', async () => {
@@ -226,6 +232,7 @@ describe('RuleManager', () => {
 					for (const res of parsedRes) {
 						expect(res.violations[0], `Message is ${res.violations[0]['message']}`).to.have.property("ruleName").that.is.not.null;
 					}
+					Sinon.assert.callCount(telemetrySpy, 1);
 				});
 
 				it('All targets match', async () => {
@@ -243,6 +250,7 @@ describe('RuleManager', () => {
 					}
 					expect(parsedRes).to.be.an("array").that.has.length(1);
 					Sinon.assert.callCount(uxSpy, 0);
+					Sinon.assert.callCount(telemetrySpy, 1);
 				});
 
 				it('Single target file does not match', async () => {
@@ -254,6 +262,7 @@ describe('RuleManager', () => {
 
 					expect(results).to.equal('');
 					Sinon.assert.calledWith(uxSpy, EVENTS.WARNING_ALWAYS, `Target: '${invalidTarget.join(', ')}' was not processed by any engines.`);
+					Sinon.assert.callCount(telemetrySpy, 1);
 				});
 			});
 
@@ -279,6 +288,7 @@ describe('RuleManager', () => {
 							expect(violation.category).to.equal(category);
 						}
 					}
+					Sinon.assert.callCount(telemetrySpy, 1);
 				});
 
 				it('Filtering by multiple categories runs any rule in either category', async () => {
@@ -299,6 +309,7 @@ describe('RuleManager', () => {
 						expect(res.violations[0], `Message is ${res.violations[0]['message']}`).to.have.property("ruleName").that.is.not.null;
 						expect(res.violations[0].category).to.be.oneOf(categories);
 					}
+					Sinon.assert.callCount(telemetrySpy, 1);
 				});
 			});
 
@@ -310,6 +321,7 @@ describe('RuleManager', () => {
 					const {results} = await ruleManager.runRulesMatchingCriteria(filters, ['app'], {format: OUTPUT_FORMAT.JSON, normalizeSeverity: false}, EMPTY_ENGINE_OPTIONS);
 					expect(typeof results).to.equal('string', `Output ${results} should have been a string`);
 					expect(results).to.equal('', `Output ${results} should have been an empty string`);
+					Sinon.assert.callCount(telemetrySpy, 1);
 				});
 
 				it('Single target file does not match', async () => {
@@ -323,6 +335,7 @@ describe('RuleManager', () => {
 					expect(results).to.equal('');
 					Sinon.assert.callCount(uxSpy, 1);
 					Sinon.assert.calledWith(uxSpy, EVENTS.WARNING_ALWAYS, `Target: '${invalidTarget.join(', ')}' was not processed by any engines.`);
+					Sinon.assert.callCount(telemetrySpy, 1);
 				});
 
 
@@ -337,6 +350,7 @@ describe('RuleManager', () => {
 					expect(results).to.equal('');
 					Sinon.assert.callCount(uxSpy, 1);
 					Sinon.assert.calledWith(uxSpy, EVENTS.WARNING_ALWAYS, `Target: '${invalidTarget.join(', ')}' was not processed by any engines.`);
+					Sinon.assert.callCount(telemetrySpy, 1);
 				});
 
 				it('Multiple targets do not match', async () => {
@@ -350,6 +364,7 @@ describe('RuleManager', () => {
 					expect(results).to.equal('');
 					Sinon.assert.callCount(uxSpy, 1);
 					Sinon.assert.calledWith(uxSpy, EVENTS.WARNING_ALWAYS, `Targets: '${invalidTargets.join(', ')}' were not processed by any engines.`);
+					Sinon.assert.callCount(telemetrySpy, 1);
 				});
 
 				it('Some targets do not match', async () => {
@@ -369,6 +384,7 @@ describe('RuleManager', () => {
 					expect(parsedRes).to.be.an("array").that.has.length(1);
 					Sinon.assert.callCount(uxSpy, 1);
 					Sinon.assert.calledWith(uxSpy, EVENTS.WARNING_ALWAYS, `Targets: '${invalidTargets.join(', ')}' were not processed by any engines.`);
+					Sinon.assert.callCount(telemetrySpy, 1);
 				});
 			});
 		});

--- a/test/lib/RuleManager.test.ts
+++ b/test/lib/RuleManager.test.ts
@@ -8,7 +8,7 @@ import {ENGINE} from '../../src/Constants';
 
 import {CategoryFilter, EngineFilter, LanguageFilter, RuleFilter, RulesetFilter} from '../../src/lib/RuleFilter';
 import {DefaultRuleManager} from '../../src/lib/DefaultRuleManager';
-import {OUTPUT_FORMAT, RuleManager} from '../../src/lib/RuleManager';
+import {OUTPUT_FORMAT, RuleManager, RunOptions} from '../../src/lib/RuleManager';
 import {EVENTS, uxEvents} from '../../src/lib/ScannerEvents';
 
 import {RuleCatalog} from '../../src/lib/services/RuleCatalog';
@@ -184,10 +184,16 @@ describe('RuleManager', () => {
 			after(() => {
 				process.chdir("../../..");
 			});
+			const runOptions: RunOptions = {
+				format: OUTPUT_FORMAT.JSON,
+				normalizeSeverity: false,
+				runDfa: false,
+				sfdxVersion: 'test'
+			};
 			describe('Test Case: Run without filters', () => {
 				it('JS project files', async () => {
 					// If we pass an empty list into the method, that's treated as the absence of filter criteria.
-					const {results} = await ruleManager.runRulesMatchingCriteria([], ['js'], {format: OUTPUT_FORMAT.JSON, normalizeSeverity: false}, EMPTY_ENGINE_OPTIONS);
+					const {results} = await ruleManager.runRulesMatchingCriteria([], ['js'], runOptions, EMPTY_ENGINE_OPTIONS);
 					let parsedRes = null;
 					if (typeof results !== "string") {
 						expect(false, `Invalid output: ${results}`);
@@ -204,7 +210,7 @@ describe('RuleManager', () => {
 
 				it('TS project files', async () => {
 					// If we pass an empty list into the method, that's treated as the absence of filter criteria.
-					const {results} = await ruleManager.runRulesMatchingCriteria([], ['ts'], {format: OUTPUT_FORMAT.JSON, normalizeSeverity: false}, EMPTY_ENGINE_OPTIONS);
+					const {results} = await ruleManager.runRulesMatchingCriteria([], ['ts'], runOptions, EMPTY_ENGINE_OPTIONS);
 					let parsedRes = null;
 					if (typeof results !== "string") {
 						expect(false, `Invalid output: ${results}`);
@@ -222,7 +228,7 @@ describe('RuleManager', () => {
 				it('App project files', async () => {
 
 					// If we pass an empty list into the method, that's treated as the absence of filter criteria.
-					const {results} = await ruleManager.runRulesMatchingCriteria([], ['app'], {format: OUTPUT_FORMAT.JSON, normalizeSeverity: false}, EMPTY_ENGINE_OPTIONS);
+					const {results} = await ruleManager.runRulesMatchingCriteria([], ['app'], runOptions, EMPTY_ENGINE_OPTIONS);
 					let parsedRes = null;
 					if (typeof results !== "string") {
 						expect(false, `Invalid output: ${results}`);
@@ -242,7 +248,7 @@ describe('RuleManager', () => {
 					const categories = ['Possible Errors'];
 					const filters = [new CategoryFilter(categories)];
 
-					const {results} = await ruleManager.runRulesMatchingCriteria(filters, validTargets, {format: OUTPUT_FORMAT.JSON, normalizeSeverity: false}, EMPTY_ENGINE_OPTIONS);
+					const {results} = await ruleManager.runRulesMatchingCriteria(filters, validTargets, runOptions, EMPTY_ENGINE_OPTIONS);
 					let parsedRes = null;
 					if (typeof results !== "string") {
 						expect(false, `Invalid output: ${results}`);
@@ -259,7 +265,7 @@ describe('RuleManager', () => {
 					// No filters
 					const filters = [];
 
-					const {results} = await ruleManager.runRulesMatchingCriteria(filters, invalidTarget, {format: OUTPUT_FORMAT.JSON, normalizeSeverity: false}, EMPTY_ENGINE_OPTIONS);
+					const {results} = await ruleManager.runRulesMatchingCriteria(filters, invalidTarget, runOptions, EMPTY_ENGINE_OPTIONS);
 
 					expect(results).to.equal('');
 					Sinon.assert.calledWith(uxSpy, EVENTS.WARNING_ALWAYS, `Target: '${invalidTarget.join(', ')}' was not processed by any engines.`);
@@ -274,7 +280,7 @@ describe('RuleManager', () => {
 					const filters = [
 						new CategoryFilter([category])];
 
-					const {results} = await ruleManager.runRulesMatchingCriteria(filters, ['app'], {format: OUTPUT_FORMAT.JSON, normalizeSeverity: false}, EMPTY_ENGINE_OPTIONS);
+					const {results} = await ruleManager.runRulesMatchingCriteria(filters, ['app'], runOptions, EMPTY_ENGINE_OPTIONS);
 					let parsedRes = null;
 					if (typeof results !== "string") {
 						expect(false, `Invalid output: ${results}`);
@@ -297,7 +303,7 @@ describe('RuleManager', () => {
 					const categories = ['Best Practices', 'Error Prone'];
 					const filters = [new CategoryFilter(categories)];
 
-					const {results} = await ruleManager.runRulesMatchingCriteria(filters, ['app'], {format: OUTPUT_FORMAT.JSON, normalizeSeverity: false}, EMPTY_ENGINE_OPTIONS);
+					const {results} = await ruleManager.runRulesMatchingCriteria(filters, ['app'], runOptions, EMPTY_ENGINE_OPTIONS);
 					let parsedRes = null;
 					if (typeof results !== "string") {
 						expect(false, `Invalid output: ${results}`);
@@ -319,7 +325,7 @@ describe('RuleManager', () => {
 					const engines = [ENGINE.RETIRE_JS, ENGINE.ESLINT];
 					const filters = [new EngineFilter(engines)];
 
-					const {results} = await ruleManager.runRulesMatchingCriteria(filters, ['app'], {format: OUTPUT_FORMAT.JSON, normalizeSeverity: false}, EMPTY_ENGINE_OPTIONS);
+					const {results} = await ruleManager.runRulesMatchingCriteria(filters, ['app'], runOptions, EMPTY_ENGINE_OPTIONS);
 					let parsedRes = null;
 					if (typeof results !== 'string') {
 						expect(false, `Invalid output: ${results}`);
@@ -352,7 +358,7 @@ describe('RuleManager', () => {
 					// Define our preposterous filter array.
 					const filters = [new CategoryFilter(['beebleborp'])];
 
-					const {results} = await ruleManager.runRulesMatchingCriteria(filters, ['app'], {format: OUTPUT_FORMAT.JSON, normalizeSeverity: false}, EMPTY_ENGINE_OPTIONS);
+					const {results} = await ruleManager.runRulesMatchingCriteria(filters, ['app'], runOptions, EMPTY_ENGINE_OPTIONS);
 					expect(typeof results).to.equal('string', `Output ${results} should have been a string`);
 					expect(results).to.equal('', `Output ${results} should have been an empty string`);
 					Sinon.assert.callCount(telemetrySpy, 1);
@@ -364,7 +370,7 @@ describe('RuleManager', () => {
 					const categories = ['Best Practices', 'Error Prone'];
 					const filters = [new CategoryFilter(categories)];
 
-					const {results} = await ruleManager.runRulesMatchingCriteria(filters, invalidTarget, {format: OUTPUT_FORMAT.JSON, normalizeSeverity: false}, EMPTY_ENGINE_OPTIONS);
+					const {results} = await ruleManager.runRulesMatchingCriteria(filters, invalidTarget, runOptions, EMPTY_ENGINE_OPTIONS);
 
 					expect(results).to.equal('');
 					Sinon.assert.callCount(uxSpy, 1);
@@ -379,7 +385,7 @@ describe('RuleManager', () => {
 					const categories = ['Best Practices', 'Error Prone'];
 					const filters = [new CategoryFilter(categories)];
 
-					const {results} = await ruleManager.runRulesMatchingCriteria(filters, invalidTarget, {format: OUTPUT_FORMAT.JSON, normalizeSeverity: false}, EMPTY_ENGINE_OPTIONS);
+					const {results} = await ruleManager.runRulesMatchingCriteria(filters, invalidTarget, runOptions, EMPTY_ENGINE_OPTIONS);
 
 					expect(results).to.equal('');
 					Sinon.assert.callCount(uxSpy, 1);
@@ -393,7 +399,7 @@ describe('RuleManager', () => {
 					const categories = ['Best Practices', 'Error Prone'];
 					const filters = [new CategoryFilter(categories)];
 
-					const {results} = await ruleManager.runRulesMatchingCriteria(filters, invalidTargets, {format: OUTPUT_FORMAT.JSON, normalizeSeverity: false}, EMPTY_ENGINE_OPTIONS);
+					const {results} = await ruleManager.runRulesMatchingCriteria(filters, invalidTargets, runOptions, EMPTY_ENGINE_OPTIONS);
 
 					expect(results).to.equal('');
 					Sinon.assert.callCount(uxSpy, 1);
@@ -408,7 +414,7 @@ describe('RuleManager', () => {
 					const categories = ['Possible Errors'];
 					const filters = [new CategoryFilter(categories)];
 
-					const {results} = await ruleManager.runRulesMatchingCriteria(filters, [...invalidTargets, ...validTargets], {format: OUTPUT_FORMAT.JSON, normalizeSeverity: false}, EMPTY_ENGINE_OPTIONS);
+					const {results} = await ruleManager.runRulesMatchingCriteria(filters, [...invalidTargets, ...validTargets], runOptions, EMPTY_ENGINE_OPTIONS);
 					let parsedRes = null;
 					if (typeof results !== "string") {
 						expect(false, `Invalid output: ${results}`);

--- a/test/lib/eslint/TypescriptEslintStrategy.test.ts
+++ b/test/lib/eslint/TypescriptEslintStrategy.test.ts
@@ -273,7 +273,7 @@ describe('TypescriptEslint Strategy', () => {
 			});
 
 			it('The typescript engine should convert the eslint error to something more user friendly', async () => {
-				const {results} = await ruleManager.runRulesMatchingCriteria([], ['invalid-ts'], {format: OUTPUT_FORMAT.JSON, normalizeSeverity: false}, EMPTY_ENGINE_OPTIONS);
+				const {results} = await ruleManager.runRulesMatchingCriteria([], ['invalid-ts'], {format: OUTPUT_FORMAT.JSON, normalizeSeverity: false, runDfa: false, sfdxVersion: 'test'}, EMPTY_ENGINE_OPTIONS);
 				// Parse the json in order to make the string match easier.
 				// There should be a single violation with a single message
 				const ruleResults: RuleResult[] = JSON.parse(results.toString());


### PR DESCRIPTION
This PR adds a telemetry event to rule engine execution that captures the following data:
- An event name (ENGINE_EXECUTION), necessary for collating data
- A boolean for each engine, indicating whether that engine was run
- The version of SFDX being used
- node version (captured by default)
- plugin version (captured by default)
- executed command (captured by default)