### PR TITLE
@W-11149717@: All cases accepted for file extension when using --outfile

### DIFF
--- a/src/lib/ScannerRunCommand.ts
+++ b/src/lib/ScannerRunCommand.ts
@@ -126,7 +126,7 @@ export abstract class ScannerRunCommand extends ScannerCommand {
 			throw new SfdxError(messages.getMessage('validations.outfileMustBeValid'), null, null, INTERNAL_ERROR_CODE);
 		} else {
 			// Look at the file extension, and infer a corresponding output format.
-			const fileExtension = outfile.slice(lastPeriod + 1);
+			const fileExtension = outfile.slice(lastPeriod + 1).toLowerCase();
 			switch (fileExtension) {
 				case OUTPUT_FORMAT.CSV:
 				case OUTPUT_FORMAT.HTML:

--- a/test/commands/scanner/run.test.ts
+++ b/test/commands/scanner/run.test.ts
@@ -272,7 +272,7 @@ describe('scanner:run', function () {
 		});
 
 		describe('Output Type: HTML', () => {
-			const outputFile = 'testout.html';
+			const outputFile = 'testout.hTmL';
 			function validateHtmlOutput(html: string): void {
 				const result = html.match(/const violations = (\[.*);/);
 				expect(result).to.be.not.null;


### PR DESCRIPTION
Use a lowercase version of the file extension before comparing with valid file types to allow extensions like .hTmL when file name provided with --outfile