### PR TITLE
@W-10127077@: adds --verbose-violations flag and functionality

### DIFF
--- a/messages/run.js
+++ b/messages/run.js
@@ -29,7 +29,10 @@ module.exports = {
 		'eslintConfigDescription': 'location of eslintrc config to customize eslint engine',
 		'eslintConfigDescriptionLong': 'Location of eslintrc to customize eslint engine',
 		'pmdConfigDescription': 'location of PMD rule reference XML file to customize rule selection',
-		'pmdConfigDescriptionLong': 'Location of PMD rule reference XML file to customize rule selection'
+		'pmdConfigDescriptionLong': 'Location of PMD rule reference XML file to customize rule selection',
+		"verboseViolationsDescription": "retire-js violation messages include more details",
+        "verboseViolationsDescriptionLong": "retire-js violation messages contain details about each vulnerability (e.g. summary, CVE, urls, etc.)"
+		
 	},
 	"validations": {
 		"outfileFormatMismatch": "Your chosen format %s does not appear to match your output file type of %s.",

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -94,7 +94,8 @@ export const Services = {
 export enum CUSTOM_CONFIG {
 	EslintConfig = "EslintConfig",
 	PmdConfig = "PmdConfig",
-	SfgeConfig = "SfgeConfig"
+	SfgeConfig = "SfgeConfig",
+	VerboseViolations = "VerboseViolations"
 }
 
 export const HARDCODED_RULES = {

--- a/src/commands/scanner/run.ts
+++ b/src/commands/scanner/run.ts
@@ -104,6 +104,10 @@ export default class Run extends ScannerRunCommand {
 			description: messages.getMessage('flags.nsDescription'),
 			longDescription: messages.getMessage('flags.nsDescriptionLong')
 		}),
+		"verbose-violations": flags.boolean({
+			description: messages.getMessage('flags.verboseViolationsDescription'),
+			longDescription: messages.getMessage('flags.verboseViolationsDescriptionLong')
+		}),
 	};
 
 	protected validateCommandFlags(): Promise<void> {
@@ -149,6 +153,13 @@ export default class Run extends ScannerRunCommand {
 			const pmdConfig = normalize(untildify(this.flags.pmdconfig as string));
 			options.set(CUSTOM_CONFIG.PmdConfig, pmdConfig);
 		}
+		
+		// Capturing verbose-violations flag value (used for RetireJS output)
+		if (this.flags["verbose-violations"]) {
+			options.set(CUSTOM_CONFIG.VerboseViolations, "true");
+		}
+		
+
 		return options;
 	}
 


### PR DESCRIPTION
Each violation displays the RetireJS vulnerabilities in one message as follows:

**component** **version** has known vulnerabilities:
severity: **severity**; summary: **summary**; other identifier: **other identifier, e.g. CVE**; ...; **info (e.g. URL) more info (e.g. URL)**
severity: **severity**; summary: **summary**; other identifier: **other identifier, e.g. CVE**; ...; **info (e.g. URL) more info (e.g. URL)**
...

- each identifier is in the format `name: value` and identifiers are separated by `; `
- each item in info is space separated

Message is the same for all formats. 