### PR TITLE
@W-11281093@ sfge and pmd-cataloger should be available as independent projects

### DIFF
--- a/pmd-cataloger/settings.gradle.kts
+++ b/pmd-cataloger/settings.gradle.kts
@@ -1,5 +1,0 @@
-rootProject.name = "pmd-cataloger"
-
-include(":cli-messaging")
-project(":cli-messaging").projectDir = file("../cli-messaging")
-

--- a/pmd-cataloger/settings.gradle.kts
+++ b/pmd-cataloger/settings.gradle.kts
@@ -1,2 +1,5 @@
 rootProject.name = "pmd-cataloger"
 
+include(":cli-messaging")
+project(":cli-messaging").projectDir = file("../cli-messaging")
+

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,6 +7,4 @@
 
 rootProject.name = "sfdx-scanner"
 
-include("cli-messaging")
-include("pmd-cataloger")
-include("sfge")
+include(":cli-messaging", ":pmd-cataloger", ":sfge")

--- a/sfge/settings.gradle.kts
+++ b/sfge/settings.gradle.kts
@@ -1,1 +1,4 @@
 rootProject.name = "sfge"
+
+include(":cli-messaging")
+project(":cli-messaging").projectDir = file("../cli-messaging")

--- a/sfge/settings.gradle.kts
+++ b/sfge/settings.gradle.kts
@@ -1,4 +1,0 @@
-rootProject.name = "sfge"
-
-include(":cli-messaging")
-project(":cli-messaging").projectDir = file("../cli-messaging")


### PR DESCRIPTION
Adding cli-messaging to sfge and pmd-cataloger so that they can be built and developed independently.
The ideal fix would be to keep sfdx-scanner and sfge as two top-level projects. Since this requires a lot of code displacement, I'm holding off at the moment.