### PR TITLE
@W-10759090@: Resolves problems identified in code review

### DIFF
--- a/cli-messaging/src/main/java/com/salesforce/messaging/EventKey.java
+++ b/cli-messaging/src/main/java/com/salesforce/messaging/EventKey.java
@@ -20,7 +20,7 @@ public enum EventKey {
 	ERROR_EXTERNAL_RECURSION_LIMIT("error.external.recursionLimitReached", 2, MessageType.ERROR, MessageHandler.UX, false),
 	ERROR_EXTERNAL_XML_NOT_READABLE("error.external.xmlNotReadable", 2, MessageType.ERROR, MessageHandler.UX, false),
 	ERROR_EXTERNAL_XML_NOT_PARSABLE("error.external.xmlNotParsable", 2, MessageType.ERROR, MessageHandler.UX, false),
-	WARNING_MULTIPLE_METHOD_TARGET_MATCHES("warning.multipleMethodTargetMatches", 3, MessageType.WARNING, MessageHandler.UX, true),
+	WARNING_MULTIPLE_METHOD_TARGET_MATCHES("warning.multipleMethodTargetMatches", 3, MessageType.WARNING, MessageHandler.UX, false),
 	WARNING_NO_METHOD_TARGET_MATCHES("warning.noMethodTargetMatches", 2, MessageType.WARNING, MessageHandler.UX, false);
 
 	final String messageKey;

--- a/messages/run.js
+++ b/messages/run.js
@@ -32,9 +32,10 @@ module.exports = {
 		'pmdConfigDescriptionLong': 'Location of PMD rule reference XML file to customize rule selection',
 		"verboseViolationsDescription": "retire-js violation messages include more details",
         "verboseViolationsDescriptionLong": "retire-js violation messages contain details about each vulnerability (e.g. summary, CVE, urls, etc.)"
-		
+
 	},
 	"validations": {
+		"methodLevelTargetingDisallowed": "Target '%s' is invalid, as this command does not support method-level targeting",
 		"outfileFormatMismatch": "Your chosen format %s does not appear to match your output file type of %s.",
 		"outfileMustBeValid": "--outfile must be a well-formed filepath.",
 		"outfileMustBeSupportedType": "--outfile must be of a supported type. Current options are: .csv; .xml; .json; .html; .sarif.",

--- a/sfge/src/main/java/com/salesforce/graph/ops/CloneUtil.java
+++ b/sfge/src/main/java/com/salesforce/graph/ops/CloneUtil.java
@@ -231,8 +231,8 @@ public final class CloneUtil {
             return (T) cloneTreeMap((TreeMap) item);
         } else if (item instanceof BaseSFVertex) {
             return item;
-		} else if (item instanceof EngineDirective) {
-			return item;
+        } else if (item instanceof EngineDirective) {
+            return item;
         } else if (item instanceof LinkedList) {
             return (T) cloneLinkedList((LinkedList) item);
         } else if (item instanceof Enum) {

--- a/sfge/src/main/java/com/salesforce/graph/ops/MethodUtil.java
+++ b/sfge/src/main/java/com/salesforce/graph/ops/MethodUtil.java
@@ -8,7 +8,6 @@ import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.out;
 import com.salesforce.apex.jorje.ASTConstants;
 import com.salesforce.apex.jorje.ASTConstants.NodeType;
 import com.salesforce.collections.CollectionUtil;
-import com.salesforce.collections.NonNullHashMap;
 import com.salesforce.exception.UnexpectedException;
 import com.salesforce.graph.ApexPath;
 import com.salesforce.graph.Schema;
@@ -130,7 +129,7 @@ public final class MethodUtil {
      * @param vertices - The method vertices returned by the query created using the target
      */
     private static void addMessagesForTarget(RuleRunnerTarget target, List<MethodVertex> vertices) {
-        NonNullHashMap<String, Integer> methodCountByName = CollectionUtil.newNonNullHashMap();
+        TreeMap<String, Integer> methodCountByName = CollectionUtil.newTreeMap();
         // Map each vertex's method name to the number of vertices sharing that name.
         for (MethodVertex methodVertex : vertices) {
             String methodName = methodVertex.getName();

--- a/sfge/src/test/java/com/salesforce/graph/ops/MethodUtilTest.java
+++ b/sfge/src/test/java/com/salesforce/graph/ops/MethodUtilTest.java
@@ -139,6 +139,28 @@ public class MethodUtilTest {
     }
 
     @Test
+    public void getTargetMethods_targetSingleMethodCaseInsensitive() {
+        TestUtil.Config config =
+                TestUtil.Config.Builder.get(g, new String[] {SOURCE_FILE_1, SOURCE_FILE_2}).build();
+        TestUtil.buildGraph(config);
+        // Create a rule target encompassing only the first non-overloaded method in the first file.
+        List<RuleRunnerTarget> targets = new ArrayList<>();
+        targets.add(
+                new RuleRunnerTarget(
+                        "TestCode0",
+                        Collections.singletonList(METHOD_WITHOUT_OVERLOADS_1.toLowerCase())));
+
+        List<MethodVertex> methodVertices = MethodUtil.getTargetedMethods(g, targets);
+
+        MatcherAssert.assertThat(methodVertices, hasSize(equalTo(1)));
+        MethodVertex firstVertex = methodVertices.get(0);
+        assertEquals(METHOD_WITHOUT_OVERLOADS_1, firstVertex.getName());
+
+        String messages = CliMessager.getInstance().getAllMessages();
+        assertEquals("[]", messages);
+    }
+
+    @Test
     public void getTargetMethods_targetMultipleMethods() {
         TestUtil.Config config =
                 TestUtil.Config.Builder.get(g, new String[] {SOURCE_FILE_1, SOURCE_FILE_2}).build();

--- a/sfge/src/test/java/com/salesforce/graph/ops/directive/EngineDirectiveTest.java
+++ b/sfge/src/test/java/com/salesforce/graph/ops/directive/EngineDirectiveTest.java
@@ -513,13 +513,13 @@ public class EngineDirectiveTest {
         MatcherAssert.assertThat(engineDirectives, contains(DISABLE_STACK_1));
     }
 
-	/**
-	 * This is a test for W-11120894, wherein the sfge-disable-stack engine directive wasn't working for methods with
-	 * exceptions inside nested forked method calls. The attempt to clone the annotation during path generation
-	 * was causing an exception, which was overriding the functionality of the annotation itself.
-	 * This test recreates such a scenario, then makes sure the associated with it were correctly generated and contain
-	 * the expected annotation.
-	 */
+    /**
+     * This is a test for W-11120894, wherein the sfge-disable-stack engine directive wasn't working
+     * for methods with exceptions inside nested forked method calls. The attempt to clone the
+     * annotation during path generation was causing an exception, which was overriding the
+     * functionality of the annotation itself. This test recreates such a scenario, then makes sure
+     * the associated with it were correctly generated and contain the expected annotation.
+     */
     @MethodSource(value = "testDisableStackDirective")
     @ParameterizedTest(name = "{displayName}: directive=({0})")
     public void testDisableStackAnnotationWithForkedExceptionPaths(String directive) {
@@ -528,20 +528,20 @@ public class EngineDirectiveTest {
                     + directive
                     + "\n"
                     + "    public static void doSomething(boolean enterBranch, boolean throwException) {\n"
-					+ "        ExceptionThrower helper = new ExceptionThrower();\n"
-					+ "        if (enterBranch) {\n"
-					+ "            ExceptionThrower.throwExceptionIfAsked(throwException);\n"
-					+ "        }\n"
-					+ "        System.debug('hello');\n"
-					+ "    }\n"
-					+ "}",
-			"public class ExceptionThrower {\n"
-					+ "    public void throwExceptionIfAsked(boolean isAsked) {\n"
-					+ "        if (isAsked) {\n"
-					+ "            throw new MyException();\n"
-					+ "        }\n"
-					+ "    }\n"
-					+ "}"
+                    + "        ExceptionThrower helper = new ExceptionThrower();\n"
+                    + "        if (enterBranch) {\n"
+                    + "            ExceptionThrower.throwExceptionIfAsked(throwException);\n"
+                    + "        }\n"
+                    + "        System.debug('hello');\n"
+                    + "    }\n"
+                    + "}",
+            "public class ExceptionThrower {\n"
+                    + "    public void throwExceptionIfAsked(boolean isAsked) {\n"
+                    + "        if (isAsked) {\n"
+                    + "            throw new MyException();\n"
+                    + "        }\n"
+                    + "    }\n"
+                    + "}"
         };
         List<EngineDirective> engineDirectives = new ArrayList<>();
         VertexPredicate predicate =

--- a/src/commands/scanner/run.ts
+++ b/src/commands/scanner/run.ts
@@ -118,6 +118,12 @@ export default class Run extends ScannerRunCommand {
 		if ((this.flags.pmdconfig || this.flags.eslintconfig) && (this.flags.category || this.flags.ruleset)) {
 			this.ux.log(messages.getMessage('output.filtersIgnoredCustom', []));
 		}
+		// None of the pathless engines support method-level targeting, so attempting to use it should result in an error.
+		for (const target of (this.flags.target as string[])) {
+			if (target.indexOf('#') > -1) {
+				throw SfdxError.create('@salesforce/sfdx-scanner', 'run', 'validations.methodLevelTargetingDisallowed', [target]);
+			}
+		}
 		return Promise.resolve();
 	}
 
@@ -153,12 +159,12 @@ export default class Run extends ScannerRunCommand {
 			const pmdConfig = normalize(untildify(this.flags.pmdconfig as string));
 			options.set(CUSTOM_CONFIG.PmdConfig, pmdConfig);
 		}
-		
+
 		// Capturing verbose-violations flag value (used for RetireJS output)
 		if (this.flags["verbose-violations"]) {
 			options.set(CUSTOM_CONFIG.VerboseViolations, "true");
 		}
-		
+
 
 		return options;
 	}


### PR DESCRIPTION
This PR does the following:
- method-level targets in SFGE are now case-insensitive.
- The SFGE warning message when multiple methods match a target is now 'always' instead of 'verbose'.
- Attempting method-level targeting in `scanner:run` now throws an error.
- A few miscellaneous formatting changes forced upon me by gradle.