### PR TITLE
@W-11267130@: violation messages use <br> instead of \n in html

### DIFF
--- a/src/lib/DefaultRuleManager.ts
+++ b/src/lib/DefaultRuleManager.ts
@@ -14,6 +14,7 @@ import {Controller} from '../Controller';
 import globby = require('globby');
 import path = require('path');
 import {uxEvents, EVENTS} from './ScannerEvents';
+import {CUSTOM_CONFIG} from '../Constants';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/sfdx-scanner', 'DefaultRuleManager');
@@ -127,7 +128,7 @@ export class DefaultRuleManager implements RuleManager {
 			psResults.forEach(r => results = results.concat(r));
 			this.logger.trace(`Received rule violations: ${JSON.stringify(results)}`);
 			this.logger.trace(`Recombining results into requested format ${runOptions.format}`);
-			return await RuleResultRecombinator.recombineAndReformatResults(results, runOptions.format, executedEngines);
+			return await RuleResultRecombinator.recombineAndReformatResults(results, runOptions.format, executedEngines, engineOptions.has(CUSTOM_CONFIG.VerboseViolations));
 		} catch (e) {
 			const message: string = e instanceof Error ? e.message : e as string;
 			throw new SfdxError(message);

--- a/src/lib/formatter/RuleResultRecombinator.ts
+++ b/src/lib/formatter/RuleResultRecombinator.ts
@@ -37,7 +37,7 @@ type DfaTableRow = BaseTableRow & {
 
 export class RuleResultRecombinator {
 
-	public static async recombineAndReformatResults(results: RuleResult[], format: OUTPUT_FORMAT, executedEngines: Set<string>): Promise<RecombinedRuleResults> {
+	public static async recombineAndReformatResults(results: RuleResult[], format: OUTPUT_FORMAT, executedEngines: Set<string>, verboseViolations = false): Promise<RecombinedRuleResults> {
 		// We need to change the results we were given into the desired final format.
 		let formattedResults: string | {columns; rows} = null;
 		switch (format) {
@@ -45,7 +45,7 @@ export class RuleResultRecombinator {
 				formattedResults = await this.constructCsv(results, executedEngines);
 				break;
 			case OUTPUT_FORMAT.HTML:
-				formattedResults = await this.constructHtml(results, executedEngines);
+				formattedResults = await this.constructHtml(results, executedEngines, verboseViolations);
 				break;
 			case OUTPUT_FORMAT.JSON:
 				formattedResults = this.constructJson(results);
@@ -351,7 +351,7 @@ URL: ${url}`;
 		return JSON.stringify(results.filter(r => r.violations.length > 0));
 	}
 
-	private static async constructHtml(results: RuleResult[], executedEngines: Set<string>): Promise<string> {
+	private static async constructHtml(results: RuleResult[], executedEngines: Set<string>, verboseViolations = false): Promise<string> {
 		// If the results were just an empty string, we can return it.
 		if (results.length === 0) {
 			return '';
@@ -373,7 +373,7 @@ URL: ${url}`;
 						ruleName: v.ruleName,
 						category: v.category,
 						url: v.url,
-						message: v.message.replace(/\n/g, '<br>'), // <br> used for line breaks in html
+						message: verboseViolations ? v.message.replace(/\n/g, '<br>') : v.message, // <br> used for line breaks in html
 						line: v.line,
 						column: v.column,
 						endLine: v.endLine || null,
@@ -387,7 +387,7 @@ URL: ${url}`;
 						ruleName: v.ruleName,
 						category: v.category,
 						url: v.url,
-						message: v.message.replace(/\n/g, '<br>'), // <br> used for line breaks in html
+						message: verboseViolations ? v.message.replace(/\n/g, '<br>') : v.message, // <br> used for line breaks in html
 						line: v.sourceLine,
 						column: v.sourceColumn,
 						sinkFileName: v.sinkFileName,

--- a/src/lib/formatter/RuleResultRecombinator.ts
+++ b/src/lib/formatter/RuleResultRecombinator.ts
@@ -1,7 +1,7 @@
 import {SfdxError} from '@salesforce/core';
 import * as path from 'path';
 import {EngineExecutionSummary, RecombinedData, RecombinedRuleResults, RuleResult, RuleViolation} from '../../types';
-import {DfaEngineFilters} from '../../Constants';
+import {DfaEngineFilters, ENGINE} from '../../Constants';
 import {OUTPUT_FORMAT} from '../RuleManager';
 import * as wrap from 'word-wrap';
 import {FileHandler} from '../util/FileHandler';
@@ -373,7 +373,7 @@ URL: ${url}`;
 						ruleName: v.ruleName,
 						category: v.category,
 						url: v.url,
-						message: verboseViolations && result.engine === 'retire-js' ? v.message.replace(/\n/g, '<br>') : v.message, // <br> used for line breaks in html
+						message: verboseViolations && result.engine === ENGINE.RETIRE_JS ? v.message.replace(/\n/g, '<br>') : v.message, // <br> used for line breaks in html
 						line: v.line,
 						column: v.column,
 						endLine: v.endLine || null,
@@ -387,7 +387,7 @@ URL: ${url}`;
 						ruleName: v.ruleName,
 						category: v.category,
 						url: v.url,
-						message: verboseViolations && result.engine === 'retire-js' ? v.message.replace(/\n/g, '<br>') : v.message, // <br> used for line breaks in html
+						message: v.message,
 						line: v.sourceLine,
 						column: v.sourceColumn,
 						sinkFileName: v.sinkFileName,

--- a/src/lib/formatter/RuleResultRecombinator.ts
+++ b/src/lib/formatter/RuleResultRecombinator.ts
@@ -373,7 +373,7 @@ URL: ${url}`;
 						ruleName: v.ruleName,
 						category: v.category,
 						url: v.url,
-						message: v.message,
+						message: v.message.replace(/\n/g, '<br>'), // <br> used for line breaks in html
 						line: v.line,
 						column: v.column,
 						endLine: v.endLine || null,
@@ -387,7 +387,7 @@ URL: ${url}`;
 						ruleName: v.ruleName,
 						category: v.category,
 						url: v.url,
-						message: v.message,
+						message: v.message.replace(/\n/g, '<br>'), // <br> used for line breaks in html
 						line: v.sourceLine,
 						column: v.sourceColumn,
 						sinkFileName: v.sinkFileName,

--- a/src/lib/formatter/RuleResultRecombinator.ts
+++ b/src/lib/formatter/RuleResultRecombinator.ts
@@ -373,7 +373,7 @@ URL: ${url}`;
 						ruleName: v.ruleName,
 						category: v.category,
 						url: v.url,
-						message: verboseViolations ? v.message.replace(/\n/g, '<br>') : v.message, // <br> used for line breaks in html
+						message: verboseViolations && result.engine === 'retire-js' ? v.message.replace(/\n/g, '<br>') : v.message, // <br> used for line breaks in html
 						line: v.line,
 						column: v.column,
 						endLine: v.endLine || null,
@@ -387,7 +387,7 @@ URL: ${url}`;
 						ruleName: v.ruleName,
 						category: v.category,
 						url: v.url,
-						message: verboseViolations ? v.message.replace(/\n/g, '<br>') : v.message, // <br> used for line breaks in html
+						message: verboseViolations && result.engine === 'retire-js' ? v.message.replace(/\n/g, '<br>') : v.message, // <br> used for line breaks in html
 						line: v.sourceLine,
 						column: v.sourceColumn,
 						sinkFileName: v.sinkFileName,

--- a/test/lib/formatter/RuleResultRecombinator.test.ts
+++ b/test/lib/formatter/RuleResultRecombinator.test.ts
@@ -288,6 +288,22 @@ const allFakeDfaRuleResultsNormalized: RuleResult[] = [
 	}
 ];
 
+const retireJsVerboseViolations: RuleResult[] = [
+	{
+		engine: 'retire-js',
+		fileName: sampleFile1,
+		violations: [{
+			"line": 1,
+			"column": 1,
+			"severity": 2,
+			"message": "jquery 3.1.0 has known vulnerabilities:\nseverity: medium; summary: jQuery before 3.4.0, as used in Drupal, Backdrop CMS, and other products, mishandles jQuery.extend(true, {}, ...) because of Object.prototype pollution; CVE: CVE-2019-11358; https://blog.jquery.com/2019/04/10/jquery-3-4-0-released/ https://nvd.nist.gov/vuln/detail/CVE-2019-11358 https://github.com/jquery/jquery/commit/753d591aea698e57d6db58c9f722cd0808619b1b\nseverity: medium; summary: Regex in its jQuery.htmlPrefilter sometimes may introduce XSS; CVE: CVE-2020-11022; https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/\nseverity: medium; summary: Regex in its jQuery.htmlPrefilter sometimes may introduce XSS; CVE: CVE-2020-11023; https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/",
+			"ruleName": "insecure-bundled-dependencies",
+			"category": "Insecure Dependencies",
+		}]
+	}
+];
+
+
 function isString(x: string | {columns; rows}): x is string {
 	return typeof x === 'string';
 }
@@ -1266,6 +1282,15 @@ describe('RuleResultRecombinator', () => {
 				// Make sure we have iterated through all of the results.
 				// It's one more than the number of problems because of the post increment.
 				expect(problemNumber).to.equal(6, 'Problem Number Index');
+			});
+		});
+
+		describe('Output Format: HTML', () => {
+			it ('Using --verbose-violations', async () => {				
+				const results = (await RuleResultRecombinator.recombineAndReformatResults(retireJsVerboseViolations, OUTPUT_FORMAT.HTML, new Set(['retire-js']), true)).results as string;
+				const violationString = results.split("const violations = [")[1].split("];\n")[0];
+				const violation: RuleViolation = JSON.parse(violationString as string);
+				expect(violation.message).to.equal("jquery 3.1.0 has known vulnerabilities:<br>severity: medium; summary: jQuery before 3.4.0, as used in Drupal, Backdrop CMS, and other products, mishandles jQuery.extend(true, {}, ...) because of Object.prototype pollution; CVE: CVE-2019-11358; https://blog.jquery.com/2019/04/10/jquery-3-4-0-released/ https://nvd.nist.gov/vuln/detail/CVE-2019-11358 https://github.com/jquery/jquery/commit/753d591aea698e57d6db58c9f722cd0808619b1b<br>severity: medium; summary: Regex in its jQuery.htmlPrefilter sometimes may introduce XSS; CVE: CVE-2020-11022; https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/<br>severity: medium; summary: Regex in its jQuery.htmlPrefilter sometimes may introduce XSS; CVE: CVE-2020-11023; https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/");
 			});
 		});
 	});


### PR DESCRIPTION
Line breaks now occur when expected. 

However, adding this code has cause a test error: Coverage for branches (79.96%) does not meet global threshold (80%)
Should constructHtml (and contructJson) have additional tests for when verboseViolations is true?