### PR TITLE
@W-10459675@: Part 4 of several. Added Messaging.InboundEmailHandler implementations as sources.

### DIFF
--- a/sfge/src/main/java/com/salesforce/graph/Schema.java
+++ b/sfge/src/main/java/com/salesforce/graph/Schema.java
@@ -28,6 +28,7 @@ public class Schema {
     public static final String IDENTIFIER = "Identifier";
     public static final String IMPLEMENTATION_OF = "ImplementationOf";
     public static final String IMPLEMENTED_BY = "ImplementedBy";
+    public static final String INTERFACE_DEFINING_TYPES = "InterfaceDefiningTypes";
     public static final String INTERFACE_NAMES = "InterfaceNames";
     /** True if this vertex is part of the Apex Standard Library */
     public static final String IS_STANDARD = "IsStandard";

--- a/sfge/src/main/java/com/salesforce/graph/build/AbstractApexVertexBuilder.java
+++ b/sfge/src/main/java/com/salesforce/graph/build/AbstractApexVertexBuilder.java
@@ -82,9 +82,11 @@ abstract class AbstractApexVertexBuilder {
             final Vertex vChild = g.addV(child.getLabel()).next();
             addProperties(g, child, vChild);
 
-            /** Handle static block if we are looking at a <clinit> method that has a block statement.
-             * See {@linkplain StaticBlockUtil} on why this is needed
-             * and how we handle it. */
+            /**
+             * Handle static block if we are looking at a <clinit> method that has a block
+             * statement. See {@linkplain StaticBlockUtil} on why this is needed and how we handle
+             * it.
+             */
             if (StaticBlockUtil.isStaticBlockStatement(node, child)) {
                 final Vertex parentVertexForChild =
                         StaticBlockUtil.createSyntheticStaticBlockMethod(g, vNode, i);

--- a/sfge/src/main/java/com/salesforce/graph/build/CaseSafePropertyUtil.java
+++ b/sfge/src/main/java/com/salesforce/graph/build/CaseSafePropertyUtil.java
@@ -81,16 +81,16 @@ public class CaseSafePropertyUtil {
         return value.toLowerCase(Locale.ROOT);
     }
 
-    private static ArrayList toCaseSafeValue(ArrayList value) {
+    private static Object[] toCaseSafeValue(ArrayList value) {
         if (value.isEmpty() || !(value.get(0) instanceof String)) {
             // An empty array or non-string array can't be made case-safe.
-            return value;
+            return value.toArray();
         } else {
             ArrayList<String> stringList = new ArrayList<>();
             for (Object o : value) {
                 stringList.add(((String) o).toLowerCase(Locale.ROOT));
             }
-            return stringList;
+            return stringList.toArray();
         }
     }
 

--- a/sfge/src/main/java/com/salesforce/graph/build/CaseSafePropertyUtil.java
+++ b/sfge/src/main/java/com/salesforce/graph/build/CaseSafePropertyUtil.java
@@ -39,12 +39,13 @@ public class CaseSafePropertyUtil {
     // The following properties are (with rare exception) assumed to be case-sensitive.
     private static final ImmutableSet<String> CASE_SENSITIVE_PROPERTIES =
             ImmutableSet.of(
-                    Schema.NAME,
                     Schema.DEFINING_TYPE,
                     Schema.FULL_METHOD_NAME,
+                    Schema.INTERFACE_DEFINING_TYPES,
                     Schema.INTERFACE_NAMES,
                     Schema.METHOD_NAME,
                     Schema.NAME,
+                    Schema.RETURN_TYPE,
                     Schema.SUPER_CLASS_NAME,
                     Schema.SUPER_INTERFACE_NAME);
 
@@ -189,6 +190,20 @@ public class CaseSafePropertyUtil {
                 return __.has(nodeType, caseSafeVariant, TextP.endingWith(toCaseSafeValue(value)));
             } else {
                 return __.has(nodeType, property, TextP.endingWith(value));
+            }
+        }
+
+        public static GraphTraversal<Object, Object> hasArrayContaining(
+                String nodeType, String property, String value) {
+            if (property.equalsIgnoreCase(Schema.DEFINING_TYPE)) {
+                throw new UnexpectedException(property);
+            }
+            String caseSafeVariant = toCaseSafeProperty(property).orElse(null);
+            if (caseSafeVariant != null) {
+                return __.hasLabel(nodeType)
+                        .has(caseSafeVariant, __.unfold().is(toCaseSafeValue(value)));
+            } else {
+                return __.hasLabel(nodeType).has(property, __.unfold().is(value));
             }
         }
     }

--- a/sfge/src/main/java/com/salesforce/graph/build/InheritanceEdgeBuilder.java
+++ b/sfge/src/main/java/com/salesforce/graph/build/InheritanceEdgeBuilder.java
@@ -183,11 +183,17 @@ public class InheritanceEdgeBuilder implements GraphBuilder {
     }
 
     private void addProperties(Long inheritorId, List<String> implementedVertexDefiningTypes) {
-        GraphTraversal<Vertex,Vertex> traversal = g.V(inheritorId);
-        // It's probably not best practice to be using an empty treeset here, but we no longer have access to the treeset
-        // that was used when adding the base properties, and we're setting a property that definitely isn't set elsewhere,
+        GraphTraversal<Vertex, Vertex> traversal = g.V(inheritorId);
+        // It's probably not best practice to be using an empty treeset here, but we no longer have
+        // access to the treeset
+        // that was used when adding the base properties, and we're setting a property that
+        // definitely isn't set elsewhere,
         // so it should be fine.
-        GremlinVertexUtil.addProperty(new TreeSet<>(), traversal, Schema.INTERFACE_DEFINING_TYPES, implementedVertexDefiningTypes);
+        GremlinVertexUtil.addProperty(
+                new TreeSet<>(),
+                traversal,
+                Schema.INTERFACE_DEFINING_TYPES,
+                implementedVertexDefiningTypes);
         traversal.iterate();
     }
 }

--- a/sfge/src/main/java/com/salesforce/graph/build/InheritanceEdgeBuilder.java
+++ b/sfge/src/main/java/com/salesforce/graph/build/InheritanceEdgeBuilder.java
@@ -10,7 +10,6 @@ import com.salesforce.graph.vertex.BaseSFVertex;
 import com.salesforce.graph.vertex.InheritableSFVertex;
 import com.salesforce.graph.vertex.SFVertexFactory;
 import com.salesforce.graph.vertex.UserClassVertex;
-import com.salesforce.graph.vertex.UserInterfaceVertex;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -18,10 +17,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
@@ -73,7 +72,8 @@ public class InheritanceEdgeBuilder implements GraphBuilder {
 
     private void processVertexInheritance(InheritableSFVertex vertex) {
         InheritableSFVertex extendedVertex = findExtendedVertex(vertex).orElse(null);
-        List<InheritableSFVertex> implementedVertices = findImplementedVertices(vertex);
+        Map<String, InheritableSFVertex> implementedVerticesByName =
+                findImplementedVerticesByName(vertex);
 
         // It's possible for the extendedVertex to be null, if the extended class is declared in a
         // file that wasn't scanned.
@@ -85,17 +85,30 @@ public class InheritanceEdgeBuilder implements GraphBuilder {
                     Schema.EXTENSION_OF);
         }
 
-        if (implementedVertices != null) {
-            for (InheritableSFVertex implementedVertex : implementedVertices) {
-                // It's possible for the implementedVertex to be null if the interface being
-                // implemented is declared in a file
-                // that wasn't scanned.
+        if (!implementedVerticesByName.isEmpty()) {
+            List<String> implementedVertexDefiningTypes = new ArrayList<>();
+            Long myId = vertex.getId();
+            for (String implementedVertexName : implementedVerticesByName.keySet()) {
+                InheritableSFVertex implementedVertex =
+                        implementedVerticesByName.get(implementedVertexName);
+                // If we actually have a vertex for this interface, we need to create edges
+                // connecting it to the implementor,
+                // and we can use its defining type for our list.
                 if (implementedVertex != null) {
                     Long implId = implementedVertex.getId();
-                    Long myId = vertex.getId();
                     addEdges(implId, myId, Schema.IMPLEMENTED_BY, Schema.IMPLEMENTATION_OF);
+                    implementedVertexDefiningTypes.add(implementedVertex.getDefiningType());
+                } else {
+                    // If there's no vertex for this interface, we can assume it's defined in some
+                    // other codebase, and therefore
+                    // whatever name was used by the implementor to reference it can be assumed to
+                    // be the defining type.
+                    implementedVertexDefiningTypes.add(implementedVertexName);
                 }
             }
+            // Give the implementor new properties indicating the full names of the implemented
+            // interfaces.
+            addProperties(myId, implementedVertexDefiningTypes);
         }
     }
 
@@ -108,18 +121,20 @@ public class InheritanceEdgeBuilder implements GraphBuilder {
         }
     }
 
-    private List<InheritableSFVertex> findImplementedVertices(InheritableSFVertex vertex) {
-        if (vertex instanceof UserInterfaceVertex) {
-            return new ArrayList<>();
-        } else {
+    private Map<String, InheritableSFVertex> findImplementedVerticesByName(
+            InheritableSFVertex vertex) {
+        Map<String, InheritableSFVertex> results = new HashMap<>();
+        // Only classes can implement interfaces.
+        if (vertex instanceof UserClassVertex) {
             String inheritorType = vertex.getDefiningType();
-            return ((UserClassVertex) vertex)
-                    .getInterfaceNames().stream()
-                            .map(i -> findInheritedVertex(i, inheritorType))
-                            .filter(v -> v.isPresent())
-                            .map(v -> v.get())
-                            .collect(Collectors.toList());
+            List<String> interfaceNames = ((UserClassVertex) vertex).getInterfaceNames();
+            for (String interfaceName : interfaceNames) {
+                InheritableSFVertex inheritedVertex =
+                        findInheritedVertex(interfaceName, inheritorType).orElse(null);
+                results.put(interfaceName, inheritedVertex);
+            }
         }
+        return results;
     }
 
     private Optional<InheritableSFVertex> findInheritedVertex(
@@ -127,17 +142,19 @@ public class InheritanceEdgeBuilder implements GraphBuilder {
         if (inheritableType == null) {
             throw new UnexpectedException("inheritableType can't be null");
         }
-        // If the inheritor type contains a period, it's an inner type. If the inheritable type does
-        // not contain a period,
-        // it could be either an outer type, or an inner type declared in the same outer type. The
-        // latter overrides the
-        // former, so we'll derive the full name of such an inner type so we can check if it exists.
-        if (inheritorType.contains(".") && !inheritableType.contains(".")) {
-            String[] parts = inheritorType.split("\\.");
-
-            String possibleInnerType = parts[0] + "." + inheritableType;
-            if (verticesByDefiningType.containsKey(possibleInnerType)) {
-                return Optional.ofNullable(verticesByDefiningType.get(possibleInnerType));
+        // If the inheritable type does NOT contain a period, then it's either an outer type, or an
+        // inner type declared
+        // in the same outer type as the inheritor type.
+        // The latter takes priority over the former, so we should check if it's the case.
+        if (!inheritableType.contains(".")) {
+            // If the inheritor type contains a period, then it's an inner type, and we should use
+            // its outer type.
+            // Otherwise, we should use the inheritor type as a potential outer type.
+            String potentialOuterType =
+                    inheritorType.contains(".") ? inheritorType.split("\\.")[0] : inheritorType;
+            String potentialInnerType = potentialOuterType + "." + inheritableType;
+            if (verticesByDefiningType.containsKey(potentialInnerType)) {
+                return Optional.ofNullable(verticesByDefiningType.get(potentialInnerType));
             }
         }
 
@@ -162,5 +179,16 @@ public class InheritanceEdgeBuilder implements GraphBuilder {
         Vertex inheritor = g.V(inheritorId).next();
         g.addE(fromEdge).from(inheritable).to(inheritor).iterate();
         g.addE(toEdge).from(inheritor).to(inheritable).iterate();
+    }
+
+    private void addProperties(Long inheritorId, List<String> implementedVertexDefiningTypes) {
+        // Add the base property and its case-safe version.
+        GraphTraversal<Vertex, Vertex> traversal =
+                g.V(inheritorId)
+                        .property(Schema.INTERFACE_DEFINING_TYPES, implementedVertexDefiningTypes);
+        CaseSafePropertyUtil.addCaseSafeProperty(
+                traversal, Schema.INTERFACE_DEFINING_TYPES, implementedVertexDefiningTypes);
+        // Commit the traversal.
+        traversal.iterate();
     }
 }

--- a/sfge/src/main/java/com/salesforce/graph/build/InheritanceEdgeBuilder.java
+++ b/sfge/src/main/java/com/salesforce/graph/build/InheritanceEdgeBuilder.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
+import java.util.TreeSet;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
@@ -182,13 +183,11 @@ public class InheritanceEdgeBuilder implements GraphBuilder {
     }
 
     private void addProperties(Long inheritorId, List<String> implementedVertexDefiningTypes) {
-        // Add the base property and its case-safe version.
-        GraphTraversal<Vertex, Vertex> traversal =
-                g.V(inheritorId)
-                        .property(Schema.INTERFACE_DEFINING_TYPES, implementedVertexDefiningTypes);
-        CaseSafePropertyUtil.addCaseSafeProperty(
-                traversal, Schema.INTERFACE_DEFINING_TYPES, implementedVertexDefiningTypes);
-        // Commit the traversal.
+        GraphTraversal<Vertex,Vertex> traversal = g.V(inheritorId);
+        // It's probably not best practice to be using an empty treeset here, but we no longer have access to the treeset
+        // that was used when adding the base properties, and we're setting a property that definitely isn't set elsewhere,
+        // so it should be fine.
+        GremlinVertexUtil.addProperty(new TreeSet<>(), traversal, Schema.INTERFACE_DEFINING_TYPES, implementedVertexDefiningTypes);
         traversal.iterate();
     }
 }

--- a/sfge/src/main/java/com/salesforce/graph/build/StaticBlockUtil.java
+++ b/sfge/src/main/java/com/salesforce/graph/build/StaticBlockUtil.java
@@ -19,9 +19,7 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 /**
  * Handles creation of synthetic methods and vertices to gracefully invoke static code blocks.
  *
- * <p>Consider this example:
- *
- * <code>
+ * <p>Consider this example: <code>
  * class StaticBlockClass {
  *  static {
  *      System.debug("inside static block 1");
@@ -30,10 +28,7 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
  *      System.debug("inside static block 2");
  *  }
  * }
- * </code>
- *
- * In Jorje's compilation structure, static blocks are represented like this:
- * <code>
+ * </code> In Jorje's compilation structure, static blocks are represented like this: <code>
  * class StaticBlockClass {
  *  private static void <clinit>() {
  *      {
@@ -46,17 +41,17 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
  * }
  * </code>
  *
- * <p>Having multiple block statements inside a method breaks SFGE's normal code flow logic.
- * This makes handling code blocks in <code><clinit>()</code> impossible.
- * <p>As an alternative, we are creating synthetic vertices in the Graph to
- * represent the static blocks as individual methods.
- * <p>We also create one top-level synthetic method ("StaticBlockInvoker") that invokes
- * individual static block methods. While creating static scope
- * for this class, we should invoke the method call expressions inside the top-level synthetic
- * method.
+ * <p>Having multiple block statements inside a method breaks SFGE's normal code flow logic. This
+ * makes handling code blocks in <code><clinit>()</code> impossible.
  *
- * <p>New structure looks like this:
- * <code>
+ * <p>As an alternative, we are creating synthetic vertices in the Graph to represent the static
+ * blocks as individual methods.
+ *
+ * <p>We also create one top-level synthetic method ("StaticBlockInvoker") that invokes individual
+ * static block methods. While creating static scope for this class, we should invoke the method
+ * call expressions inside the top-level synthetic method.
+ *
+ * <p>New structure looks like this: <code>
  *     class StaticBlockClass {
  *      private static void SyntheticStaticBlock_1() {
  *          System.debug("inside static block 1");
@@ -90,12 +85,11 @@ public final class StaticBlockUtil {
      *     parent for blockStatementVertex, and a sibling of <clinit>()
      */
     public static Vertex createSyntheticStaticBlockMethod(
-        GraphTraversalSource g,
-        Vertex clinitVertex,
-        int staticBlockIndex) {
+            GraphTraversalSource g, Vertex clinitVertex, int staticBlockIndex) {
         final Vertex syntheticMethodVertex = g.addV(ASTConstants.NodeType.METHOD).next();
         final String definingType = clinitVertex.value(Schema.DEFINING_TYPE);
-        final List<Vertex> siblings = GremlinUtil.getChildren(g, GremlinVertexUtil.getParentVertex(g, clinitVertex));
+        final List<Vertex> siblings =
+                GremlinUtil.getChildren(g, GremlinVertexUtil.getParentVertex(g, clinitVertex));
         final int nextSiblingIndex = siblings.size();
 
         addSyntheticStaticBlockMethodProperties(
@@ -286,7 +280,10 @@ public final class StaticBlockUtil {
     }
 
     private static void addStaticBlockInvokerProperties(
-        GraphTraversalSource g, String definingType, Vertex staticBlockInvokerVertex, int childIndex) {
+            GraphTraversalSource g,
+            String definingType,
+            Vertex staticBlockInvokerVertex,
+            int childIndex) {
         verifyType(staticBlockInvokerVertex, ASTConstants.NodeType.METHOD);
         final Map<String, Object> properties = new HashMap<>();
         properties.put(Schema.NAME, STATIC_BLOCK_INVOKER_METHOD);
@@ -296,11 +293,11 @@ public final class StaticBlockUtil {
     }
 
     private static void addSyntheticStaticBlockMethodProperties(
-        GraphTraversalSource g,
-        String definingType,
-        Vertex syntheticMethodVertex,
-        int staticBlockIndex,
-        int childIndex) {
+            GraphTraversalSource g,
+            String definingType,
+            Vertex syntheticMethodVertex,
+            int staticBlockIndex,
+            int childIndex) {
         verifyType(syntheticMethodVertex, ASTConstants.NodeType.METHOD);
         final Map<String, Object> properties = new HashMap<>();
         properties.put(

--- a/sfge/src/main/java/com/salesforce/graph/ops/MethodUtil.java
+++ b/sfge/src/main/java/com/salesforce/graph/ops/MethodUtil.java
@@ -81,6 +81,9 @@ public final class MethodUtil {
     private static final Logger LOGGER = LogManager.getLogger(MethodUtil.class);
 
     private static final String PAGE_REFERENCE = "PageReference";
+    private static final String INBOUND_EMAIL_HANDLER = "Messaging.InboundEmailHandler";
+    private static final String HANDLE_INBOUND_EMAIL = "handleInboundEmail";
+    private static final String INBOUND_EMAIL_RESULT = "Messaging.InboundEmailResult";
     public static final String INSTANCE_CONSTRUCTOR_CANONICAL_NAME = "<init>";
     public static final String STATIC_CONSTRUCTOR_CANONICAL_NAME = "<clinit>";
 
@@ -255,6 +258,21 @@ public final class MethodUtil {
                                         // Ignore any standard methods, otherwise will get a ton of
                                         // extra results.
                                         __.not(__.has(Schema.IS_STANDARD, true)))));
+    }
+
+    public static List<MethodVertex> getInboundEmailHandlerMethods(
+            GraphTraversalSource g, List<String> targetFiles) {
+        return SFVertexFactory.loadVertices(
+                g,
+                // Get any target class that implements the email handler interface.
+                TraversalUtil.traverseImplementationsOf(g, targetFiles, INBOUND_EMAIL_HANDLER)
+                        // Get every implementation of the handle email method.
+                        .out(Schema.CHILD)
+                        .where(H.has(NodeType.METHOD, Schema.NAME, HANDLE_INBOUND_EMAIL))
+                        // Filter the results by return type and arity to limit the possibility of
+                        // getting unnecessary results.
+                        .where(H.has(NodeType.METHOD, Schema.RETURN_TYPE, INBOUND_EMAIL_RESULT))
+                        .has(Schema.ARITY, 2));
     }
 
     /**

--- a/sfge/src/main/java/com/salesforce/graph/ops/TraversalUtil.java
+++ b/sfge/src/main/java/com/salesforce/graph/ops/TraversalUtil.java
@@ -70,6 +70,11 @@ public final class TraversalUtil {
                                         .toArray(GraphTraversal[]::new));
     }
 
+    /**
+     * Returns a traversal containing every class in the target files that  implements the specified interface, either
+     * directly or indirectly (i.e., by extending a class that implements it, implementing an interface that extends it,
+     * or extending a class that does either of those things). An empty target array implicitly targets the whole graph.
+     */
     public static GraphTraversal<Vertex, Vertex> traverseImplementationsOf(
             GraphTraversalSource g, List<String> targetFiles, String interfaceName) {
         // For our traversal, we want to start with every class that implements either the target

--- a/sfge/src/main/java/com/salesforce/graph/ops/TraversalUtil.java
+++ b/sfge/src/main/java/com/salesforce/graph/ops/TraversalUtil.java
@@ -71,9 +71,10 @@ public final class TraversalUtil {
     }
 
     /**
-     * Returns a traversal containing every class in the target files that  implements the specified interface, either
-     * directly or indirectly (i.e., by extending a class that implements it, implementing an interface that extends it,
-     * or extending a class that does either of those things). An empty target array implicitly targets the whole graph.
+     * Returns a traversal containing every class in the target files that implements the specified
+     * interface, either directly or indirectly (i.e., by extending a class that implements it,
+     * implementing an interface that extends it, or extending a class that does either of those
+     * things). An empty target array implicitly targets the whole graph.
      */
     public static GraphTraversal<Vertex, Vertex> traverseImplementationsOf(
             GraphTraversalSource g, List<String> targetFiles, String interfaceName) {

--- a/sfge/src/main/java/com/salesforce/graph/ops/TraversalUtil.java
+++ b/sfge/src/main/java/com/salesforce/graph/ops/TraversalUtil.java
@@ -1,7 +1,9 @@
 package com.salesforce.graph.ops;
 
 import com.salesforce.apex.jorje.ASTConstants;
+import com.salesforce.apex.jorje.ASTConstants.NodeType;
 import com.salesforce.graph.Schema;
+import com.salesforce.graph.build.CaseSafePropertyUtil.H;
 import com.salesforce.rules.AbstractRuleRunner.RuleRunnerTarget;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -66,6 +68,65 @@ public final class TraversalUtil {
                                 targets.stream()
                                         .map(t -> t.createTraversal(__.select("Root")))
                                         .toArray(GraphTraversal[]::new));
+    }
+
+    public static GraphTraversal<Vertex, Vertex> traverseImplementationsOf(
+            GraphTraversalSource g, List<String> targetFiles, String interfaceName) {
+        // For our traversal, we want to start with every class that implements either the target
+        // interface or one of its
+        // subtypes. Do that with a union of these two subtraversals.
+        // Also, start with the hasLabel() call, because doing an initial filter along an indexed
+        // field saves us a ton of time.
+        GraphTraversal<Vertex, Vertex> traversal =
+                g.V().hasLabel(NodeType.USER_CLASS, NodeType.USER_INTERFACE)
+                        .union(
+                                // Subtraversal 1: Get every class that implements the target
+                                // interface, via a helper method.
+                                __.where(
+                                        H.hasArrayContaining(
+                                                NodeType.USER_CLASS,
+                                                Schema.INTERFACE_DEFINING_TYPES,
+                                                interfaceName)),
+                                // Subtraversal 2: Get every class that implements a subtype of the
+                                // target interface, by starting with all
+                                // the direct subtypes of the interface...
+                                __.where(
+                                                H.has(
+                                                        NodeType.USER_INTERFACE,
+                                                        Schema.SUPER_INTERFACE_NAME,
+                                                        interfaceName))
+                                        .union(
+                                                __.identity(),
+                                                // ...recursively adding subtypes of those
+                                                // interfaces...
+                                                __.repeat(__.out(Schema.EXTENDED_BY)).emit())
+                                        // ... and getting every class that implements one of those
+                                        // interfaces.
+                                        .out(Schema.IMPLEMENTED_BY)
+                                // Now, we add every subclass of any of these classes, recursively.
+                                )
+                        .union(__.identity(), __.repeat(__.out(Schema.EXTENDED_BY)).emit());
+
+        // If there are no target files, we're clear to return this traversal since it includes all
+        // relevant classes in
+        // the graph.
+        if (targetFiles.isEmpty()) {
+            return traversal;
+        } else {
+            // Otherwise, we need to filter so we're only returning the classes in a target file. To
+            // do that, do a traversal
+            // to get all the IDs of classes defined in the target files.
+            Object[] targetIds =
+                    fileRootTraversal(g, targetFiles)
+                            .union(__.identity(), __.repeat(__.out(Schema.CHILD)).emit())
+                            .hasLabel(NodeType.USER_CLASS)
+                            .id()
+                            .toList()
+                            .toArray();
+            // Note, there's no .hasId(Object...) overload, so we're using the .hasId(Object,
+            // ...Object) overload instead.
+            return traversal.hasId(targetIds);
+        }
     }
 
     private TraversalUtil() {}

--- a/sfge/src/main/java/com/salesforce/rules/RuleUtil.java
+++ b/sfge/src/main/java/com/salesforce/rules/RuleUtil.java
@@ -67,6 +67,8 @@ public final class RuleUtil {
             methods.addAll(MethodUtil.getPageReferenceMethods(g, fileLevelTargets));
             // ...and global-exposed methods...
             methods.addAll(MethodUtil.getGlobalMethods(g, fileLevelTargets));
+            // ...and implementations of Messaging.InboundEmailHandler#handleInboundEmail...
+            methods.addAll(MethodUtil.getInboundEmailHandlerMethods(g, fileLevelTargets));
             // ...and exposed methods on VF controllers.
             methods.addAll(MethodUtil.getExposedControllerMethods(g, fileLevelTargets));
         }

--- a/sfge/src/test/java/com/salesforce/graph/build/CustomerApexVertexBuilderTest.java
+++ b/sfge/src/test/java/com/salesforce/graph/build/CustomerApexVertexBuilderTest.java
@@ -117,11 +117,10 @@ public class CustomerApexVertexBuilderTest {
                         Schema.SUPER_CLASS_NAME + CaseSafePropertyUtil.CASE_SAFE_SUFFIX));
         assertEquals(
                 "someinterface",
-                ((ArrayList)
+                ((Object[])
                                 userClassVertex.get(
                                         Schema.INTERFACE_NAMES
-                                                + CaseSafePropertyUtil.CASE_SAFE_SUFFIX))
-                        .get(0));
+                                                + CaseSafePropertyUtil.CASE_SAFE_SUFFIX))[0]);
 
         Map<Object, Object> userInterfaceVertex =
                 g.V().hasLabel(NodeType.USER_INTERFACE).elementMap().next();

--- a/sfge/src/test/java/com/salesforce/graph/build/InheritanceEdgeBuilderTest.java
+++ b/sfge/src/test/java/com/salesforce/graph/build/InheritanceEdgeBuilderTest.java
@@ -1,7 +1,19 @@
 package com.salesforce.graph.build;
 
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.IsEqual.equalTo;
+
 import com.salesforce.TestUtil;
+import com.salesforce.apex.jorje.ASTConstants.NodeType;
+import com.salesforce.graph.Schema;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.apache.tinkerpop.gremlin.process.traversal.Order;
+import org.apache.tinkerpop.gremlin.process.traversal.Scope;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -14,22 +26,319 @@ public class InheritanceEdgeBuilderTest {
     }
 
     @Test
-    public void testSimpleExtension() {
-        // TODO
+    public void testNoInheritance() {
+        String[] sourceCodes = {"public class c1 {}", "public interface i1 {}"};
+
+        // Build the graph.
+        // TODO: Ideally, this would call the edge builder directly against an incomplete graph.
+        TestUtil.buildGraph(g, sourceCodes);
+
+        // Verify that nothing has any inheritance edges.
+        verifyNoEdges(g, Schema.IMPLEMENTED_BY);
+        verifyNoEdges(g, Schema.IMPLEMENTATION_OF);
+        verifyNoEdges(g, Schema.EXTENDED_BY);
+        verifyNoEdges(g, Schema.EXTENSION_OF);
     }
 
     @Test
-    public void testInnerTypeExtension() {
-        // TODO
+    public void testSimpleClassExtension() {
+        String[] sourceCodes = {
+            "public class c1 {}", "public class c2 extends c1{}",
+        };
+
+        // Build the graph.
+        // TODO: Ideally, this would call the edge builder directly against an incomplete graph.
+        TestUtil.buildGraph(g, sourceCodes);
+
+        // Verify that the extension looks right.
+        verifyExtension(g, "c1", "c2");
+
+        // Verify that there are no implementation edges.
+        verifyNoEdges(g, Schema.IMPLEMENTED_BY);
+        verifyNoEdges(g, Schema.IMPLEMENTATION_OF);
+    }
+
+    @Test
+    public void testSimpleInterfaceExtension() {
+        String[] sourceCodes = {
+            "public interface i1 {}", "public interface i2 extends i1{}",
+        };
+
+        // Build the graph.
+        // TODO: Ideally, this would call the edge builder directly against an incomplete graph.
+        TestUtil.buildGraph(g, sourceCodes);
+
+        // Verify that the extension looks right.
+        verifyExtension(g, "i1", "i2");
+
+        // Verify that there are no implementation edges.
+        verifyNoEdges(g, Schema.IMPLEMENTED_BY);
+        verifyNoEdges(g, Schema.IMPLEMENTATION_OF);
     }
 
     @Test
     public void testSimpleImplementation() {
-        // TODO
+        String[] sourceCodes = {
+            "public interface i1 {}", "public class c1 implements i1{}",
+        };
+
+        // Build the graph.
+        // TODO: Ideally, this would call the edge builder directly against an incomplete graph.
+        TestUtil.buildGraph(g, sourceCodes);
+
+        // Verify that the implementations look right.
+        verifyImplementation(g, "i1", "c1");
+
+        // Verify that there are no extension edges.
+        verifyNoEdges(g, Schema.EXTENDED_BY);
+        verifyNoEdges(g, Schema.EXTENSION_OF);
     }
 
     @Test
-    public void testInnerTypeImplementation() {
-        // TODO
+    public void testImplementationOfExternalInterface() {
+        String[] sourceCodes = {"public class c1 implements ExternallyDeclaredInterface {}"};
+
+        // Build the graph.
+        // TODO: Ideally, this would call the edge builder directly against an incomplete graph.
+        TestUtil.buildGraph(g, sourceCodes);
+
+        // Verify that the right properties were set.
+        verifyInterfaceDefiningTypeProperty(
+                g, "ExternallyDeclaredInterface", Collections.singletonList("c1"));
+        // Verify that no edges were created.
+        verifyNoEdges(g, Schema.IMPLEMENTED_BY);
+        verifyNoEdges(g, Schema.IMPLEMENTATION_OF);
+        verifyNoEdges(g, Schema.EXTENDED_BY);
+        verifyNoEdges(g, Schema.EXTENSION_OF);
+    }
+
+    @Test
+    public void testExtensionOfInnerClass() {
+        String[] sourceCodes = {
+            // Extensions in this class don't use the outer class name.
+            "public class OuterClass1 extends InnerClass1 {\n"
+                    + "    public class InnerClass1 {}\n"
+                    + "    public class InnerClass2 extends InnerClass1 {}\n"
+                    + "}",
+            // Extensions in this class use the outer class name.
+            "public class OuterClass2 extends OuterClass2.InnerClass1 {\n"
+                    + "    public class InnerClass1 {}\n"
+                    + "    public class InnerClass2 extends InnerClass1 {}\n"
+                    + "}",
+            // Third class extends one of the inner classes in another class.
+            "public class OuterClass3 extends OuterClass2.InnerClass1 {}"
+        };
+
+        // Build the graph.
+        // TODO: Ideally, this would call the edge builder directly against an incomplete graph.
+        TestUtil.buildGraph(g, sourceCodes);
+
+        // Make sure OuterClass1.InnerClass1 is extended by the right classes.
+        verifyExtension(
+                g,
+                "OuterClass1.InnerClass1",
+                Arrays.asList("OuterClass1", "OuterClass1.InnerClass2"));
+
+        // Make sure OuterClass2.InnerClass1 is extended by the right classes.
+        verifyExtension(
+                g,
+                "OuterClass2.InnerClass1",
+                Arrays.asList("OuterClass2", "OuterClass2.InnerClass2", "OuterClass3"));
+
+        // Verify that there are no implementation edges.
+        verifyNoEdges(g, Schema.IMPLEMENTED_BY);
+        verifyNoEdges(g, Schema.IMPLEMENTATION_OF);
+    }
+
+    @Test
+    public void testImplementationOfInnerInterface() {
+        String[] sourceCodes = {
+            // Implementations in this class don't use the outer class name.
+            "public class OuterClass1 implements InnerInterface1 {\n"
+                    + "    public class InnerInterface1 {}\n"
+                    + "    public class InnerClass1 implements InnerInterface1 {}\n"
+                    + "}",
+            // Implementations in this class use the outer class name.
+            "public class OuterClass2 implements OuterClass2.InnerInterface1 {\n"
+                    + "    public class InnerInterface1 {}\n"
+                    + "    public class InnerClass1 implements InnerInterface1 {}\n"
+                    + "}",
+            // Third class extends one of the inner classes in another class.
+            "public class OuterClass3 implements OuterClass2.InnerInterface1 {}"
+        };
+
+        // Build the graph.
+        // TODO: Ideally, this would call the edge builder directly against an incomplete graph.
+        TestUtil.buildGraph(g, sourceCodes);
+
+        // Make sure OuterClass1.InnerInterface1 is implemented by the right classes.
+        verifyImplementation(
+                g,
+                "OuterClass1.InnerInterface1",
+                Arrays.asList("OuterClass1", "OuterClass1.InnerClass1"));
+
+        // Make sure OuterClass2.InnerInterface1 is implemented by the right classes.
+        verifyImplementation(
+                g,
+                "OuterClass2.InnerInterface1",
+                Arrays.asList("OuterClass2", "OuterClass2.InnerClass1", "OuterClass3"));
+
+        // Verify that there are no extension edges.
+        verifyNoEdges(g, Schema.EXTENDED_BY);
+        verifyNoEdges(g, Schema.EXTENSION_OF);
+    }
+
+    @Test
+    public void testExtensionOfOwnOuterClass() {
+        String[] sourceCodes = {
+            "public class OuterClass1 {\n"
+                    + "    public class InnerClass1 extends OuterClass1 {}\n"
+                    + "}"
+        };
+
+        // Build the graph.
+        // TODO: Ideally, this would call the edge builder directly against an incomplete graph.
+        TestUtil.buildGraph(g, sourceCodes);
+
+        // Verify that the right extension edges exist.
+        verifyExtension(g, "OuterClass1", "OuterClass1.InnerClass1");
+
+        // Verify that there are no implementation edges.
+        verifyNoEdges(g, Schema.IMPLEMENTED_BY);
+        verifyNoEdges(g, Schema.IMPLEMENTATION_OF);
+    }
+
+    @Test
+    public void testClassNameOverlap() {
+        String[] sourceCodes = {
+            // This class extends its own inner class without using the outer class name.
+            "public class OuterClass1 extends NameOverlappedClass {\n"
+                    + "    public class NameOverlappedClass {}\n"
+                    + "}",
+            // This class has the same name as the inner class the other class extends.
+            "public class NameOverlappedClass {}",
+            // This class extends the outer class with the conflict name.
+            "public class OuterClass2 extends NameOverlappedClass {}"
+        };
+
+        // Build the graph.
+        // TODO: Ideally, this would call the edge builder directly against an incomplete graph.
+        TestUtil.buildGraph(g, sourceCodes);
+
+        // Verify that the right extension edges exist.
+        verifyExtension(g, "NameOverlappedClass", "OuterClass2");
+        verifyExtension(g, "OuterClass1.NameOverlappedClass", "OuterClass1");
+
+        // Verify that there are no implementation edges.
+        verifyNoEdges(g, Schema.IMPLEMENTED_BY);
+        verifyNoEdges(g, Schema.IMPLEMENTATION_OF);
+    }
+
+    @Test
+    public void testInterfaceNameOverlap() {
+        String[] sourceCodes = {
+            // This class implements its own inner interface without using the outer class name.
+            "public class OuterClass1 implements NameOverlappedInterface {\n"
+                    + "    public class NameOverlappedInterface {}\n"
+                    + "}",
+            // This interface has the same name as the inner interface the other class extends.
+            "public interface NameOverlappedInterface {}",
+            // This class implements the outer class with the conflict name.
+            "public class OuterClass2 implements NameOverlappedInterface {}"
+        };
+
+        // Build the graph.
+        // TODO: Ideally, this would call the edge builder directly against an incomplete graph.
+        TestUtil.buildGraph(g, sourceCodes);
+
+        // Verify that the right implementation edges exist.
+        verifyImplementation(g, "NameOverlappedInterface", "OuterClass2");
+        verifyImplementation(g, "OuterClass1.NameOverlappedInterface", "OuterClass1");
+
+        // Verify that there are no extension edges.
+        verifyNoEdges(g, Schema.EXTENDED_BY);
+        verifyNoEdges(g, Schema.EXTENSION_OF);
+    }
+
+    private void verifyNoEdges(GraphTraversalSource g, String edgeName) {
+        List<Vertex> vertices = g.V().out(edgeName).toList();
+        MatcherAssert.assertThat(vertices, hasSize(equalTo(0)));
+    }
+
+    private void verifyExtension(
+            GraphTraversalSource g, String parentDefiningType, String childDefiningType) {
+        verifyExtension(g, parentDefiningType, Collections.singletonList(childDefiningType));
+    }
+
+    private void verifyExtension(
+            GraphTraversalSource g, String parentDefiningType, List<String> childDefiningTypes) {
+        verifyEdges(
+                g, Schema.EXTENDED_BY, Schema.EXTENSION_OF, parentDefiningType, childDefiningTypes);
+    }
+
+    private void verifyImplementation(
+            GraphTraversalSource g, String parentDefiningType, String childDefiningType) {
+        verifyImplementation(g, parentDefiningType, Collections.singletonList(childDefiningType));
+    }
+
+    private void verifyImplementation(
+            GraphTraversalSource g, String parentDefiningType, List<String> childDefiningTypes) {
+        verifyEdges(
+                g,
+                Schema.IMPLEMENTED_BY,
+                Schema.IMPLEMENTATION_OF,
+                parentDefiningType,
+                childDefiningTypes);
+        verifyInterfaceDefiningTypeProperty(g, parentDefiningType, childDefiningTypes);
+    }
+
+    private void verifyEdges(
+            GraphTraversalSource g,
+            String outgoingEdge,
+            String incomingEdge,
+            String parentDefiningType,
+            List<String> childDefiningTypes) {
+        List<Object> outgoingVertices =
+                g.V().has(Schema.DEFINING_TYPE, parentDefiningType)
+                        .out(outgoingEdge)
+                        .values(Schema.DEFINING_TYPE)
+                        .order(Scope.global)
+                        .by(Order.asc)
+                        .toList();
+        List<Object> incomingVertices =
+                g.V().has(Schema.DEFINING_TYPE, parentDefiningType)
+                        .in(incomingEdge)
+                        .values(Schema.DEFINING_TYPE)
+                        .order(Scope.global)
+                        .by(Order.asc)
+                        .toList();
+
+        // Both lists should have the same vertices in the same order.
+        MatcherAssert.assertThat(outgoingVertices, hasSize(equalTo(childDefiningTypes.size())));
+        MatcherAssert.assertThat(incomingVertices, hasSize(equalTo(childDefiningTypes.size())));
+        for (int i = 0; i < childDefiningTypes.size(); i++) {
+            MatcherAssert.assertThat(
+                    outgoingVertices.get(i).toString(), equalTo(childDefiningTypes.get(i)));
+            MatcherAssert.assertThat(
+                    incomingVertices.get(i).toString(), equalTo(childDefiningTypes.get(i)));
+        }
+    }
+
+    private void verifyInterfaceDefiningTypeProperty(
+            GraphTraversalSource g, String parentDefiningType, List<String> childDefiningTypes) {
+        // For each child type, get the property on that vertex.
+        List<Object> propValues =
+                g.V().where(
+                                CaseSafePropertyUtil.H.hasWithin(
+                                        NodeType.USER_CLASS,
+                                        Schema.DEFINING_TYPE,
+                                        childDefiningTypes))
+                        .values(Schema.INTERFACE_DEFINING_TYPES)
+                        .toList();
+        for (Object propValue : propValues) {
+            MatcherAssert.assertThat(
+                    propValue.toString(),
+                    equalTo(Collections.singletonList(parentDefiningType).toString()));
+        }
     }
 }

--- a/sfge/src/test/java/com/salesforce/graph/build/InheritanceEdgeBuilderTest.java
+++ b/sfge/src/test/java/com/salesforce/graph/build/InheritanceEdgeBuilderTest.java
@@ -1,5 +1,6 @@
 package com.salesforce.graph.build;
 
+import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.IsEqual.equalTo;
 
@@ -337,8 +338,8 @@ public class InheritanceEdgeBuilderTest {
                         .toList();
         for (Object propValue : propValues) {
             MatcherAssert.assertThat(
-                    propValue.toString(),
-                    equalTo(Collections.singletonList(parentDefiningType).toString()));
+                (Object[])propValue,
+                arrayContaining(parentDefiningType));
         }
     }
 }

--- a/sfge/src/test/java/com/salesforce/graph/ops/MethodUtilTest.java
+++ b/sfge/src/test/java/com/salesforce/graph/ops/MethodUtilTest.java
@@ -428,4 +428,34 @@ public class MethodUtilTest {
             MatcherAssert.assertThat(excludedName, excludedMethod.isTest(), equalTo(true));
         }
     }
+
+    @Test
+    public void testGetInboundEmailHandlerMethods() {
+        String[] sourceCode = {
+            "public class MyClass implements Messaging.InboundEmailHandler {\n"
+                    + "    public Messaging.InboundEmailResult handleInboundEmail(Messaging.InboundEmail email, Messaging.InboundEnvelope envelope) {\n"
+                    + "        return null;\n"
+                    + "    }\n"
+                    + "    public Messaging.InboundEmailHandler someSecondaryMethod() {\n"
+                    + "        return null;\n"
+                    + "    }\n"
+                    + "}\n",
+            "public class MyClass2 {\n"
+                    + "    public Messaging.InboundEmailResult handleInboundEmail(Messaging.InboundEmail email, Messaging.InboundEnvelope envelope) {\n"
+                    + "        return null;\n"
+                    + "    }\n"
+                    + "    public Messaging.InboundEmailHandler someSecondaryMethod() {\n"
+                    + "        return null;\n"
+                    + "    }\n"
+                    + "}\n"
+        };
+        TestUtil.buildGraph(g, sourceCode);
+
+        List<MethodVertex> methods = MethodUtil.getInboundEmailHandlerMethods(g, new ArrayList<>());
+        // The `MyClass#handleInboundEmail` method should be included because it's an implementation
+        // of the desired interface.
+        MatcherAssert.assertThat(methods, hasSize(equalTo(1)));
+        MatcherAssert.assertThat(methods.get(0).getName(), equalTo("handleInboundEmail"));
+        MatcherAssert.assertThat(methods.get(0).getDefiningType(), equalTo("MyClass"));
+    }
 }

--- a/sfge/src/test/java/com/salesforce/rules/RuleUtilTest.java
+++ b/sfge/src/test/java/com/salesforce/rules/RuleUtilTest.java
@@ -118,6 +118,26 @@ public class RuleUtilTest {
     }
 
     @Test
+    public void getPathEntryPoints_includesInboundEmailHandlerMethods() {
+        String sourceCode =
+                "public class MyClass implements Messaging.InboundEmailHandler {\n"
+                        + "    public Messaging.InboundEmailResult handleInboundEmail(Messaging.InboundEmail email, Messaging.InboundEnvelope envelope) {\n"
+                        + "        return null;\n"
+                        + "    }\n"
+                        + "    public Messaging.InboundEmailHandler someSecondaryMethod() {\n"
+                        + "        return null;\n"
+                        + "    }\n"
+                        + "}\n";
+        TestUtil.buildGraph(g, sourceCode, true);
+
+        List<MethodVertex> entryPoints = RuleUtil.getPathEntryPoints(g);
+
+        MatcherAssert.assertThat(entryPoints, hasSize(equalTo(1)));
+        MethodVertex firstVertex = entryPoints.get(0);
+        assertEquals("handleInboundEmail", firstVertex.getName());
+    }
+
+    @Test
     public void getPathEntryPoints_includesExposedControllerMethods() {
         try {
             String controllerSourceCode =

--- a/sfge/src/test/java/com/salesforce/rules/RuleUtilTest.java
+++ b/sfge/src/test/java/com/salesforce/rules/RuleUtilTest.java
@@ -65,14 +65,14 @@ public class RuleUtilTest {
     @Test
     public void getPathEntryPoints_includesGlobalMethods() {
         String sourceCode =
-            "public class Foo {\n"
-                + "    global static void globalStaticMethod() {\n"
-                + "    }\n"
-                + "    global void globalInstanceMethod() {\n"
-                + "    }\n"
-                + "    public static void publicStaticMethod() {\n"
-                + "    }\n"
-                + "}\n";
+                "public class Foo {\n"
+                        + "    global static void globalStaticMethod() {\n"
+                        + "    }\n"
+                        + "    global void globalInstanceMethod() {\n"
+                        + "    }\n"
+                        + "    public static void publicStaticMethod() {\n"
+                        + "    }\n"
+                        + "}\n";
         TestUtil.buildGraph(g, sourceCode, true);
 
         List<MethodVertex> entryPoints = RuleUtil.getPathEntryPoints(g);


### PR DESCRIPTION
This PR does the following:
- Adds a  new vertex property, `InterfaceDefiningTypes`, which captures the full defining type of each interface implemented by a class, and a case-safe equivalent for this property.
These properties are populated during the execution of `InheritanceEdgeBuilder`.
- Adds robust test coverage for the new and existing functionality of `InheritanceEdgeBuilder`.
- Adds a case-safe equivalent for the existing property, `ReturnType`.
- Adds a new case-safe traversal method, `hasArrayContaining()`, which returns vertices whose value of a specified property is an array containing a specified value.
- Adds a new TraversalUtil method, `traverseImplementationsOf()`, which traverses every class that implements a given interface both directly and indirectly (i.e., extends a class that implements it, or implements an interface that extends it), along with robust test coverage for this new method.
- Adds the `Messaging.InboundEmailResult handleInboundEmail()` method on `Messaging.InboundEmailHandler` implementations (both direct and indirect) as entrypoints for `ApexFlsViolationRule`.

Change to be added in supplemental PR:
- Rename `InheritanceEdgeBuilder` to something like `InheritanceInformationCreator`, since it now does more than just building edges.