### PR TITLE
@W-11446174@: changed eslint parser to @babel/eslint-parser

### DIFF
--- a/src/lib/eslint/JavascriptEslintStrategy.ts
+++ b/src/lib/eslint/JavascriptEslintStrategy.ts
@@ -9,15 +9,22 @@ import {ESLint} from 'eslint';
 const ES_CONFIG: ESLint.Options = {
 	"baseConfig": {},
 	"overrideConfig": {
+		"parser": "@babel/eslint-parser",
 		"parserOptions": {
-			"sourceType": "module",
-			"ecmaVersion": 2018,
+			"requireConfigFile": false,
+			"babelOptions": {
+				"parserOpts": {
+					"plugins": ["classProperties", ["decorators", {"decoratorsBeforeExport": false}]]
+				}
+			}
 		},
 		"ignorePatterns": [
 			"node_modules/!**"
 		]
 	},
-	"useEslintrc": false // Will not use an external config
+	"useEslintrc": false, // Will not use an external config
+	"resolvePluginsRelativeTo": __dirname, // Use the plugins found in the sfdx scanner installation directory
+	"cwd": __dirname // Use the parser found in the sfdx scanner installation
 };
 
 export class JavascriptEslintStrategy implements EslintStrategy {


### PR DESCRIPTION
This stops eslint from throwing a parsing error when it comes across lwc specific syntax so it can continue and evaluate eslint rules