### PR TITLE
@W-11476976@ Don't block stripInaccessible() on custom value

### DIFF
--- a/sfge/src/main/java/com/salesforce/graph/symbols/apex/system/SObjectAccessDecision.java
+++ b/sfge/src/main/java/com/salesforce/graph/symbols/apex/system/SObjectAccessDecision.java
@@ -2,7 +2,6 @@ package com.salesforce.graph.symbols.apex.system;
 
 import com.salesforce.exception.UnexpectedException;
 import com.salesforce.exception.UnimplementedMethodException;
-import com.salesforce.exception.UserActionException;
 import com.salesforce.graph.DeepCloneable;
 import com.salesforce.graph.ops.ApexStandardLibraryUtil;
 import com.salesforce.graph.ops.CloneUtil;
@@ -171,14 +170,12 @@ public final class SObjectAccessDecision extends ApexStandardValue<SObjectAccess
         } else if (sanitizableValue instanceof ApexSoqlValue) {
             sanitizedValue =
                     buildSanitizedValue(builder, (SoqlExpressionVertex) sanitizableValueVertex);
-        } else if (sanitizableValue instanceof ApexSingleValue) {
+        } else if (sanitizableValue instanceof ApexSingleValue
+                || sanitizableValue instanceof ApexCustomValue) {
             sanitizedValue =
                     builder.declarationVertex(SyntheticTypedVertex.get("List<SObject>"))
                             .withStatus(ValueStatus.INDETERMINANT)
                             .buildList();
-        } else if (sanitizableValue instanceof ApexCustomValue) {
-            throw new UserActionException(
-                    "Action needed: Do not use stripInaccessible() check on custom settings since custom settings expect only CRUD");
         } else {
             throw new UnexpectedException(
                     "ApexValue type not handled for stripInaccessible call: " + sanitizableValue);

--- a/sfge/src/test/java/com/salesforce/graph/symbols/apex/SObjectAccessDecisionTest.java
+++ b/sfge/src/test/java/com/salesforce/graph/symbols/apex/SObjectAccessDecisionTest.java
@@ -59,6 +59,30 @@ public class SObjectAccessDecisionTest {
     }
 
     @Test
+    public void testCustomSettings() {
+        String[] sourceCode = {
+            "public class MyClass {\n"
+                    + "    public static void doSomething() {\n"
+                    + "       MySettings__c ms = MySettings__c.getOrgDefaults();\n"
+                    + "		SObjectAccessDecision sd = Security.stripInaccessible(AccessType.UPDATABLE, ms);\n"
+                    + "		System.debug(sd.getRecords());\n"
+                    + "    }\n"
+                    + "}\n"
+        };
+
+        TestRunner.Result<SystemDebugAccumulator> result = TestRunner.walkPath(g, sourceCode);
+        SystemDebugAccumulator visitor = result.getVisitor();
+
+        final ApexListValue outputListValue = visitor.getSingletonResult();
+        assertThat(
+                outputListValue.isSanitized(
+                        MethodBasedSanitization.SanitizerMechanism.STRIP_INACCESSIBLE,
+                        FlsConstants.StripInaccessibleAccessType.UPDATABLE),
+                equalTo(true));
+        assertThat(outputListValue.isIndeterminant(), equalTo(true));
+    }
+
+    @Test
     public void testAccessDecisionValueIncorrectAccessType() {
         String[] sourceCode = {
             "public class MyClass {\n"

--- a/sfge/src/test/java/com/salesforce/rules/fls/apex/StripInaccessibleCommonScenariosTest.java
+++ b/sfge/src/test/java/com/salesforce/rules/fls/apex/StripInaccessibleCommonScenariosTest.java
@@ -1,9 +1,7 @@
 package com.salesforce.rules.fls.apex;
 
-import com.salesforce.exception.UserActionException;
 import com.salesforce.rules.ApexFlsViolationRule;
 import com.salesforce.testutils.BaseFlsTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,21 +29,5 @@ public class StripInaccessibleCommonScenariosTest extends BaseFlsTest {
                         + "}\n";
 
         assertNoViolation(rule, sourceCode);
-    }
-
-    @Test
-    public void testRejectCustomSettingFlsCheck() {
-        String[] sourceCode = {
-            "public class MyClass {\n"
-                    + "    public static void foo() {\n"
-                    + "       MySettings__c ms = MySettings__c.getOrgDefaults();\n"
-                    + "		SObjectAccessDecision sd = Security.stripInaccessible(AccessType.UPDATABLE, ms);\n"
-                    + "		update sd.getRecords();\n"
-                    + "    }\n"
-                    + "}\n"
-        };
-
-        Assertions.assertThrows(
-                UserActionException.class, () -> assertNoViolation(rule, sourceCode));
     }
 }


### PR DESCRIPTION
Stop throwing UserAction error when `stripInaccessible()` is executed on a custom value. Instead, handle its sanitized output as an indeterminant list value.