### PR TITLE
@W-11446192@: checks if any files are processed by both eslint and eslint-lwc and emits warning

### DIFF
--- a/messages/DefaultRuleManager.js
+++ b/messages/DefaultRuleManager.js
@@ -1,6 +1,7 @@
 module.exports = {
 	"warning": {
 		"targetSkipped": "Target: '%s' was not processed by any engines.",
-		"targetsSkipped": "Targets: '%s' were not processed by any engines."
+		"targetsSkipped": "Targets: '%s' were not processed by any engines.",
+		"pathsDoubleProcessed": "At least one file was processed by both ESLint and ESLint-LWC simultaneously, which could result in duplicate violations. Customize the targetPatterns property for eslint and eslint-lwc engines in %s to remove overlap on the following file(s): %s",
 	}
 }

--- a/test/lib/RuleManager.test.ts
+++ b/test/lib/RuleManager.test.ts
@@ -4,7 +4,7 @@ import {Lifecycle} from '@salesforce/core';
 
 import {Controller} from '../../src/Controller';
 import {Rule, RuleGroup, RuleTarget, TelemetryData} from '../../src/types';
-import {ENGINE} from '../../src/Constants';
+import {ENGINE, CONFIG_PILOT_FILE} from '../../src/Constants';
 
 import {CategoryFilter, EngineFilter, LanguageFilter, RuleFilter, RulesetFilter} from '../../src/lib/RuleFilter';
 import {DefaultRuleManager} from '../../src/lib/DefaultRuleManager';
@@ -21,6 +21,10 @@ import * as TestOverrides from '../test-related-lib/TestOverrides';
 import * as TestUtils from '../TestUtils';
 import path = require('path');
 import Sinon = require('sinon');
+
+import {Messages} from '@salesforce/core';
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/sfdx-scanner', 'DefaultRuleManager');
 
 TestOverrides.initializeTestSetup();
 
@@ -272,6 +276,35 @@ describe('RuleManager', () => {
 					Sinon.assert.calledWith(uxSpy, EVENTS.WARNING_ALWAYS, `Target: '${invalidTarget.join(', ')}' was not processed by any engines.`);
 					Sinon.assert.callCount(telemetrySpy, 1);
 				});
+
+				it('Warns correctly if eslint and eslint-lwc have one duplicate path to process', async () => {
+					const targets = ['../invalid-lwc'];
+					const filters: EngineFilter[] = [new EngineFilter(["eslint-lwc", "eslint", "pmd"])];
+
+					await ruleManager.runRulesMatchingCriteria(filters, targets, runOptions, EMPTY_ENGINE_OPTIONS);
+
+					const filename = path.join(__dirname, '..','code-fixtures', 'invalid-lwc', 'invalidApiDecorator', 'noLeadingUpperCase.js')
+					const warningMessage = messages.getMessage('warning.pathsDoubleProcessed', [`${Controller.getSfdxScannerPath()}/${CONFIG_PILOT_FILE}`, `${filename}`])
+
+					Sinon.assert.calledWith(uxSpy, EVENTS.WARNING_ALWAYS, warningMessage);
+					Sinon.assert.callCount(telemetrySpy, 1);
+				});
+
+				it('Warns correctly if eslint and eslint-lwc have one duplicate path to process', async () => {
+					const targets = ["js", "../invalid-lwc"];
+					const filters: EngineFilter[] = [new EngineFilter(["eslint-lwc", "eslint", "pmd"])];
+
+					await ruleManager.runRulesMatchingCriteria(filters, targets, runOptions, EMPTY_ENGINE_OPTIONS);
+
+					const baseConfigEnv = path.join(__dirname, '..','code-fixtures', 'projects', 'js', 'src', 'baseConfigEnv.js')
+					const fileThatUsesQUnit = path.join(__dirname, '..','code-fixtures', 'projects', 'js', 'src', 'fileThatUsesQUnit.js')
+					const simpleYetWrong = path.join(__dirname, '..','code-fixtures', 'projects', 'js', 'src', 'simpleYetWrong.js')
+					const warningMessage = messages.getMessage('warning.pathsDoubleProcessed', [`${Controller.getSfdxScannerPath()}/${CONFIG_PILOT_FILE}`, `${baseConfigEnv}, ${fileThatUsesQUnit}, ${simpleYetWrong}, and 1 more`])
+
+					Sinon.assert.calledWith(uxSpy, EVENTS.WARNING_ALWAYS, warningMessage);
+					Sinon.assert.callCount(telemetrySpy, 1);
+				});
+
 			});
 
 			describe('Test Case: Run by category', () => {


### PR DESCRIPTION
If any of the same paths are processed by eslint and eslint-lwc, we emit a warning to the user that they should use target patterns in the config file. 