### PR TITLE
@W-10459671@ Redirecting ApexPathExpander logs to log file

### DIFF
--- a/sfge/src/main/resources/log4j2.xml
+++ b/sfge/src/main/resources/log4j2.xml
@@ -23,6 +23,9 @@
             <AppenderRef ref="LogToFile"/>
 			<AppenderRef ref="LogToCliMessager"/>
         </Logger>
+		<Logger name="com.salesforce.graph.ops.expander.ApexPathExpanderUtil" level="WARN" additivity="false">
+			<AppenderRef ref="LogToFile"/>
+		</Logger>
 		<Logger name="com.salesforce.graph.ops.GraphUtil" level="INFO" additivity="false">
 			<AppenderRef ref="LogToFile"/>
 		</Logger>


### PR DESCRIPTION
Redirecting path expander warnings to log files directly since there's no actionable work for users.