### PR TITLE
NEW: @W-11646074@ Added --sfgejvmargs parameter to `scanner:run:dfa` command

### DIFF
--- a/messages/run-dfa.js
+++ b/messages/run-dfa.js
@@ -49,9 +49,12 @@ module.exports = {
 	Use --severity-threshold to throw a non-zero exit code when rule violations of a specific normalized severity (or greater) are found. For this example, if there are any rule violations with a severity of 2 or more (which includes 1-high and 2-moderate), the exit code will be equal to the severity of the most severe violation.
 		E.g., $ sfdx scanner:run:dfa --target "/some-project/" --projectdir "/some-project/" --severity-threshold 2
 	Use --rule-thread-count to allow more (or fewer) entrypoints to be evaluated concurrently.
-		E.g., $ sfdx scanner:run:dfa --rule-thread-count 6
+		E.g., $ sfdx scanner:run:dfa --rule-thread-count 6 ...
 	Use --rule-thread-timeout to increase (or decrease) the maximum runtime for a single entrypoint evaluation.
 		E.g., $ sfdx scanner:run:dfa --rule-thread-timeout 9000000 ...
 			Increases timeout from 15 minutes (default) to 150 minutes.
+	Use --sfgejvmargs to pass JVM args to override system defaults while executing Salesforce Graph Engine's rules. 
+		E.g., $ sfdx scanner:run:dfa --sfgejvmargs "-Xmx8g" ...
+			Overrides system's default heapspace allocation to 8g and decreases chances of encountering OutOfMemory error.
 `
 };

--- a/messages/run-dfa.js
+++ b/messages/run-dfa.js
@@ -20,6 +20,8 @@ module.exports = {
 		"rulethreadtimeoutDescriptionLong": "Time limit for evaluating a single entrypoint. Value in milliseconds. Inherits from SFGE_RULE_THREAD_TIMEOUT env-var if set. Default is 900,000 ms, or 15 minutes.",
 		"sevthresholdDescription": "throws an error when violations of specific severity (or more severe) are detected, invokes --normalize-severity",
 		"sevthresholdDescriptionLong": "Throws an error if violations are found with equal or greater severity than provided value. Values are 1 (high), 2 (moderate), and 3 (low). Exit code is the most severe violation. Using this flag also invokes the --normalize-severity flag",
+		"sfgejvmargsDescription": "JVM args to optimize SFGE execution",
+		"sfgejvmargsDescriptionLong": "Specify JVM args to optimize memory utilization of SFGE execution. TODO: more information on what params to include.",
 		"targetDescription": "location of source code",
 		"targetDescriptionLong": "Source code location. May use glob patterns, or specify individual methods with #-syntax. Multiple values can be specified as a comma-separated list"
 	},

--- a/messages/run-dfa.js
+++ b/messages/run-dfa.js
@@ -20,8 +20,8 @@ module.exports = {
 		"rulethreadtimeoutDescriptionLong": "Time limit for evaluating a single entrypoint. Value in milliseconds. Inherits from SFGE_RULE_THREAD_TIMEOUT env-var if set. Default is 900,000 ms, or 15 minutes.",
 		"sevthresholdDescription": "throws an error when violations of specific severity (or more severe) are detected, invokes --normalize-severity",
 		"sevthresholdDescriptionLong": "Throws an error if violations are found with equal or greater severity than provided value. Values are 1 (high), 2 (moderate), and 3 (low). Exit code is the most severe violation. Using this flag also invokes the --normalize-severity flag",
-		"sfgejvmargsDescription": "JVM args to optimize SFGE execution",
-		"sfgejvmargsDescriptionLong": "Specify JVM args to optimize memory utilization of SFGE execution. TODO: more information on what params to include.",
+		"sfgejvmargsDescription": "JVM arguments to optimize SFGE execution to your system",
+		"sfgejvmargsDescriptionLong": "Specify JVM arguments to override system defaults while executing SFGE. For multiple arguments, add them to the same string separated by space.",
 		"targetDescription": "location of source code",
 		"targetDescriptionLong": "Source code location. May use glob patterns, or specify individual methods with #-syntax. Multiple values can be specified as a comma-separated list"
 	},

--- a/src/commands/scanner/run/dfa.ts
+++ b/src/commands/scanner/run/dfa.ts
@@ -95,7 +95,7 @@ export default class Dfa extends ScannerRunCommand {
 			longDescription: messages.getMessage('flags.ignoreparseerrorsDescriptionLong'),
 			env: 'SFGE_IGNORE_PARSE_ERRORS'
 		}),
-		sfgejvmargs: flags.string({
+		'sfgejvmargs': flags.string({
 			description: messages.getMessage('flags.sfgejvmargsDescription'),
 			longDescription: messages.getMessage('flags.sfgejvmargsDescriptionLong'),
 			env: 'SFGE_JVM_ARGS'
@@ -146,8 +146,8 @@ export default class Dfa extends ScannerRunCommand {
 		if (this.flags['rule-thread-timeout'] != null) {
 			sfgeConfig.ruleThreadTimeout = this.flags['rule-thread-timeout'] as number;
 		}
-		if (this.flags.sfgejvmargs != null) {
-			sfgeConfig.jvmArgs = this.flags.sfgejvmargs;
+		if (this.flags['sfgejvmargs'] != null) {
+			sfgeConfig.jvmArgs = this.flags['sfgejvmargs'] as string;
 		}
 		// Check the status of the flag first, since the flag being true should trump the environment variable's value.
 		if (this.flags['ignore-parse-errors'] != null) {

--- a/src/commands/scanner/run/dfa.ts
+++ b/src/commands/scanner/run/dfa.ts
@@ -94,6 +94,11 @@ export default class Dfa extends ScannerRunCommand {
 			description: messages.getMessage('flags.ignoreparseerrorsDescription'),
 			longDescription: messages.getMessage('flags.ignoreparseerrorsDescriptionLong'),
 			env: 'SFGE_IGNORE_PARSE_ERRORS'
+		}),
+		sfgejvmargs: flags.string({
+			description: messages.getMessage('flags.sfgejvmargsDescription'),
+			longDescription: messages.getMessage('flags.sfgejvmargsDescriptionLong'),
+			env: 'SFGE_JVM_ARGS'
 		})
 		// END: Config-overrideable engine flags.
 	};
@@ -140,6 +145,9 @@ export default class Dfa extends ScannerRunCommand {
 		}
 		if (this.flags['rule-thread-timeout'] != null) {
 			sfgeConfig.ruleThreadTimeout = this.flags['rule-thread-timeout'] as number;
+		}
+		if (this.flags.sfgejvmargs != null) {
+			sfgeConfig.jvmArgs = this.flags.sfgejvmargs;
 		}
 		// Check the status of the flag first, since the flag being true should trump the environment variable's value.
 		if (this.flags['ignore-parse-errors'] != null) {

--- a/src/lib/sfge/SfgeWrapper.ts
+++ b/src/lib/sfge/SfgeWrapper.ts
@@ -123,8 +123,6 @@ export class SfgeWrapper extends CommandLineSupport {
 
 	private async createInputFile(input: SfgeInput): Promise<string> {
 		const inputFile = await this.fh.tmpFileWithCleanup();
-		console.log(`inputFile=${inputFile}`);
-		console.log(`input file contents=${JSON.stringify(input)}`);
 		await this.fh.writeFile(inputFile, JSON.stringify(input));
 		return inputFile;
 	}

--- a/src/lib/sfge/SfgeWrapper.ts
+++ b/src/lib/sfge/SfgeWrapper.ts
@@ -32,6 +32,7 @@ interface SfgeWrapperOptions {
 	command: string;
 	rules: Rule[];
 	spinnerManager: SpinnerManager;
+	jvmArgs?: string,
 	ruleThreadCount?: number;
 	ruleThreadTimeout?: number;
 	ignoreParseErrors?: boolean;
@@ -87,6 +88,7 @@ export class SfgeWrapper extends CommandLineSupport {
 	private rules: Rule[];
 	private logFilePath: string;
 	private spinnerManager: SpinnerManager;
+	private jvmArgs: string;
 	private ruleThreadCount: number;
 	private ruleThreadTimeout: number;
 	private ignoreParseErrors: boolean;
@@ -98,6 +100,7 @@ export class SfgeWrapper extends CommandLineSupport {
 		this.command = options.command;
 		this.rules = options.rules;
 		this.spinnerManager = options.spinnerManager;
+		this.jvmArgs = options.jvmArgs;
 		this.ruleThreadCount = options.ruleThreadCount;
 		this.ruleThreadTimeout = options.ruleThreadTimeout;
 		this.ignoreParseErrors = options.ignoreParseErrors;
@@ -120,6 +123,8 @@ export class SfgeWrapper extends CommandLineSupport {
 
 	private async createInputFile(input: SfgeInput): Promise<string> {
 		const inputFile = await this.fh.tmpFileWithCleanup();
+		console.log(`inputFile=${inputFile}`);
+		console.log(`input file contents=${JSON.stringify(input)}`);
 		await this.fh.writeFile(inputFile, JSON.stringify(input));
 		return inputFile;
 	}
@@ -154,6 +159,9 @@ export class SfgeWrapper extends CommandLineSupport {
 		this.logger.trace(`Rules to be executed: ${JSON.stringify(inputObject.rulesToRun)}`);
 
 		const args = [`-Dsfge_log_name=${this.logFilePath}`, '-cp', classpath.join(path.delimiter)];
+		if (this.jvmArgs != null) {
+			args.push(this.jvmArgs);
+		}
 		if (this.ruleThreadCount != null) {
 			args.push(`-DSFGE_RULE_THREAD_COUNT=${this.ruleThreadCount}`);
 		}
@@ -223,6 +231,7 @@ export class SfgeWrapper extends CommandLineSupport {
 			rules: rules,
 			// Running rules could take quite a while, so we should use a functional spinner.
 			spinnerManager: await SfgeSpinnerManager.create({}),
+			jvmArgs: sfgeConfig.jvmArgs,
 			ruleThreadCount: sfgeConfig.ruleThreadCount,
 			ruleThreadTimeout: sfgeConfig.ruleThreadTimeout,
 			ignoreParseErrors: sfgeConfig.ignoreParseErrors

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -179,4 +179,5 @@ export type SfgeConfig = {
 	ruleThreadCount?: number;
 	ruleThreadTimeout?: number;
 	ignoreParseErrors?: boolean;
+	jvmArgs?: string;
 };


### PR DESCRIPTION
Added new parameter to help override default JVM args while executing SFGE.
The intended use is to increase heap space while running scanner:run:dfa command so that the chances of encountering an OutOfMemory error is lowered. This change does not address the root cause.