### PR TITLE
DOC: @W-11721133@: Added banner indicating the imminent retirement of v2.x

### DIFF
--- a/docs/_articles/en/index.md
+++ b/docs/_articles/en/index.md
@@ -24,7 +24,7 @@ lang: en
 <br>
 <div class="slds-notify slds-notify_alert slds-theme_alert-texture slds-text-heading_small slds-text-align_center slds-theme_warning" role="alert">
   <span class="slds-assistive-text">warning</span>
-  	v{{ site.data.versions.scanner }} is the final planned v2.x version. From v{{ site.data.versions-v3.firstdefault }} onwards, v3.x will be the default version.
+  	The v3.x pilot is almost over! Starting with our October 2022 release, v3.x will become the default version of the plug-in, and v2.x will no longer be supported.
 </div>
 <br>
 

--- a/docs/_articles/en/index.md
+++ b/docs/_articles/en/index.md
@@ -12,19 +12,23 @@ lang: en
 <br>
 <div class="slds-notify slds-notify_alert slds-theme_alert-texture slds-text-heading_small slds-theme_success" role="alert">
   <span class="slds-assistive-text">success</span>
-  	New pilot version {{ site.data.versions-v3.scanner }} of the plug-in has been released on {{ site.data.versions-v3.releasedon }}
+  	{{ site.data.versions-v3.releasedon }}: New pilot version {{ site.data.versions-v3.scanner }} of Salesforce Code Analyzer is available
 	&nbsp;&nbsp;
 	<a href="./en/v3.x/whats-new-v3/">Check out what's new</a>
 </div>
 <br>
 <div class="slds-notify slds-notify_alert slds-theme_alert-texture slds-text-heading_small slds-text-align_center slds-theme_warning" role="alert">
   <span class="slds-assistive-text">warning</span>
-  	A new version (v{{ site.data.versions.scanner }}) of the plug-in was released on {{ site.data.versions.releasedon }} &nbsp;&nbsp;<a href="./en/release-information/">Release Information</a>
+  	{{ site.data.versions.releasedon }}: The latest version v{{ site.data.versions.scanner }} is available&nbsp;&nbsp;<a href="./en/release-information/">Release Information</a>
 </div>
 <br>
 <div class="slds-notify slds-notify_alert slds-theme_alert-texture slds-text-heading_small slds-text-align_center slds-theme_warning" role="alert">
   <span class="slds-assistive-text">warning</span>
-  	The v3.x pilot is almost over! Starting with our October 2022 release, v3.x will become the default version of the plug-in, and v2.x will no longer be supported.
+<p>
+  	Support and updates for Code Analyzer v2.x are scheduled to end as of the October 26, 2022 release.
+  	You can continue to use v2.x after the October release; however, we recommend using Code Analyzer v3.x instead.
+ 	For more information, see <a href="./en/v3.x/getting-started/prerequisites/">Getting Started with v3.x.</a>
+</p>
 </div>
 <br>
 

--- a/docs/_articles/en/index.md
+++ b/docs/_articles/en/index.md
@@ -22,6 +22,11 @@ lang: en
   	A new version (v{{ site.data.versions.scanner }}) of the plug-in was released on {{ site.data.versions.releasedon }} &nbsp;&nbsp;<a href="./en/release-information/">Release Information</a>
 </div>
 <br>
+<div class="slds-notify slds-notify_alert slds-theme_alert-texture slds-text-heading_small slds-text-align_center slds-theme_warning" role="alert">
+  <span class="slds-assistive-text">warning</span>
+  	v{{ site.data.versions.scanner }} is the final planned v2.x version. From v{{ site.data.versions-v3.firstdefault }} onwards, v3.x will be the default version.
+</div>
+<br>
 
 ## Salesforce Code Analyzer Plug-in
 

--- a/docs/_data/versions-v3.yml
+++ b/docs/_data/versions-v3.yml
@@ -1,4 +1,5 @@
 scanner: '3.4.0'
+firstdefault: '3.6.0'
 releasedon: '08-17-2022'
 pmd: '6.48.0'
 eslint: '8.x'

--- a/docs/_data/versions-v3.yml
+++ b/docs/_data/versions-v3.yml
@@ -1,5 +1,4 @@
 scanner: '3.4.0'
-firstdefault: '3.6.0'
 releasedon: '08-17-2022'
 pmd: '6.48.0'
 eslint: '8.x'


### PR DESCRIPTION
The second and third banners have been reworded. The fourth banner is net-new.
![Screen Shot 2022-09-12 at 3 36 20 PM (2)](https://user-images.githubusercontent.com/4054488/189753809-4921c571-c1de-429f-b868-3397a55f2c02.png)

