### PR TITLE
CHANGE: @W-11261182@: Added SFGE-side telemetry events.

### DIFF
--- a/cli-messaging/src/main/java/com/salesforce/messaging/EventKey.java
+++ b/cli-messaging/src/main/java/com/salesforce/messaging/EventKey.java
@@ -38,9 +38,12 @@ public enum EventKey {
     WARNING_GENERAL("warning.sfgeWarnLog", 1, MessageType.WARNING, MessageHandler.UX, true),
 	WARNING_MULTIPLE_METHOD_TARGET_MATCHES("warning.multipleMethodTargetMatches", 3, MessageType.WARNING, MessageHandler.UX, false),
 	WARNING_NO_METHOD_TARGET_MATCHES("warning.noMethodTargetMatches", 2, MessageType.WARNING, MessageHandler.UX, false),
-    ERROR_GENERAL("error.internal.sfgeErrorLog", 1, MessageType.ERROR, MessageHandler.UX, false);
+    ERROR_GENERAL("error.internal.sfgeErrorLog", 1, MessageType.ERROR, MessageHandler.UX, false),
 
-	final String messageKey;
+    /** GENERAL PURPOSE */
+    INFO_TELEMETRY("info.telemetry", 1, MessageType.TELEMETRY, MessageHandler.INTERNAL, false);
+
+    final String messageKey;
 	final int argCount;
 	final MessageType messageType;
 	final MessageHandler messageHandler;

--- a/cli-messaging/src/main/java/com/salesforce/messaging/Message.java
+++ b/cli-messaging/src/main/java/com/salesforce/messaging/Message.java
@@ -57,6 +57,7 @@ public class Message {
 	}
 
 	enum MessageType {
+        TELEMETRY,
 		INFO,
 		WARNING,
 		ERROR

--- a/messages/EventKeyTemplates.js
+++ b/messages/EventKeyTemplates.js
@@ -15,7 +15,8 @@ module.exports = {
 		"sfgeFinishedBuildingGraph": "Added all compilation units to graph.",
 		"sfgePathEntryPointsIdentified": "Identified %s path entry point(s).",
 		"sfgeViolationsInPathProgress": "Detected %s violation(s) from %s path(s) on %s/%s entry point(s).",
-		"sfgeCompletedPathAnalysis": "Overall, analyzed %s path(s) from %s entry point(s). Detected %s violation(s)."
+		"sfgeCompletedPathAnalysis": "Overall, analyzed %s path(s) from %s entry point(s). Detected %s violation(s).",
+		"telemetry": "This message is unused."
 	},
 	"warning": {
 		"invalidCategorySkipped": "Cataloger: Skipping invalid PMD Category file '%s'.",

--- a/sfge/src/main/java/com/salesforce/CliMessagerAppender.java
+++ b/sfge/src/main/java/com/salesforce/CliMessagerAppender.java
@@ -3,7 +3,6 @@ package com.salesforce;
 import com.salesforce.config.SfgeConfigProvider;
 import com.salesforce.messaging.CliMessager;
 import com.salesforce.messaging.EventKey;
-import com.salesforce.telemetry.TelemetryUtil;
 import java.io.Serializable;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.Appender;
@@ -64,14 +63,9 @@ public class CliMessagerAppender extends AbstractAppender {
     public void append(LogEvent event) {
         Level level = event.getLevel();
         if (Level.WARN.equals(level)) {
-            String eventMessage = getEventMessage(event);
-            if (eventMessage.toLowerCase().startsWith("todo:")) {
-                TelemetryUtil.postWarningTelemetry(
-                        this.getLayout().toSerializable(event).toString());
-            }
             if (this.shouldLogWarningsOnVerbose) {
                 CliMessager.postMessage(
-                        "SFGE Warning as Info", EventKey.INFO_GENERAL, eventMessage);
+                        "SFGE Warning as Info", EventKey.INFO_GENERAL, getEventMessage(event));
             }
         } else if (Level.ERROR.equals(level)) {
             CliMessager.postMessage(

--- a/sfge/src/main/java/com/salesforce/CliMessagerAppender.java
+++ b/sfge/src/main/java/com/salesforce/CliMessagerAppender.java
@@ -3,6 +3,7 @@ package com.salesforce;
 import com.salesforce.config.SfgeConfigProvider;
 import com.salesforce.messaging.CliMessager;
 import com.salesforce.messaging.EventKey;
+import com.salesforce.telemetry.TelemetryUtil;
 import java.io.Serializable;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.Appender;
@@ -63,9 +64,14 @@ public class CliMessagerAppender extends AbstractAppender {
     public void append(LogEvent event) {
         Level level = event.getLevel();
         if (Level.WARN.equals(level)) {
+            String eventMessage = getEventMessage(event);
+            if (eventMessage.toLowerCase().startsWith("todo:")) {
+                TelemetryUtil.postWarningTelemetry(
+                        this.getLayout().toSerializable(event).toString());
+            }
             if (this.shouldLogWarningsOnVerbose) {
                 CliMessager.postMessage(
-                        "SFGE Warning as Info", EventKey.INFO_GENERAL, getEventMessage(event));
+                        "SFGE Warning as Info", EventKey.INFO_GENERAL, eventMessage);
             }
         } else if (Level.ERROR.equals(level)) {
             CliMessager.postMessage(

--- a/sfge/src/main/java/com/salesforce/TelemetryAppender.java
+++ b/sfge/src/main/java/com/salesforce/TelemetryAppender.java
@@ -1,0 +1,58 @@
+package com.salesforce;
+
+import com.salesforce.telemetry.TelemetryUtil;
+import java.io.Serializable;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.*;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginElement;
+import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+
+/**
+ * Custom log4j2 appender to send logs as telemetry events through {@link
+ * com.salesforce.telemetry.TelemetryUtil}. This helps us capture telemetry events in response to
+ * unsupported/pathological scenarios. Invoked from log4j2.xml
+ */
+@Plugin(
+        name = "TelemetryAppender",
+        category = Core.CATEGORY_NAME,
+        elementType = Appender.ELEMENT_TYPE)
+public class TelemetryAppender extends AbstractAppender {
+    @PluginFactory
+    public static TelemetryAppender createAppender(
+            @PluginAttribute("name") String name,
+            @PluginElement("Layout") Layout<? extends Serializable> layout,
+            @PluginElement("Filter") final Filter filter) {
+        if (name == null) {
+            // Assign default name to avoid complaining
+            name = "TelemetryAppender";
+        }
+        if (layout == null) {
+            layout = PatternLayout.createDefaultLayout();
+        }
+        return new TelemetryAppender(name, filter, layout, true);
+    }
+
+    protected TelemetryAppender(
+            String name,
+            Filter filter,
+            Layout<? extends Serializable> layout,
+            final boolean ignoreExceptions) {
+        super(name, filter, layout, ignoreExceptions, null);
+    }
+
+    @Override
+    public void append(LogEvent event) {
+        Level level = event.getLevel();
+        if (Level.WARN.equals(level)) {
+            String eventMessage = event.getMessage().getFormattedMessage();
+            if (eventMessage.toLowerCase().startsWith("todo:")) {
+                TelemetryUtil.postWarningTelemetry(
+                        this.getLayout().toSerializable(event).toString(), event.getThrown());
+            }
+        }
+    }
+}

--- a/sfge/src/main/java/com/salesforce/apex/jorje/JorjeUtil.java
+++ b/sfge/src/main/java/com/salesforce/apex/jorje/JorjeUtil.java
@@ -129,7 +129,7 @@ public final class JorjeUtil {
         }
     }
 
-    public static class JorjeCompilationException extends SfgeRuntimeException {
+    public static final class JorjeCompilationException extends SfgeRuntimeException {
         JorjeCompilationException(String message) {
             super(message);
         }

--- a/sfge/src/main/java/com/salesforce/exception/DuplicateKeyException.java
+++ b/sfge/src/main/java/com/salesforce/exception/DuplicateKeyException.java
@@ -1,7 +1,7 @@
 package com.salesforce.exception;
 
 /** Indicates a developer error where the same key was added to a map twice */
-public class DuplicateKeyException extends SfgeRuntimeException {
+public final class DuplicateKeyException extends SfgeRuntimeException {
     public DuplicateKeyException(Object key, Object previousEntry, Object newEntry) {
         super("Duplicate keys. key=" + key + ", previous=" + previousEntry + ", new=" + newEntry);
     }

--- a/sfge/src/main/java/com/salesforce/exception/ProgrammingException.java
+++ b/sfge/src/main/java/com/salesforce/exception/ProgrammingException.java
@@ -1,7 +1,7 @@
 package com.salesforce.exception;
 
 /** Indicates a programming logic error, such as an item being initialized more than once. */
-public class ProgrammingException extends SfgeRuntimeException {
+public final class ProgrammingException extends SfgeRuntimeException {
     public ProgrammingException(String message) {
         super(message);
     }

--- a/sfge/src/main/java/com/salesforce/exception/SfgeInterruptedException.java
+++ b/sfge/src/main/java/com/salesforce/exception/SfgeInterruptedException.java
@@ -5,4 +5,8 @@ package com.salesforce.exception;
  * stop. Any long running methods should periodically invoke {@link Thread#interrupted()} and throw
  * this exception if appropriate.
  */
-public final class SfgeInterruptedException extends SfgeRuntimeException {}
+public final class SfgeInterruptedException extends SfgeRuntimeException {
+    public SfgeInterruptedException() {
+        super();
+    }
+}

--- a/sfge/src/main/java/com/salesforce/exception/SfgeRuntimeException.java
+++ b/sfge/src/main/java/com/salesforce/exception/SfgeRuntimeException.java
@@ -1,19 +1,30 @@
 package com.salesforce.exception;
 
+import com.salesforce.telemetry.TelemetryUtil;
+
 public abstract class SfgeRuntimeException extends RuntimeException {
     public SfgeRuntimeException() {
         super();
+        TelemetryUtil.postExceptionTelemetry(
+                this.getClass().getSimpleName() + ": No message available");
     }
 
     public SfgeRuntimeException(Throwable cause) {
         super(cause);
+        String telemetryMessage =
+                String.format("%s: %s", this.getClass().getSimpleName(), cause.getMessage());
+        TelemetryUtil.postExceptionTelemetry(telemetryMessage);
     }
 
     public SfgeRuntimeException(String msg) {
         super(msg);
+        String telemetryMessage = String.format("%s: %s", this.getClass().getSimpleName(), msg);
+        TelemetryUtil.postExceptionTelemetry(telemetryMessage);
     }
 
     public SfgeRuntimeException(String msg, Throwable cause) {
         super(msg, cause);
+        String telemetryMessage = String.format("%s: %s", this.getClass().getSimpleName(), msg);
+        TelemetryUtil.postExceptionTelemetry(telemetryMessage);
     }
 }

--- a/sfge/src/main/java/com/salesforce/exception/SfgeRuntimeException.java
+++ b/sfge/src/main/java/com/salesforce/exception/SfgeRuntimeException.java
@@ -5,26 +5,21 @@ import com.salesforce.telemetry.TelemetryUtil;
 public abstract class SfgeRuntimeException extends RuntimeException {
     public SfgeRuntimeException() {
         super();
-        TelemetryUtil.postExceptionTelemetry(
-                this.getClass().getSimpleName() + ": No message available");
+        TelemetryUtil.postExceptionTelemetry(this);
     }
 
     public SfgeRuntimeException(Throwable cause) {
         super(cause);
-        String telemetryMessage =
-                String.format("%s: %s", this.getClass().getSimpleName(), cause.getMessage());
-        TelemetryUtil.postExceptionTelemetry(telemetryMessage);
+        TelemetryUtil.postExceptionTelemetry(this, cause);
     }
 
     public SfgeRuntimeException(String msg) {
         super(msg);
-        String telemetryMessage = String.format("%s: %s", this.getClass().getSimpleName(), msg);
-        TelemetryUtil.postExceptionTelemetry(telemetryMessage);
+        TelemetryUtil.postExceptionTelemetry(this);
     }
 
     public SfgeRuntimeException(String msg, Throwable cause) {
         super(msg, cause);
-        String telemetryMessage = String.format("%s: %s", this.getClass().getSimpleName(), msg);
-        TelemetryUtil.postExceptionTelemetry(telemetryMessage);
+        TelemetryUtil.postExceptionTelemetry(this, cause);
     }
 }

--- a/sfge/src/main/java/com/salesforce/exception/TodoException.java
+++ b/sfge/src/main/java/com/salesforce/exception/TodoException.java
@@ -1,6 +1,6 @@
 package com.salesforce.exception;
 
-public class TodoException extends SfgeRuntimeException {
+public final class TodoException extends SfgeRuntimeException {
     public TodoException() {
         this("TODO");
     }

--- a/sfge/src/main/java/com/salesforce/exception/UnexpectedException.java
+++ b/sfge/src/main/java/com/salesforce/exception/UnexpectedException.java
@@ -12,7 +12,7 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
  * Thrown when an AST related assumption is violated. Some code still uses this where a {@link
  * TodoException} is more appropriate.
  */
-public class UnexpectedException extends SfgeRuntimeException {
+public final class UnexpectedException extends SfgeRuntimeException {
     public UnexpectedException(Object obj) {
         super(obj != null ? obj.toString() : "<null>");
     }

--- a/sfge/src/main/java/com/salesforce/exception/UserActionException.java
+++ b/sfge/src/main/java/com/salesforce/exception/UserActionException.java
@@ -4,7 +4,7 @@ package com.salesforce.exception;
  * Denotes exceptions caused by incorrect code. Code may have compiled but user needs to take an
  * action to fix their code.
  */
-public class UserActionException extends SfgeRuntimeException {
+public final class UserActionException extends SfgeRuntimeException {
     public UserActionException(String message) {
         super(message);
     }

--- a/sfge/src/main/java/com/salesforce/exception/VisitNotOverriddenException.java
+++ b/sfge/src/main/java/com/salesforce/exception/VisitNotOverriddenException.java
@@ -7,7 +7,7 @@ import com.salesforce.graph.vertex.BaseSFVertex;
  * pattern relies on compile time dispatch to the correct overloaded visitor method in order for the
  * pattern to work.
  */
-public class VisitNotOverriddenException extends SfgeRuntimeException {
+public final class VisitNotOverriddenException extends SfgeRuntimeException {
     public VisitNotOverriddenException() {
         this("Concrete classes need to override visit or else the visitor won't work.");
     }

--- a/sfge/src/main/java/com/salesforce/graph/ops/expander/ApexPathExpanderRuntimeException.java
+++ b/sfge/src/main/java/com/salesforce/graph/ops/expander/ApexPathExpanderRuntimeException.java
@@ -3,4 +3,8 @@ package com.salesforce.graph.ops.expander;
 import com.salesforce.exception.SfgeRuntimeException;
 
 /** Base class for all runtime exceptions thrown by ApexPathExpander related code */
-public abstract class ApexPathExpanderRuntimeException extends SfgeRuntimeException {}
+public abstract class ApexPathExpanderRuntimeException extends SfgeRuntimeException {
+    protected ApexPathExpanderRuntimeException(String msg) {
+        super(msg);
+    }
+}

--- a/sfge/src/main/java/com/salesforce/graph/ops/expander/NullValueAccessedException.java
+++ b/sfge/src/main/java/com/salesforce/graph/ops/expander/NullValueAccessedException.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
  * <p>The ApexValue can be null because it is a real bug in the code, or it could be that the org is
  * setup in such a way that what we interpret as a null condition will never happen in practice.
  */
-public class NullValueAccessedException extends ApexPathExpanderRuntimeException {
+public final class NullValueAccessedException extends ApexPathExpanderRuntimeException {
     private final ApexValue<?> apexValue;
     private final MethodCallExpressionVertex vertex;
 
@@ -22,6 +22,7 @@ public class NullValueAccessedException extends ApexPathExpanderRuntimeException
      */
     public NullValueAccessedException(
             ApexValue<?> apexValue, @Nullable MethodCallExpressionVertex vertex) {
+        super("ApexValue=" + apexValue + ", vertex=" + (vertex != null ? vertex : "<null>"));
         this.apexValue = apexValue;
         this.vertex = vertex;
     }

--- a/sfge/src/main/java/com/salesforce/graph/ops/expander/switches/ApexPathCaseStatementExcluder.java
+++ b/sfge/src/main/java/com/salesforce/graph/ops/expander/switches/ApexPathCaseStatementExcluder.java
@@ -114,5 +114,9 @@ public final class ApexPathCaseStatementExcluder implements ApexPathExcluder {
     private ApexPathCaseStatementExcluder() {}
 
     /** Thrown by ExcludeCaseStatementVertexVisitor if the when block should be excluded */
-    static final class CaseStatementExcludedException extends SfgeRuntimeException {}
+    static final class CaseStatementExcludedException extends SfgeRuntimeException {
+        CaseStatementExcludedException() {
+            super();
+        }
+    }
 }

--- a/sfge/src/main/java/com/salesforce/graph/visitor/ApexPathWalker.java
+++ b/sfge/src/main/java/com/salesforce/graph/visitor/ApexPathWalker.java
@@ -274,7 +274,8 @@ public final class ApexPathWalker implements ClassStaticScopeProvider {
         private final ThrowStatementVertex vertex;
 
         private ThrowStatementVertexVisitedException(ThrowStatementVertex vertex) {
-            super(vertex.toString());
+            // NOTE: We're very deliberately NOT calling `super()` here, since this
+            // exception type doesn't require telemetry.
             this.vertex = vertex;
         }
     }

--- a/sfge/src/main/java/com/salesforce/graph/visitor/ApexPathWalker.java
+++ b/sfge/src/main/java/com/salesforce/graph/visitor/ApexPathWalker.java
@@ -274,6 +274,7 @@ public final class ApexPathWalker implements ClassStaticScopeProvider {
         private final ThrowStatementVertex vertex;
 
         private ThrowStatementVertexVisitedException(ThrowStatementVertex vertex) {
+            super(vertex.toString());
             this.vertex = vertex;
         }
     }

--- a/sfge/src/main/java/com/salesforce/telemetry/TelemetryUtil.java
+++ b/sfge/src/main/java/com/salesforce/telemetry/TelemetryUtil.java
@@ -1,0 +1,101 @@
+package com.salesforce.telemetry;
+
+import com.google.gson.Gson;
+import com.salesforce.messaging.CliMessager;
+import com.salesforce.messaging.EventKey;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+public final class TelemetryUtil {
+    private static final String MAIN_THREAD_NAME = "main";
+
+    /**
+     * Posts a telemetry event in response to a {@link org.apache.logging.log4j.Logger#warn} call.
+     *
+     * @param message - The message being logged.
+     */
+    public static void postWarningTelemetry(String message) {
+        EventType eventType =
+                isMainThread() ? EventType.MAIN_THREAD_WARNING : EventType.RULE_THREAD_WARNING;
+        postTelemetry(message, eventType);
+    }
+
+    /**
+     * Posts a telemetry event in response to an {@link
+     * com.salesforce.exception.SfgeRuntimeException} being thrown.
+     *
+     * @param message - The exception's message, if available.
+     */
+    public static void postExceptionTelemetry(String message) {
+        EventType eventType =
+                isMainThread() ? EventType.MAIN_THREAD_EXCEPTION : EventType.RULE_THREAD_EXCEPTION;
+        postTelemetry(message, eventType);
+    }
+
+    private static void postTelemetry(String message, EventType eventType) {
+        TelemetryData telemetryData = new TelemetryData(message, eventType);
+        CliMessager.postMessage(
+                "TelemetryData", EventKey.INFO_TELEMETRY, new Gson().toJson(telemetryData));
+    }
+
+    /** Returns a boolean indicating whether this thread is the main thread. */
+    private static boolean isMainThread() {
+        // Assumption: The name of the main thread will consistently be "main".
+        // If this assumption is invalidated, this code must change.
+        return MAIN_THREAD_NAME.equalsIgnoreCase(Thread.currentThread().getName());
+    }
+
+    /** An object that can be used as the base for an SFDX telemetry event. */
+    private static class TelemetryData {
+        /** Necessary property for telemetry objects. */
+        private final String eventName = "SFGE_TELEMETRY";
+
+        private final String message;
+        private final EventType eventType;
+        private final String stackTrace;
+
+        public TelemetryData(String message, EventType eventType) {
+            this.message = message;
+            this.eventType = eventType;
+            StackTraceElement[] stackTraceElements = Thread.currentThread().getStackTrace();
+            this.stackTrace =
+                    Arrays.stream(stackTraceElements)
+                            // We want five-ish stack frames of meaningful context, and the first
+                            // two
+                            // frames are always going to be this constructor and one of the
+                            // TelemetryUtil methods (which aren't terribly meaningful). So we'll
+                            // get the first seven stack frames.
+                            .limit(7)
+                            .map(StackTraceElement::toString)
+                            .collect(Collectors.joining("\n"));
+        }
+    }
+
+    private enum EventType {
+        /**
+         * Indicates that an unsupported scenario was encountered in the main thread, and in
+         * response a warning was logged but execution continued to the best of its ability.
+         */
+        MAIN_THREAD_WARNING,
+        /**
+         * Indicates that an unsupported scenario was encountered in a rule executor thread, and in
+         * response a warning was logged but execution continued to the best of its ability.
+         */
+        RULE_THREAD_WARNING,
+        /**
+         * Indicates than an unsupported scenario was encountered in the main thread, and that an
+         * exception was thrown in response. This typically means that the process as a whole was
+         * forced to exit unsuccessfully.
+         */
+        MAIN_THREAD_EXCEPTION,
+        /**
+         * Indicates that an unsupported scenario was encountered in a rule executor thread, and
+         * that an exception was thrown in response. This typically means that rules can no longer
+         * meaningfully execute against the relevant path entrypoint, but other entrypoints can
+         * still be evaluated.
+         */
+        RULE_THREAD_EXCEPTION;
+    }
+
+    private TelemetryUtil() {}
+}

--- a/sfge/src/main/resources/log4j2.xml
+++ b/sfge/src/main/resources/log4j2.xml
@@ -3,8 +3,11 @@
 	<!-- status = The level of internal Log4j events that should be logged to the console. -->
     <Appenders>
 		<CliMessagerAppender name="LogToCliMessager">
-			<PatternLayout pattern="%c{1}:%L %m%n"/>
+			<PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} %m%n"/>
 		</CliMessagerAppender>
+		<TelemetryAppender name="LogToTelemetry">
+			<PatternLayout pattern="%c{1}:%L %m%n"/>
+		</TelemetryAppender>
         <Console name="LogToConsole" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} %X{ruleRunId} %-5p %c{1}:%L - %m%n"/>
         </Console>
@@ -22,6 +25,7 @@
         <Logger name="com.salesforce" level="WARN" additivity="false">
             <AppenderRef ref="LogToFile"/>
 			<AppenderRef ref="LogToCliMessager"/>
+			<AppenderRef ref="LogToTelemetry"/>
         </Logger>
 		<Logger name="com.salesforce.graph.ops.expander.ApexPathExpanderUtil" level="WARN" additivity="false">
 			<AppenderRef ref="LogToFile"/>
@@ -49,6 +53,7 @@
             <AppenderRef ref="LogToFile"/>
             <AppenderRef ref="LogToConsole"/>
 			<AppenderRef ref="LogToCliMessager"/>
+			<AppenderRef ref="LogToTelemetry"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/sfge/src/main/resources/log4j2.xml
+++ b/sfge/src/main/resources/log4j2.xml
@@ -3,7 +3,7 @@
 	<!-- status = The level of internal Log4j events that should be logged to the console. -->
     <Appenders>
 		<CliMessagerAppender name="LogToCliMessager">
-			<PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} %m%n"/>
+			<PatternLayout pattern="%c{1}:%L %m%n"/>
 		</CliMessagerAppender>
         <Console name="LogToConsole" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} %X{ruleRunId} %-5p %c{1}:%L - %m%n"/>


### PR DESCRIPTION
This PR does the following:
- Adds a new `TelemetryUtil.java` class capable to constructing telemetry events and posting them to the console, where they will be consumed by SFGE.
- Adds to the `SfgeRuntimeException` constructors a call to `TelemetryUtil.java`.
- Makes all non-abstract subclasses of `SfgeRuntimeException` final, and makes their constructors all call `super()`.
- Modifies the logging pattern of `CliMessagerAppender` and causes it to pass this pattern into `TelemetryUtil.java`.