### PR TITLE
CHANGE: @W-11733210@: We made SFCA source config data from `Config.json` instead of `Config-pilot.json`.

### DIFF
--- a/messages/Config.js
+++ b/messages/Config.js
@@ -1,4 +1,5 @@
 module.exports = {
+	"GeneratingConfigFromPilot": "Generating config file by copying pilot config file. If this is undesirable, delete or rename `%s`.",
 	"InvalidStringArrayValue": "Invalid value for property '%s' in Config for %s. Expected an array of strings: %s",
 	"InvalidBooleanValue": "Invalid value for property '%s' in Config for %s. Expected a boolean: %s",
 	"InvalidNumberValue": "Invalid value for property '%s' in Config for %s. Expected a number: %s",

--- a/src/lib/DefaultRuleManager.ts
+++ b/src/lib/DefaultRuleManager.ts
@@ -14,7 +14,7 @@ import {Controller} from '../Controller';
 import globby = require('globby');
 import path = require('path');
 import {uxEvents, EVENTS} from './ScannerEvents';
-import {CUSTOM_CONFIG, ENGINE, CONFIG_PILOT_FILE} from '../Constants';
+import {CUSTOM_CONFIG, ENGINE, CONFIG_FILE} from '../Constants';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/sfdx-scanner', 'DefaultRuleManager');
@@ -131,7 +131,7 @@ export class DefaultRuleManager implements RuleManager {
 			if (pathsDoubleProcessed.length > numFilesShown) {
 				filesToDisplay.push(`and ${pathsDoubleProcessed.length - numFilesShown} more`)
 			}
-			uxEvents.emit(EVENTS.WARNING_ALWAYS, messages.getMessage('warning.pathsDoubleProcessed', [`${Controller.getSfdxScannerPath()}/${CONFIG_PILOT_FILE}`, `${filesToDisplay.join(', ')}`]));
+			uxEvents.emit(EVENTS.WARNING_ALWAYS, messages.getMessage('warning.pathsDoubleProcessed', [`${Controller.getSfdxScannerPath()}/${CONFIG_FILE}`, `${filesToDisplay.join(', ')}`]));
 		}
 
 

--- a/test/lib/RuleManager.test.ts
+++ b/test/lib/RuleManager.test.ts
@@ -4,7 +4,7 @@ import {Lifecycle} from '@salesforce/core';
 
 import {Controller} from '../../src/Controller';
 import {Rule, RuleGroup, RuleTarget, TelemetryData} from '../../src/types';
-import {ENGINE, CONFIG_PILOT_FILE} from '../../src/Constants';
+import {ENGINE, CONFIG_FILE} from '../../src/Constants';
 
 import {CategoryFilter, EngineFilter, LanguageFilter, RuleFilter, RulesetFilter} from '../../src/lib/RuleFilter';
 import {DefaultRuleManager} from '../../src/lib/DefaultRuleManager';
@@ -284,7 +284,7 @@ describe('RuleManager', () => {
 					await ruleManager.runRulesMatchingCriteria(filters, targets, runOptions, EMPTY_ENGINE_OPTIONS);
 
 					const filename = path.join(__dirname, '..','code-fixtures', 'invalid-lwc', 'invalidApiDecorator', 'noLeadingUpperCase.js')
-					const warningMessage = messages.getMessage('warning.pathsDoubleProcessed', [`${Controller.getSfdxScannerPath()}/${CONFIG_PILOT_FILE}`, `${filename}`])
+					const warningMessage = messages.getMessage('warning.pathsDoubleProcessed', [`${Controller.getSfdxScannerPath()}/${CONFIG_FILE}`, `${filename}`])
 
 					Sinon.assert.calledWith(uxSpy, EVENTS.WARNING_ALWAYS, warningMessage);
 					Sinon.assert.callCount(telemetrySpy, 1);
@@ -299,7 +299,7 @@ describe('RuleManager', () => {
 					const baseConfigEnv = path.join(__dirname, '..','code-fixtures', 'projects', 'js', 'src', 'baseConfigEnv.js')
 					const fileThatUsesQUnit = path.join(__dirname, '..','code-fixtures', 'projects', 'js', 'src', 'fileThatUsesQUnit.js')
 					const simpleYetWrong = path.join(__dirname, '..','code-fixtures', 'projects', 'js', 'src', 'simpleYetWrong.js')
-					const warningMessage = messages.getMessage('warning.pathsDoubleProcessed', [`${Controller.getSfdxScannerPath()}/${CONFIG_PILOT_FILE}`, `${baseConfigEnv}, ${fileThatUsesQUnit}, ${simpleYetWrong}, and 1 more`])
+					const warningMessage = messages.getMessage('warning.pathsDoubleProcessed', [`${Controller.getSfdxScannerPath()}/${CONFIG_FILE}`, `${baseConfigEnv}, ${fileThatUsesQUnit}, ${simpleYetWrong}, and 1 more`])
 
 					Sinon.assert.calledWith(uxSpy, EVENTS.WARNING_ALWAYS, warningMessage);
 					Sinon.assert.callCount(telemetrySpy, 1);

--- a/test/lib/util/Config.test.ts
+++ b/test/lib/util/Config.test.ts
@@ -181,7 +181,7 @@ describe('Config.ts', () => {
 	});
 	describe('Methods', () => {
 		describe('#init()', () => {
-			it('When neither GA nor pilot configs exist only the GA config is created', async () => {
+			it('When neither GA nor pilot configs exist, only the GA config is created', async () => {
 				const {existsStub, mkDirStub, writeFileStub} = SINON_SETUP_FUNCTIONS.NO_EXISTING_CONFIGS();
 				const config = new Config();
 
@@ -246,7 +246,7 @@ describe('Config.ts', () => {
 				await config.init();
 
 				// ASSERTIONS
-				// Since we already have a config, only the creation check for the GA config should have occurred.
+				// Since we already have a config, only the existence check for the GA config should have occurred.
 				expect(existsStub.calledWith(CONFIG_PATH)).to.equal(true, 'GA config existence check unexpectedly skipped');
 				expect(existsStub.calledWith(CONFIG_PILOT_PATH)).to.equal(false, 'pilot config existence check unexpectedly occurred');
 				expect(writeFileStub.calledWith(CONFIG_PATH)).to.equal(false, 'Since GA config exists, it should not be modified during initialization');


### PR DESCRIPTION
This PR changes the following:
- The plug-in once again sources its config data from `Config.json` instead of `Config-pilot.json`
- If `Config.json` doesn't exist but `Config-pilot.json` does, then `Config.json` is created by copying `Config-pilot.json` and a warning is logged to the user.
- When upgrading from a previous *major* version, a back-up of the old config is always created. Previously a back-up was only created when the upgrade failed.
- `VersionUpgradeManager.ts` has an upgrade script for upgrading to v3.6.0 or later, that copies the contents of `Config-pilot.json` into `Config.json`.