### PR TITLE
FIX: @W-11723805@: Fixed null pointer exception when parsing comments with empty commas.

### DIFF
--- a/sfge/src/main/java/com/salesforce/graph/ops/directive/EngineDirectiveParser.java
+++ b/sfge/src/main/java/com/salesforce/graph/ops/directive/EngineDirectiveParser.java
@@ -45,6 +45,9 @@ public class EngineDirectiveParser {
             comment = normalizeValue(rawComment);
         }
         final String[] arrayElements = directive.split(Token.ARRAY_SEPARATOR);
+        if (arrayElements.length == 0) {
+            return Optional.empty();
+        }
         for (int i = 0; i < arrayElements.length; i++) {
             final String arrayElement = arrayElements[i];
             if (i == 0) {

--- a/sfge/src/test/java/com/salesforce/graph/ops/directive/EngineDirectiveParserTest.java
+++ b/sfge/src/test/java/com/salesforce/graph/ops/directive/EngineDirectiveParserTest.java
@@ -55,6 +55,7 @@ public class EngineDirectiveParserTest {
 
         List<Arguments> arguments =
                 Arrays.asList(
+                        Arguments.of(",", NodeType.METHOD, null),
                         Arguments.of("", NodeType.METHOD, null),
                         Arguments.of("sfge-unrelated", NodeType.EXPRESSION_STATEMENT, null),
                         Arguments.of("sfge-disable", NodeType.USER_CLASS, DISABLE_NO_RULE),


### PR DESCRIPTION
Previously, having code where an inline comment consisted of just a comma would cause a null pointer exception.
For example,
```
boolean b = true;\\,
boolean b1 = false;
```
This has been addressed.