### PR TITLE
CHANGE: @W-11790341@: Compilation errors now give more digestible message.

### DIFF
--- a/sfge/src/main/java/com/salesforce/Main.java
+++ b/sfge/src/main/java/com/salesforce/Main.java
@@ -218,9 +218,13 @@ public class Main {
     }
 
     private String formatError(Throwable error) {
-        final String causedByMessage =
-                error.getCause() != null ? ", Caused by: " + error.getCause().getMessage() : "";
-        return ERROR_PREFIX + error.getMessage() + causedByMessage;
+        return ERROR_PREFIX
+                + (error.getCause() != null
+                        ? String.format(
+                                UserFacingMessages.EXCEPTION_FORMAT_TEMPLATE,
+                                error.getMessage(),
+                                error.getCause().getMessage())
+                        : error.getMessage());
     }
 
     static class Dependencies {

--- a/sfge/src/main/java/com/salesforce/apex/jorje/JorjeUtil.java
+++ b/sfge/src/main/java/com/salesforce/apex/jorje/JorjeUtil.java
@@ -18,6 +18,7 @@ import apex.jorje.semantic.compiler.parser.ParserEngine;
 import apex.jorje.semantic.compiler.sfdc.NoopCompilerProgressCallback;
 import apex.jorje.services.exception.CompilationException;
 import apex.jorje.services.exception.ParseException;
+import com.salesforce.config.UserFacingMessages;
 import com.salesforce.exception.SfgeRuntimeException;
 import com.salesforce.exception.UnexpectedException;
 import java.util.*;
@@ -86,11 +87,11 @@ public final class JorjeUtil {
                             .map(
                                     e ->
                                             String.format(
-                                                    "ParseException at %d:%d. (%s)",
+                                                    UserFacingMessages.INVALID_SYNTAX_TEMPLATE,
                                                     e.getLoc().getLine(),
                                                     e.getLoc().getColumn(),
                                                     e.getError()))
-                            .collect(Collectors.joining(";")));
+                            .collect(Collectors.joining("\n")));
         }
 
         // Wrap the top level Jorje node in a AstNodeWrapper and build a new tree of AstNodeWrappers

--- a/sfge/src/main/java/com/salesforce/config/UserFacingMessages.java
+++ b/sfge/src/main/java/com/salesforce/config/UserFacingMessages.java
@@ -34,4 +34,10 @@ public final class UserFacingMessages {
     public static final String FIELDS_MESSAGE_TEMPLATE = " with field(s) [%s]";
     public static final String FIELD_HANDLING_NOTICE =
             " Confirm that the objects and fields involved in these segments have FLS checks: [%s].";
+
+    public static final String INVALID_SYNTAX_TEMPLATE = "Invalid syntax at %d:%d. (%s)";
+
+    public static final String FIX_COMPILATION_ERRORS = "Fix compilation errors in %s and retry";
+
+    public static final String EXCEPTION_FORMAT_TEMPLATE = "%s, Caused by:\n%s";
 }

--- a/sfge/src/main/java/com/salesforce/graph/ops/GraphUtil.java
+++ b/sfge/src/main/java/com/salesforce/graph/ops/GraphUtil.java
@@ -181,11 +181,7 @@ public final class GraphUtil {
                     "Could not read file/directory " + sourceFileVisitor.lastVisitedFile, ex);
         } catch (JorjeUtil.JorjeCompilationException ex) {
             throw new GraphLoadException(
-                    "Could not parse file "
-                            + sourceFileVisitor.lastVisitedFile
-                            + ": "
-                            + ex.getMessage(),
-                    ex);
+                    "Could not parse file " + sourceFileVisitor.lastVisitedFile, ex);
         }
 
         return comps;

--- a/sfge/src/main/java/com/salesforce/graph/ops/GraphUtil.java
+++ b/sfge/src/main/java/com/salesforce/graph/ops/GraphUtil.java
@@ -12,6 +12,7 @@ import com.salesforce.apex.jorje.JorjeUtil;
 import com.salesforce.apex.jorje.TopLevelWrapper;
 import com.salesforce.collections.CollectionUtil;
 import com.salesforce.config.SfgeConfigProvider;
+import com.salesforce.config.UserFacingMessages;
 import com.salesforce.exception.SfgeException;
 import com.salesforce.graph.Schema;
 import com.salesforce.graph.build.Util;
@@ -181,7 +182,10 @@ public final class GraphUtil {
                     "Could not read file/directory " + sourceFileVisitor.lastVisitedFile, ex);
         } catch (JorjeUtil.JorjeCompilationException ex) {
             throw new GraphLoadException(
-                    "Could not parse file " + sourceFileVisitor.lastVisitedFile, ex);
+                    String.format(
+                            UserFacingMessages.FIX_COMPILATION_ERRORS,
+                            sourceFileVisitor.lastVisitedFile),
+                    ex);
         }
 
         return comps;

--- a/sfge/src/test/java/com/salesforce/graph/ops/GraphUtilTest.java
+++ b/sfge/src/test/java/com/salesforce/graph/ops/GraphUtilTest.java
@@ -62,7 +62,7 @@ public class GraphUtilTest {
                     Assertions.assertThrows(
                             GraphUtil.GraphLoadException.class,
                             () -> TestUtil.compileTestFiles(g, testInfo));
-            MatcherAssert.assertThat(ex.getMessage(), containsString("Could not parse file"));
+            MatcherAssert.assertThat(ex.getMessage(), containsString("Fix compilation errors"));
             MatcherAssert.assertThat(
                     ex.getMessage(),
                     containsString("testParseErrorIsIgnored" + File.separator + "MyClass.cls"));


### PR DESCRIPTION
Whereas previously a compilation failure in Salesforce Graph Engine produced an error resembling this...
```
ERROR: SFGE encountered an error and couldn't complete analysis: Could not parse file /Users/me/path/to/my/fileAuraEnabledFls.cls: Syntax(error = UnexpectedToken(loc = (21, 8, 132, 137), token = 'statc')),Syntax(error = UnexpectedToken(loc = (21, 8, 132, 137), token = 'statc')),Syntax(error = UnexpectedToken(loc = (21, 14, 134, 141), token = 'Account')), Caused by: Syntax(error = UnexpectedToken(loc = (21, 8, 132, 137), token = 'statc')),Syntax(error = UnexpectedToken(loc = (21, 8, 132, 137), token = 'statc')),Syntax(error = UnexpectedToken(loc = (21, 14, 134, 141), token = 'Account'))
```
They now resemble this:
```
ERROR: SFGE encountered an error and couldn't complete analysis: Fix compilation errors in /Users/me/path/to/my/file/AuraEnabledFls.cls and retry, Caused by:
Invalid syntax at 21:8. (Unexpected token 'statc'.)
Invalid syntax at 21:14. (Unexpected token 'Account'.)
```