### PR TITLE
CHANGE (CodeAnalyzer): @W-11326833@: We more robustly enforce PR naming conventions.

### DIFF
--- a/github-actions/verify-pr-title/src/index.ts
+++ b/github-actions/verify-pr-title/src/index.ts
@@ -1,7 +1,6 @@
 import core = require("@actions/core");
 import github = require("@actions/github");
-import { verifyPRTitleForBugId } from "./verifyPrTitle";
-import { verifyPRTitleForBadTitle } from "./verifyPrTitle";
+import { verifyDevBranchPrTitle, verifyReleaseBranchPrTitle } from "./verifyPrTitle";
 
 /**
  * Verifies that a pull request title conforms to the pattern required by git2gus
@@ -17,15 +16,33 @@ function run(): void {
 			return;
 		}
 
-		// Examine the title and base branch for the expected patterns
+		// Examine the title for the expected patterns, which vary depending on what the target branch is.
 		const title = pullRequest.title as string;
-		if (verifyPRTitleForBugId(title) && verifyPRTitleForBadTitle(title)) {
-			console.log(`PR Title '${title}' accepted.`);
+		const base = pullRequest.base as {ref: string};
+		const targetBranch = base.ref;
+		if (targetBranch === "release" || targetBranch === "documentation") {
+			// Release branches have their own less stringent format.
+			if (verifyReleaseBranchPrTitle(title)) {
+				console.log(`PR title '${title}' accepted for release branch.`);
+			} else {
+				core.setFailed(
+					`PR title '${title}' does not match the release PR template of "RELEASE: @W-XXXX@: Summary".`
+				);
+				return;
+			}
+		} else if (targetBranch === "dev" || targetBranch === "docdev") {
+			// Dev branches have a more stringent format.
+			if (verifyDevBranchPrTitle(title)) {
+				console.log(`PR title '${title}' accepted for dev branch.`);
+			} else {
+				core.setFailed(
+					`PR title '${title}' does not match the dev PR template of "TYPE (SCOPE): @W-XXXX@: Summary"`
+				);
+				return;
+			}
 		} else {
-			core.setFailed(
-				`PR Title '${title}' is missing a valid GUS work item OR it starts with d/ or r/`
-			);
-			return;
+			// Not sure why you'd have a pull request aimed at some other branch, but that should probably be allowed.
+			console.log(`PR title '${title}' automatically accepted for non-release, non-dev branch`);
 		}
 	} catch (error) {
 		if (error instanceof Error) {

--- a/github-actions/verify-pr-title/src/verifyPrTitle.ts
+++ b/github-actions/verify-pr-title/src/verifyPrTitle.ts
@@ -1,22 +1,60 @@
-// Matches @W-0000@ through @W-99999999@
-const reBugId = /@W-\d{4,8}@/;
-
-// Matches r/ R/ d/ D/
-const reBranch = /^[rdRD]\//;
+/**
+ * This regex portion matches @W-0000@ through @W-999999999@,
+ * to enforce that the title contains a work record number consumable
+ * by Git2Gus.
+ * All pull request titles will require this segment.
+ */
+const WORK_ITEM_SEGMENT = "@W-\\d{4,8}@";
 
 /**
- * Verifies title conforms to the pattern required by git2gus.
- * git2gus requires the WorkItemId to be enclosed by two '@' signs.
- * A valid WorkItemId consists of 'W-' followed by 4-8 digits.
+ * This is a regex segment that matches the accepted options for feature branch PR type.
+ * NOTE: This segment allows for exactly one type.
  */
-export function verifyPRTitleForBugId(title: string): boolean {
-	return reBugId.test(title);
+const FEATURE_TYPE_SEGMENT = "(NEW|FIX|CHANGE)";
+
+/**
+ * These are all the possible options for feature branch PR Scope.
+ */
+const FEATURE_SCOPE_OPTIONS = [
+	"CodeAnalyzer",
+	"CPD",
+	"ESLint",
+	"GraphEngine",
+	"PMD",
+	"RetireJS"
+];
+
+/**
+ * This is a regex segment that matches the accepted options for feature branch PR scope, enclosed
+ * in parentheses.
+ * NOTE: This segment allows for multiple scopes, separated by a pipe (|)
+ */
+const FEATURE_SCOPE_SEGMENT = `\\(\\s*(${FEATURE_SCOPE_OPTIONS.join("|")})(${FEATURE_SCOPE_OPTIONS.map(s => `\\s*\\|\\s*${s}`).join("|")})*\\s*\\)`;
+
+/**
+ * This regex combines the above segments to collectively enforce our naming template for pull requests aimed a development branch.
+ */
+const DEV_BRANCH_NAMING_REGEX = new RegExp(`^\\s*${FEATURE_TYPE_SEGMENT}\\s*${FEATURE_SCOPE_SEGMENT}\\s*:\\s*${WORK_ITEM_SEGMENT}\\s*:.+`, "i");
+
+/**
+ * This regex combines segments to collectively enforce our naming template for pull requests aimed at a release branch.
+ */
+const RELEASE_BRANCH_NAMING_REGEX = new RegExp(`\\s*RELEASE\\s*:\\s*${WORK_ITEM_SEGMENT}\\s*:.+`, "i");
+
+/**
+ * Returns true if the provided string is an acceptable title for a PR aimed at a development branch.
+ * (e.g., `docdev`, `dev`)
+ * @param title
+ */
+export function verifyDevBranchPrTitle(title: string): boolean {
+	return DEV_BRANCH_NAMING_REGEX.test(title);
 }
 
 /**
- * Verifies that the Title does not begin with d/ or r/ to prevent
- * titles that look like d/W-xxx or r/W-xxx
+ * Returns true if the provided string is an acceptable title for a PR aimed at a release branch.
+ * (e.g., `documentation`, `release`)
+ * @param title
  */
-export function verifyPRTitleForBadTitle(title: string): boolean {
-	return !reBranch.test(title);
+export function verifyReleaseBranchPrTitle(title: string): boolean {
+	return RELEASE_BRANCH_NAMING_REGEX.test(title);
 }

--- a/github-actions/verify-pr-title/test/verifyPrTitle.test.ts
+++ b/github-actions/verify-pr-title/test/verifyPrTitle.test.ts
@@ -1,63 +1,176 @@
 import { expect } from "chai";
-import { verifyPRTitleForBugId } from "../src/verifyPrTitle";
-import { verifyPRTitleForBadTitle } from "../src/verifyPrTitle";
+import { verifyDevBranchPrTitle, verifyReleaseBranchPrTitle } from "../src/verifyPrTitle";
 
-describe("Positive Tests", () => {
-	it("work item only", () => {
-		expect(verifyPRTitleForBugId("@W-1234@")).to.equal(true);
+describe("#verifyDevBranchPrTitle()", () => {
+	describe("Positive Tests", () => {
+		describe("Allow valid type values", () => {
+			it("Type value: NEW", () => {
+				expect(verifyDevBranchPrTitle("NEW (PMD): @W-1111@: This is a message.")).to.equal(true);
+			});
+
+			it("Type value: CHANGE", () => {
+				expect(verifyDevBranchPrTitle("CHANGE (PMD): @W-1111@: beep boop bop.")).to.equal(true);
+			});
+
+			it("Type value: FIX", () => {
+				expect(verifyDevBranchPrTitle("FIX (PMD): @W-1111@: beep boop bop.")).to.equal(true);
+			});
+		});
+
+		describe("Allow multiple scopes", () => {
+			it("Scopes: PMD + ESLint", () => {
+				expect(verifyDevBranchPrTitle("NEW (PMD|ESLint): @W-1111@: beep boop bop.")).to.equal(true);
+			});
+
+			it("Scopes: PMD + ESLint + RetireJS", () => {
+				expect(verifyDevBranchPrTitle("NEW (PMD|ESLint|RetireJS): @W-1111@: beep boop bop.")).to.equal(true);
+			});
+		});
+
+		describe("Be flexible with input", () => {
+			it("Be case-insensitive", () => {
+				expect(verifyDevBranchPrTitle("nEw (PmD): @W-1111@: beep boop bop.")).to.equal(true);
+			});
+
+			it("Allow excessive spacing", () => {
+				expect(verifyDevBranchPrTitle("   NEW   (    PMD   |    ESLint  | RetireJS   )  :    @W-1111@  :    beep boop bop.")).to.equal(true);
+			});
+
+			it("Allow no spacing", () => {
+				expect(verifyDevBranchPrTitle("NEW(PMD):@W-1111@:beep boop bop.")).to.equal(true);
+			});
+		})
 	});
 
-	it("work item at start of title", () => {
-		expect(verifyPRTitleForBugId("@W-1234@ fix")).to.equal(true);
-	});
+	describe("Negative Tests", () => {
+		it("Empty PR title", () => {
+			expect(verifyDevBranchPrTitle("")).to.equal(false);
+		});
 
-	it("work item at end of title", () => {
-		expect(verifyPRTitleForBugId("Fixes @W-1234@")).to.equal(true);
-	});
+		it("Improperly-ordered PR title", () => {
+			expect(verifyDevBranchPrTitle("(PMD) NEW: @W-1111@: beep boop bop.")).to.equal(false);
+		});
 
-	it("work item in middle of title", () => {
-		expect(verifyPRTitleForBugId("Fixes @W-1234@ - something")).to.equal(true);
-	});
+		describe("Problems with PR type", () => {
+			it("Invalid PR type", () => {
+				expect(verifyDevBranchPrTitle("MEW (PMD): @W-1111@: beep boop bop.")).to.equal(false);
+			});
 
-	it("work item minium range", () => {
-		expect(verifyPRTitleForBugId("@W-0000@")).to.equal(true);
-	});
+			it("Multiple PR types", () => {
+				expect(verifyDevBranchPrTitle("NEW CHANGE (PMD): @W-1111@: beep boop bop.")).to.equal(false);
+			});
 
-	it("work item maximum range", () => {
-		expect(verifyPRTitleForBugId("@W-99999999@")).to.equal(true);
-	});
+			it("Missing PR type", () => {
+				expect(verifyDevBranchPrTitle("(PMD): @W-1111@: beep boop bop.")).to.equal(false);
+			});
+		});
 
-	it("Title does not start with invalid tokens d/W or r/W", () => {
-		expect(verifyPRTitleForBadTitle("@W-12345678")).to.equal(true);
+		describe("Problems with PR scope", () => {
+			it("Invalid PR scope", () => {
+				expect(verifyDevBranchPrTitle("NEW (PMQ): @W-1111@: beep boop bop.")).to.equal(false);
+			});
+
+			it("Missing PR scope", () => {
+				expect(verifyDevBranchPrTitle("NEW : @W-1111@: beep boop bop.")).to.equal(false);
+			});
+
+			it("Empty PR scope", () => {
+				expect(verifyDevBranchPrTitle("NEW (): @W-1111@: beep boop bop.")).to.equal(false);
+			});
+
+			it("Improperly-delimited PR scopes (comma instead of pipe)", () => {
+				expect(verifyDevBranchPrTitle("NEW (PMD,CPD): @W-1111@: beep boop bop.")).to.equal(false);
+			});
+
+			it("Improperly-delimited PR scopes (missing pipe)", () => {
+				expect(verifyDevBranchPrTitle("NEW (PMDCPD): @W-1111@: beep boop bop.")).to.equal(false);
+			});
+		});
+
+		describe("Problems with PR work number", () => {
+			it("Work item below minimum range", () => {
+				expect(verifyDevBranchPrTitle("NEW (PMD): @W-999@: beep boop bop.")).to.equal(false);
+			});
+
+			it("Work item above maximum range", () => {
+				expect(verifyDevBranchPrTitle("NEW (PMD): @W-100000000@: beep boop bop.")).to.equal(false);
+			});
+
+			it("Work item contains letters", () => {
+				expect(verifyDevBranchPrTitle("NEW (PMD): @W-1003a00@: beep boop bop.")).to.equal(false);
+			});
+
+			it("Work item missing leading @-symbol", () => {
+				expect(verifyDevBranchPrTitle("NEW (PMD): W-1000@: beep boop bop.")).to.equal(false);
+			});
+
+			it("Work item missing trailing @-symbol", () => {
+				expect(verifyDevBranchPrTitle("NEW (PMD): @W-1000: beep boop bop.")).to.equal(false);
+			});
+
+			it("Work item missing", () => {
+				expect(verifyDevBranchPrTitle("NEW (PMD): beep boop bop.")).to.equal(false);
+			});
+		});
 	});
 });
+describe("#verifyReleaseBranchPrTitle()", () => {
+	describe("Positive tests", () => {
+		it("Happy path", () => {
+			expect(verifyReleaseBranchPrTitle("RELEASE: @W-1111@: Releasing v3.6.2.")).to.equal(true);
+		});
 
-describe("Negative Tests", () => {
-		it("work item out of minimum range", () => {
-		expect(verifyPRTitleForBugId("@W-999@")).to.equal(false);
+		describe("Be flexible with input", () => {
+			it("Be case-insensitive", () => {
+				expect(verifyReleaseBranchPrTitle("ReLeAsE: @w-1111@: Releasing v3.6.2")).to.equal(true);
+			});
+
+			it("Allow excessive spacing", () => {
+				expect(verifyReleaseBranchPrTitle("     RELEASE    :    @W-1111@    :    Releasing v3.6.2")).to.equal(true);
+			});
+
+			it("Allow no spacing", () => {
+				expect(verifyReleaseBranchPrTitle("RELEASE:@W-1111@:Releasingv3.6.2")).to.equal(true);
+			});
+		});
 	});
+	describe("Negative tests", () => {
+		it("Improperly-ordered PR title", () => {
+			expect(verifyReleaseBranchPrTitle("@W-1111@: RELEASE: Releasing v3.6.2")).to.equal(false);
+		});
 
-	it("work item out of maximum range", () => {
-		expect(verifyPRTitleForBugId("@W-000000000@")).to.equal(false);
-	});
+		it("Scope wrongfully included", () => {
+			expect(verifyReleaseBranchPrTitle("RELEASE (PMD): @W-1111@: Releasing v3.6.2")).to.equal(false);
+		});
 
-	it("work item missing leading @ sign", () => {
-		expect(verifyPRTitleForBugId("W-1234@")).to.equal(false);
-	});
+		it("Disallowed type portion", () => {
+			expect(verifyReleaseBranchPrTitle("REEEELEASE: @W-1111@: Releasing v3.6.2")).to.equal(false);
+		});
 
-	it("work item missing trailing @ sign", () => {
-		expect(verifyPRTitleForBugId("@W-1234")).to.equal(false);
-	});
+		describe("Problems with PR work number", () => {
+			it("Work item below minimum range", () => {
+				expect(verifyDevBranchPrTitle("RELEASE: @W-999@: Releasing v3.6.2.")).to.equal(false);
+			});
 
-	it("work item invalid format", () => {
-		expect(verifyPRTitleForBugId("@W-1234ab@")).to.equal(false);
-	});
+			it("Work item above maximum range", () => {
+				expect(verifyDevBranchPrTitle("RELEASE: @W-1000000000@: Releasing v3.6.2.")).to.equal(false);
+			});
 
-	it("Title starts with invalid token d/W", () => {
-		expect(verifyPRTitleForBadTitle("d/W")).to.equal(false);
-	});
+			it("Work item contains letters", () => {
+				expect(verifyDevBranchPrTitle("RELEASE: @W-1003a00@: Releasing v3.6.2.")).to.equal(false);
+			});
 
-	it("Title starts with invalid token r/W", () => {
-		expect(verifyPRTitleForBadTitle("r/W")).to.equal(false);
+			it("Work item missing leading @-symbol", () => {
+				expect(verifyDevBranchPrTitle("RELEASE: W-1000@: Releasing v3.6.2.")).to.equal(false);
+			});
+
+			it("Work item missing trailing @-symbol", () => {
+				expect(verifyDevBranchPrTitle("RELEASE: @W-1000: Releasing v3.6.2.")).to.equal(false);
+			});
+
+			it("Work item missing", () => {
+				expect(verifyDevBranchPrTitle("RELEASE: beep boop bop.")).to.equal(false);
+			});
+		});
 	});
 });


### PR DESCRIPTION
After this PR is merged, subsequent PRs to `dev` will be subjected to the following checks:
- A verification that the PR title matches our agreed-upon convention of "type (scope): @W-XXXXX@: Summary".

Additionally, subsequent PRs to docdev will be subject to the following checks:
- A verification that the PR title matches our agreed upon convention of "RELEASE: @w-xxxxxx@: Summary".