### PR TITLE
CHANGE (PMD): @W-12107365@: Upgrade to PMD 6.51.0

### DIFF
--- a/pmd-cataloger/build.gradle.kts
+++ b/pmd-cataloger/build.gradle.kts
@@ -9,7 +9,7 @@ group = "sfdx"
 version = "1.0"
 
 val distDir = "$buildDir/../../dist"
-val pmdVersion = "6.50.0"
+val pmdVersion = "6.51.0"
 val pmdFile = "pmd-bin-$pmdVersion.zip"
 val pmdUrl = "https://github.com/pmd/pmd/releases/download/pmd_releases%2F${pmdVersion}/${pmdFile}"
 val skippableJarRegexes = setOf("""^common_[\d\.-]*\.jar""".toRegex(),

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1,7 +1,7 @@
 import os = require('os');
 import path = require('path');
 
-export const PMD_VERSION = '6.50.0';
+export const PMD_VERSION = '6.51.0';
 export const SFGE_VERSION = '1.0.1-pilot';
 export const CATALOG_FILE = 'Catalog.json';
 export const CUSTOM_PATHS_FILE = 'CustomPaths.json';

--- a/src/lib/pmd/PmdEngine.ts
+++ b/src/lib/pmd/PmdEngine.ts
@@ -73,7 +73,7 @@ abstract class BasePmdEngine extends AbstractRuleEngine {
 	 * This Map is a temporary solution allowing us to silence new rules until they can be properly integrated.
 	 * @private
 	 */
-	private SKIPPED_RULES_TO_REASON_MAP: Map<string,string> = new Map([['eagerlyloadeddescribesobjectresult', 'Semantic version incompatible']]);
+	private SKIPPED_RULES_TO_REASON_MAP: Map<string,string> = new Map([['apexunittestclassshouldhaverunas', 'Semantic version incompatible']]);
 
 	protected logger: Logger;
 	protected config: Config;


### PR DESCRIPTION
This PR does the following:
- Upgrades the PMD version to 6.51.0, up from 6.50.0.
- Unsilences the rule `EagerlyLoadedDescribeSObjectResult`, whose impact has been deemed to be acceptably small for introduction in a minor release.
- Disables the new-to-6.51.0 rule `ApexUnitTestClassMustHaveRunAs`, whose impact is still being evaluated.