### PR TITLE
CHANGE (GraphEngine): @W-12098244@: Moved Section from FAQ to Graph Engine Rules

### DIFF
--- a/docs/_articles/en/v3.x/faq.md
+++ b/docs/_articles/en/v3.x/faq.md
@@ -110,6 +110,8 @@ Graph Engine builds up the context of the source code in its entirety before it 
 
 To learn how, read about [Engine Directives](./en/v3.x/salesforce-graph-engine/working-with-sfge/#add-engine-directives).
 
+## Questions about Interpreting ApexFlsViolationRule results
+
 #### Q: My data operation is already protected though not through a CRUD/FLS check. I'm confident that a CRUD/FLS check is not needed. How do I make the violation go away?
 
 If you determine that the CRUD operation in question is protected by a sanitizer that SFGE doesn’t recognize, you can add an [engine directive](./en/v3.x/salesforce-graph-engine/working-with-sfge/#add-engine-directives) to let SFGE know that the CRUD operation _is_ in fact safe.

--- a/docs/_articles/en/v3.x/faq.md
+++ b/docs/_articles/en/v3.x/faq.md
@@ -110,44 +110,6 @@ Graph Engine builds up the context of the source code in its entirety before it 
 
 To learn how, read about [Engine Directives](./en/v3.x/salesforce-graph-engine/working-with-sfge/#add-engine-directives).
 
-## Questions about Interpreting ApexFlsViolationRule results
-
-#### Q: What do the violation messages mean?
-
-Match your violation message with the different message formats described below to understand what it implies.
-
-*Common Scenario*
-
->_Validation-Type_ validation is missing for _Operation-Name_ operation on _Object-Type_ with field(s) _Comma-Separated-Fields_
-
-Parameter explanation:
-
-* _Validation-Type_: Type of validation to be added. CRUD requires object-level checks. FLS requires field-level checks.
-
-* _Operation-Name_: Data operation that needs to be sanitized.
-
-* _Object-Type_: Object on which the data operations happen. If SFGE couldn’t guess the object type, you might see the variable name sometimes, and *SFGE_Unresolved_Argument* at other times.
-
-* _Comma-Separated-Fields_: Fields on which the data operation works. If you see _Unknown_ as the only field or as one of the fields, this means SFGE did not have all the information to guess the fields, and trusts you to determine the unlisted fields.
-
-
-*Additional Clause*
-
-
-> _Validation-Type_ validation is missing for _Operation-Name_ operation on _Object-Type_ with field(s) _Comma-Separated-Fields_ - SFGE may not have parsed some objects/fields correctly. Please confirm if the objects/fields involved in these segments have FLS checks: _Unknown-Segments_
-
-Same as the common scenario, but this additionally means SFGE is not confident about the object names and/or field names it detected. This could also happen if the field or object ends with __r. In both cases, please make sure the relational field/object or the unparsed segments has the required CRUD/FLS checks. Once you’ve taken care of it, you could add an [engine directive](./en/v3.x/salesforce-graph-engine/working-with-sfge/#add-engine-directives) to let SFGE know that it doesn’t have to create a violation.
-
-*stripInaccessible warning*
-
-The `stripInaccessible` warning is thrown for all `stripInaccessible` checks on READ access type. This warning is thrown because Graph Engine has no way to ensure that the sanitized value returned by `SecurityDecision` is the value used in the code that follows the check. You must confirm the values through manual inspection, then add an engine directive to have Graph Engine ignore this warning in the next run. Alternatively, disable these violations by using the `--rule-disable-warning-violation` flag or setting its corresponding environment variable, SFGE_RULE_DISABLE_WARNING_VIOLATION, to true.
-
-*Internal error*
-
-Internal error. Work in progress. Please ignore.
-
-This indicates that SFGE ran into an error while assessing the source/sink path mentioned in the violation. While we continue to work on fixing these errors, please make sure that the path in question is sanitized anyway.
-
 #### Q: My data operation is already protected though not through a CRUD/FLS check. I'm confident that a CRUD/FLS check is not needed. How do I make the violation go away?
 
 If you determine that the CRUD operation in question is protected by a sanitizer that SFGE doesn’t recognize, you can add an [engine directive](./en/v3.x/salesforce-graph-engine/working-with-sfge/#add-engine-directives) to let SFGE know that the CRUD operation _is_ in fact safe.

--- a/docs/_articles/en/v3.x/salesforce-graph-engine/rules.md
+++ b/docs/_articles/en/v3.x/salesforce-graph-engine/rules.md
@@ -37,10 +37,43 @@ ApexFlsViolationRule detects [Create, Read, Update, and Delete (CRUD) and Field-
 |				 |SOQL queries that use [WITH SECURITY_ENFORCED](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_with_security_enforced.htm#apex_classes_with_security_enforced)|
 |				 |Lists filtered by [Security.stripInaccessible](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_with_security_stripInaccessible.htm)|
 
-Have a look at related [FAQ](./en/v3.x/faq/#questions-about-interpreting-apexflsviolationrule-results) to understand the results generated.
+### Interpreting ApexFlsViolationRule Results
+
+Match any violation message that you receive with these scenarios to understand more about the violation.
+
+*Common Scenario*
+
+>_Validation-Type_ validation is missing for _Operation-Name_ operation on _Object-Type_ with fields _Comma-Separated-Fields_
+
+Parameter explanation:
+
+* _Validation-Type_: Type of validation to be added. CRUD requires object-level checks, and FLS requires field-level checks.
+
+* _Operation-Name_: Data operation that must be sanitized.
+
+* _Object-Type_: Object on which the data operations happen. If Graph Engine couldn’t guess the object type, you see the variable name or *SFGE_Unresolved_Argument*.
+
+* _Comma-Separated-Fields_: Fields on which the data operation works. If you see _Unknown_ as the only field or as one of the fields, Graph Engine didn't have enough information to guess the fields, and you must determine the unlisted fields manually.
+
+*Additional Clause Scenario*
+
+> _Validation-Type_ validation is missing for _Operation-Name_ operation on _Object-Type_ with fields _Comma-Separated-Fields_ - Graph Engine couldn't parse all objects and fields correctly. Confirm manually if the objectsfields involved in these segments have FLS checks: _Unknown-Segments_
+
+Same as the common scenario, plus Graph Engine isn't confident about the object names or field names it detected. You also see this additional clause when your field or object ends with __r. In both cases, review the relational field, object, and the unparsed segments to ensure they have the required CRUD/FLS checks. Next, add an [engine directive](./en/v3.x/salesforce-graph-engine/working-with-sfge/#add-engine-directives) to let Graph Engine know that it doesn’t have to create a violation.
+
+*stripInaccessible Warning Scenario*
+
+The `stripInaccessible` warning is thrown for all `stripInaccessible` checks on READ access type. Graph Engine has no way to ensure that the sanitized value returned by `SecurityDecision` is the value used in the code that follows the check. Confirm the values manually, then add an engine directive to force Graph Engine to ignore this warning in the next run. Alternatively, disable these violations by using the `--rule-disable-warning-violation` flag or setting its corresponding environment variable, SFGE_RULE_DISABLE_WARNING_VIOLATION, to true.
+
+*Internal Error Scenario*
+
+> Graph Engine ran into an error while accessing the path mentioned in the violation. Graph Engine identified your source and sink, but couldn’t identify your sanitizer. Verify manually that you have a sanitizer in this path.
+
+Graph Engine ran into an error while assessing the source and sink path mentioned in the violation. Verify your code manually to ensure that the path in question is sanitized.
 
 #### See Also
 
+- [FAQ](./en/v3.x/faq/#questions-about-interpreting-apexflsviolationrule-results)
 - [Enforce Security With the stripInaccessible Method](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_with_security_stripInaccessible.htm)
 - [Enforcing Object and Field Permissions](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_perms_enforcing.htm)
 - [Filter SOQL Queries Using WITH SECURITY_ENFORCED](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_with_security_enforced.htm)

--- a/docs/_articles/en/v3.x/salesforce-graph-engine/rules.md
+++ b/docs/_articles/en/v3.x/salesforce-graph-engine/rules.md
@@ -57,9 +57,9 @@ Parameter explanation:
 
 *Additional Clause Scenario*
 
-> _Validation-Type_ validation is missing for _Operation-Name_ operation on _Object-Type_ with fields _Comma-Separated-Fields_ - Graph Engine couldn't parse all objects and fields correctly. Confirm manually if the objectsfields involved in these segments have FLS checks: _Unknown-Segments_
+> _Validation-Type_ validation is missing for _Operation-Name_ operation on _Object-Type_ with fields _Comma-Separated-Fields_ - Graph Engine couldn't parse all objects and fields correctly. Confirm manually if the objects and fields involved in these segments have FLS checks: _Unknown-Segments_
 
-Same as the common scenario, plus Graph Engine isn't confident about the object names or field names it detected. You also see this additional clause when your field or object ends with __r. In both cases, review the relational field, object, and the unparsed segments to ensure they have the required CRUD/FLS checks. Next, add an [engine directive](./en/v3.x/salesforce-graph-engine/working-with-sfge/#add-engine-directives) to let Graph Engine know that it doesn’t have to create a violation.
+Same as the common scenario, but also Graph Engine isn't confident about the object names or field names it detected. You also see this additional clause when your field or object ends with `__r`. In both cases, review the relational field, object, and the unparsed segments to ensure they have the required CRUD/FLS checks. Next, add an [engine directive](./en/v3.x/salesforce-graph-engine/working-with-sfge/#add-engine-directives) to force Graph Engine to ignore this warning in the next run.
 
 *stripInaccessible Warning Scenario*
 

--- a/docs/_articles/en/v3.x/salesforce-graph-engine/rules.md
+++ b/docs/_articles/en/v3.x/salesforce-graph-engine/rules.md
@@ -41,7 +41,7 @@ ApexFlsViolationRule detects [Create, Read, Update, and Delete (CRUD) and Field-
 
 Match any violation message that you receive with these scenarios to understand more about the violation.
 
-*Common Scenario*
+*Common Case*
 
 >_Validation-Type_ validation is missing for _Operation-Name_ operation on _Object-Type_ with fields _Comma-Separated-Fields_
 
@@ -55,21 +55,21 @@ Parameter explanation:
 
 * _Comma-Separated-Fields_: Fields on which the data operation works. If you see _Unknown_ as the only field or as one of the fields, Graph Engine didn't have enough information to guess the fields, and you must determine the unlisted fields manually.
 
-*Additional Clause Scenario*
+*Additional Clause Case*
 
 > _Validation-Type_ validation is missing for _Operation-Name_ operation on _Object-Type_ with fields _Comma-Separated-Fields_ - Graph Engine couldn't parse all objects and fields correctly. Confirm manually if the objects and fields involved in these segments have FLS checks: _Unknown-Segments_
 
-Same as the common scenario, but also Graph Engine isn't confident about the object names or field names it detected. You also see this additional clause when your field or object ends with `__r`. In both cases, review the relational field, object, and the unparsed segments to ensure they have the required CRUD/FLS checks. Next, add an [engine directive](./en/v3.x/salesforce-graph-engine/working-with-sfge/#add-engine-directives) to force Graph Engine to ignore this warning in the next run.
+Same as the common case, but also Graph Engine isn't confident about the object names or field names it detected. You also see this additional clause when your field or object ends with `__r`. In both cases, review the relational field, object, and the unparsed segments to ensure they have the required CRUD/FLS checks. Next, add an [engine directive](./en/v3.x/salesforce-graph-engine/working-with-sfge/#add-engine-directives) to force Graph Engine to ignore this warning in the next run.
 
-*stripInaccessible Warning Scenario*
+*stripInaccessible Warning Case*
 
 The `stripInaccessible` warning is thrown for all `stripInaccessible` checks on READ access type. Graph Engine has no way to ensure that the sanitized value returned by `SecurityDecision` is the value used in the code that follows the check. Confirm the values manually, then add an engine directive to force Graph Engine to ignore this warning in the next run. Alternatively, disable these violations by using the `--rule-disable-warning-violation` flag or setting its corresponding environment variable, SFGE_RULE_DISABLE_WARNING_VIOLATION, to true.
 
-*Internal Error Scenario*
+*Internal Error Case*
 
-> Graph Engine ran into an error while accessing the path mentioned in the violation. Graph Engine identified your source and sink, but couldn’t identify your sanitizer. Verify manually that you have a sanitizer in this path.
+> Graph Engine identified your source and sink, but you must manually verify that you have a sanitizer in this path. Then, add an engine directive to skip the path. Next, create a GitHub issue for the Code Analyzer team that includes the error and stack trace. After we fix this issue, check the Code Analyzer release notes for more info. Error and stacktrace: [placeholder error message + stacktrace info]
 
-Graph Engine ran into an error while assessing the source and sink path mentioned in the violation. Verify your code manually to ensure that the path in question is sanitized.
+Graph Engine ran into an error while walking this path. Manually verify that you have a sanitizer on the path, and add an engine directive to skip the path. Next, create a GitHub issue for the Code Analyzer team that includes the error and stack trace so we can research and resolve it. After we determine a fix for the issue, check Code Analyzer [Release Information](https://forcedotcom.github.io/sfdx-scanner/en/v3.x/release-information/) for more info.
 
 #### See Also
 

--- a/docs/_articles/en/v3.x/salesforce-graph-engine/rules.md
+++ b/docs/_articles/en/v3.x/salesforce-graph-engine/rules.md
@@ -39,7 +39,7 @@ ApexFlsViolationRule detects [Create, Read, Update, and Delete (CRUD) and Field-
 
 ### Interpreting ApexFlsViolationRule Results
 
-Match any violation message that you receive with these scenarios to understand more about the violation.
+Match any violation message that you receive with these cases to understand more about the violation.
 
 *Common Case*
 

--- a/docs/_articles/en/v3.x/salesforce-graph-engine/rules.md
+++ b/docs/_articles/en/v3.x/salesforce-graph-engine/rules.md
@@ -67,7 +67,7 @@ The `stripInaccessible` warning is thrown for all `stripInaccessible` checks on 
 
 *Internal Error Case*
 
-> Graph Engine identified your source and sink, but you must manually verify that you have a sanitizer in this path. Then, add an engine directive to skip the path. Next, create a GitHub issue for the Code Analyzer team that includes the error and stack trace. After we fix this issue, check the Code Analyzer release notes for more info. Error and stacktrace: [placeholder error message + stacktrace info]
+> Graph Engine identified your source and sink, but you must manually verify that you have a sanitizer in this path. Then, add an engine directive to skip the path. Next, create a GitHub issue for the Code Analyzer team that includes the error and stack trace. After we fix this issue, check the Code Analyzer release notes for more info. Error and stacktrace: [details]
 
 Graph Engine ran into an error while walking this path. Manually verify that you have a sanitizer on the path, and add an engine directive to skip the path. Next, create a GitHub issue for the Code Analyzer team that includes the error and stack trace so we can research and resolve it. After we determine a fix for the issue, check Code Analyzer [Release Information](https://forcedotcom.github.io/sfdx-scanner/en/v3.x/release-information/) for more info.
 


### PR DESCRIPTION
Moved details on how to interpret Apex violation results from FAQ to Graph Engine section
- updated language to fit with CCX standards
- if any error messages, violations, warnings were updated, these should be updated in Messages files, too