### PR TITLE
CHANGE (CodeAnalyzer): @W-11999008@: Refactor DFA-based GraphEngine in preparation for enabling new rule.

### DIFF
--- a/messages/DefaultRuleManager.js
+++ b/messages/DefaultRuleManager.js
@@ -3,5 +3,8 @@ module.exports = {
 		"targetSkipped": "The specified target wasn't processed by any engines. Use the --engine parameter to select a different engine or specify a different target. Specified target: %s.",
 		"targetsSkipped": "The specified targets weren't processed by any engines: %s. Review your target and engine combinations and try again.",
 		"pathsDoubleProcessed": "One or more files were processed by eslint and eslint-lwc simultaneously. To remove possible duplicate violations, customize the targetPatterns property for eslint and eslint-lwc engines in %s on these files: %s.",
+	},
+	"error": {
+		"cannotRunDfaAndNonDfaConcurrently": "DFA engines %s cannot be run concurrently with non-DFA engines %s"
 	}
 }

--- a/sfge/src/main/java/com/salesforce/Main.java
+++ b/sfge/src/main/java/com/salesforce/Main.java
@@ -27,30 +27,28 @@ import org.apache.logging.log4j.Logger;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 
 /**
- * The main class, invoked by sfdx-scanner. `catalog` flow lists all of the available rules in a
- * standardized format.
- *
- * <p>The `execute` flow accepts as a parameter the name of a file whose contents are a JSON with
- * the following structure:
+ * The main class, invoked by sfdx-scanner. The first arg should be either `catalog` or `execute`,
+ * and determines which flow runs. <br>
+ * For `catalog`, the second arg should be either `pathless` or `dfa`. Enabled rules matching that
+ * type will be logged as a JSON. No meaningful environment variables exist for this flow. Exit code
+ * 0 means success. Any other exit code means failure. <br>
+ * For `execute`, the second arg should be the path to a JSON file whose contents are structured as:
  *
  * <ol>
- *   <li>rulesToRun: An array of rule names.
- *   <li>projectDirs: An array of directories from which the graph should be built.
- *   <li>targets: An array of objects with a `targetFile` property indicating the file to be
- *       analyzed and a `targetMethods` property indicating individual methods.
+ *   <li>rulesToRun: an array of rule names.
+ *   <li>projectDirs: an array of directories from which the graph should be built.
+ *   <li>targets: an array of objects with a `targetFile` property indicating the file to be
+ *       analyzed and a `targetMethods` property that may optionally indicate individual methods
+ *       within that file.
  * </ol>
  *
- * <p>Exit codes:
+ * The following exit codes are possible:
  *
- * <ul>
- *   <li>Negative numbers indicate an internal error.
- *   <li>0 indicates a successful run with * no violations.
- *   <li>Positive numbers indicate a successful run with exit-code-many violations.
- * </ul>
- *
- * <p>Usage: mvn exec:java -Dexec.mainClass=com.salesforce.Main -Dexec.args="catalog" OR mvn
- * exec:java -Dexec.mainClass=com.salesforce.Main -Dexec.args="execute [path to file listing
- * targets] [path to file listing sources] [comma-separated rules]"
+ * <ol>
+ *   <li>0: Successful run without violations.
+ *   <li>1: Internal error with no violations.
+ *   <li>4: Successful run with violations.5: Internal error with some violations.>
+ * </ol>
  */
 @SuppressWarnings(
         "PMD.SystemPrintln") // Since println is currently used to communicate to outer layer
@@ -104,6 +102,7 @@ public class Main {
         }
     }
 
+    /** Expectations for args documented in class header above. */
     private int catalog(String... args) {
         LOGGER.info("Invoked CATALOG flow");
         CliArgParser.CatalogArgParser cap = new CliArgParser.CatalogArgParser();
@@ -120,6 +119,7 @@ public class Main {
         return EXIT_GOOD_RUN_NO_VIOLATIONS;
     }
 
+    /** Expectations for args documented in class header above. */
     private int execute(String... args) {
         LOGGER.info("Invoked EXECUTE flow");
         // Parse the arguments with our delegate class.

--- a/sfge/src/main/java/com/salesforce/Main.java
+++ b/sfge/src/main/java/com/salesforce/Main.java
@@ -17,7 +17,6 @@ import com.salesforce.metainfo.MetaInfoCollectorProvider;
 import com.salesforce.rules.AbstractRule;
 import com.salesforce.rules.AbstractRuleRunner;
 import com.salesforce.rules.RuleRunner;
-import com.salesforce.rules.RuleUtil;
 import com.salesforce.rules.Violation;
 import com.salesforce.rules.ops.ProgressListenerProvider;
 import java.util.Arrays;
@@ -97,7 +96,7 @@ public class Main {
 
         switch (action) {
             case CATALOG:
-                return catalog();
+                return catalog(args);
             case EXECUTE:
                 return execute(args);
             default:
@@ -105,11 +104,13 @@ public class Main {
         }
     }
 
-    private int catalog() {
+    private int catalog(String... args) {
         LOGGER.info("Invoked CATALOG flow");
+        CliArgParser.CatalogArgParser cap = new CliArgParser.CatalogArgParser();
         List<AbstractRule> rules;
         try {
-            rules = RuleUtil.getEnabledRules();
+            cap.parseArgs(args);
+            rules = cap.getSelectedRules();
         } catch (SfgeException | SfgeRuntimeException ex) {
             dependencies.printError(ex.getMessage());
             return EXIT_WITH_INTERNAL_ERROR_NO_VIOLATIONS;

--- a/sfge/src/main/java/com/salesforce/cli/CliArgParser.java
+++ b/sfge/src/main/java/com/salesforce/cli/CliArgParser.java
@@ -41,6 +41,48 @@ public class CliArgParser {
         }
     }
 
+    public static class CatalogArgParser {
+        private static final int ARG_COUNT = 2;
+        // NOTE: This value must match the one for the RuleType enum declared in Constants.ts.
+        private static final String PATHLESS = "pathless";
+        // NOTE: This value must match the one for the RuleType enum declared in Constants.ts.
+        private static final String DFA = "dfa";
+
+        private List<AbstractRule> selectedRules;
+
+        public CatalogArgParser() {
+            selectedRules = new ArrayList<>();
+        }
+
+        public void parseArgs(String... args) throws RuleUtil.RuleNotFoundException {
+            if (LOGGER.isInfoEnabled()) {
+                LOGGER.info("CLI args received: " + Arrays.toString(args));
+            }
+            // Make sure we have the right number of arguments.
+            if (args.length != ARG_COUNT) {
+                throw new InvocationException(
+                        String.format(
+                                "Wrong number of arguments. Expected %d; received %d",
+                                ARG_COUNT, args.length));
+            }
+            switch (args[1]) {
+                case PATHLESS:
+                    selectedRules = RuleUtil.getEnabledStaticRules();
+                    break;
+                case DFA:
+                    selectedRules = RuleUtil.getEnabledPathBasedRules();
+                    break;
+                default:
+                    selectedRules = RuleUtil.getEnabledRules();
+                    break;
+            }
+        }
+
+        public List<AbstractRule> getSelectedRules() {
+            return selectedRules;
+        }
+    }
+
     public static class ExecuteArgParser {
         private static int ARG_COUNT = 2;
 
@@ -90,28 +132,6 @@ public class CliArgParser {
 
         public List<AbstractRule> getSelectedRules() {
             return selectedRules;
-        }
-
-        private void identifyProjectDirs(String inputFile) {
-            try {
-                projectDirs.addAll(readFile(inputFile));
-            } catch (IOException ex) {
-                throw new InvocationException(
-                        "Could not read source-list file " + inputFile + ": " + ex.getMessage(),
-                        ex);
-            }
-        }
-
-        private void identifyTargetFiles(String inputFile) {
-            try {
-                String targetJson = String.join("\n", readFile(inputFile));
-                Gson gson = new Gson();
-                targets.addAll(Arrays.asList(gson.fromJson(targetJson, RuleRunnerTarget[].class)));
-            } catch (IOException ex) {
-                throw new InvocationException(
-                        "Could not read target-list file " + inputFile + ": " + ex.getMessage(),
-                        ex);
-            }
         }
 
         private ExecuteInput readInputFile(String fileName) {

--- a/sfge/src/main/java/com/salesforce/cli/CliArgParser.java
+++ b/sfge/src/main/java/com/salesforce/cli/CliArgParser.java
@@ -54,6 +54,10 @@ public class CliArgParser {
             selectedRules = new ArrayList<>();
         }
 
+        /**
+         * See the documentation of {@link com.salesforce.Main} for information about the
+         * expectations for args.
+         */
         public void parseArgs(String... args) throws RuleUtil.RuleNotFoundException {
             if (LOGGER.isInfoEnabled()) {
                 LOGGER.info("CLI args received: " + Arrays.toString(args));
@@ -104,6 +108,10 @@ public class CliArgParser {
             this.dependencies = dependencies;
         }
 
+        /**
+         * See the documentation of {@link com.salesforce.Main} for information about the
+         * expectations for args.
+         */
         public void parseArgs(String... args) {
             if (LOGGER.isInfoEnabled()) {
                 LOGGER.info("CLI args received: " + Arrays.toString(args));

--- a/sfge/src/main/java/com/salesforce/rules/RuleUtil.java
+++ b/sfge/src/main/java/com/salesforce/rules/RuleUtil.java
@@ -18,6 +18,18 @@ import org.reflections.Reflections;
 public final class RuleUtil {
     private static final Logger LOGGER = LogManager.getLogger(RuleUtil.class);
 
+    public static List<AbstractRule> getEnabledStaticRules() throws RuleNotFoundException {
+        return getEnabledRules().stream()
+                .filter(rule -> rule instanceof AbstractStaticRule)
+                .collect(Collectors.toList());
+    }
+
+    public static List<AbstractRule> getEnabledPathBasedRules() throws RuleNotFoundException {
+        return getEnabledRules().stream()
+                .filter(rule -> rule instanceof AbstractPathBasedRule)
+                .collect(Collectors.toList());
+    }
+
     public static List<AbstractRule> getEnabledRules() throws RuleNotFoundException {
         final List<AbstractRule> allRules = getAllRules();
         return allRules.stream().filter(rule -> rule.isEnabled()).collect(Collectors.toList());

--- a/sfge/src/test/java/com/salesforce/MainTest.java
+++ b/sfge/src/test/java/com/salesforce/MainTest.java
@@ -10,6 +10,7 @@ import com.google.common.collect.Lists;
 import com.salesforce.cli.CliArgParser;
 import com.salesforce.cli.Result;
 import com.salesforce.config.UserFacingMessages;
+import com.salesforce.messaging.CliMessager;
 import com.salesforce.rules.RuleRunner;
 import com.salesforce.rules.Violation;
 import com.salesforce.testutils.DummyVertex;
@@ -17,6 +18,7 @@ import java.io.IOException;
 import java.util.List;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -66,6 +68,12 @@ public class MainTest {
 
         Mockito.lenient().when(dependencies.createExecuteArgParser()).thenReturn(executeArgParser);
         Mockito.lenient().when(dependencies.getGraph()).thenReturn(g);
+        CliMessager.getInstance().resetMessages();
+    }
+
+    @AfterEach
+    void teardown() {
+        CliMessager.getInstance().resetMessages();
     }
 
     @Test

--- a/sfge/src/test/java/com/salesforce/cli/CliArgParserTest.java
+++ b/sfge/src/test/java/com/salesforce/cli/CliArgParserTest.java
@@ -1,0 +1,70 @@
+package com.salesforce.cli;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.salesforce.config.UserFacingMessages;
+import com.salesforce.rules.RuleUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class CliArgParserTest {
+
+    @ValueSource(
+            strings = {
+                // Simple lowercase test.
+                "execute",
+                // Case-insensitivity test.
+                "eXeCuTe",
+            })
+    @ParameterizedTest(name = "{displayName}: {0}")
+    public void getCliAction_getsExecuteEnum(String arg) {
+        CliArgParser parser = new CliArgParser();
+        CliArgParser.CLI_ACTION result = parser.getCliAction(arg);
+        assertThat(result, equalTo(CliArgParser.CLI_ACTION.EXECUTE));
+    }
+
+    @ValueSource(
+            strings = {
+                // Simple lowercase test.
+                "catalog",
+                // Case-insensitivity test.
+                "CaTaLoG"
+            })
+    @ParameterizedTest(name = "{displayName}: {0}")
+    public void getCliAction_getsCatalogEnum(String arg) {
+        CliArgParser parser = new CliArgParser();
+        CliArgParser.CLI_ACTION result = parser.getCliAction(arg);
+        assertThat(result, equalTo(CliArgParser.CLI_ACTION.CATALOG));
+    }
+
+    @Test
+    public void getCliAction_throwsExpectedError() {
+        CliArgParser parser = new CliArgParser();
+        assertThrows(
+                CliArgParser.InvocationException.class,
+                () -> parser.getCliAction("notARealAction"),
+                String.format(UserFacingMessages.UNRECOGNIZED_ACTION, "notARealAction"));
+    }
+
+    @CsvSource({
+        // As we add new DFA and non-DFA rules, the numbers in these tests
+        // will increase.
+        "pathless, 0",
+        "dfa, 1"
+    })
+    @ParameterizedTest(name = "{displayName}: {0} rules")
+    public void catalogFlowReturnsExpectedRules(String arg, int ruleCount) {
+        CliArgParser.CatalogArgParser parser = new CliArgParser.CatalogArgParser();
+        try {
+            parser.parseArgs("catalog", arg);
+            assertThat(parser.getSelectedRules().size(), equalTo(ruleCount));
+        } catch (RuleUtil.RuleNotFoundException rnf) {
+            fail("Should not throw exception");
+        }
+    }
+}

--- a/sfge/src/test/java/com/salesforce/graph/ops/PathEntryPointUtilTest.java
+++ b/sfge/src/test/java/com/salesforce/graph/ops/PathEntryPointUtilTest.java
@@ -10,6 +10,7 @@ import com.salesforce.collections.CollectionUtil;
 import com.salesforce.graph.Schema;
 import com.salesforce.graph.vertex.MethodVertex;
 import com.salesforce.graph.vertex.SFVertexFactory;
+import com.salesforce.messaging.CliMessager;
 import com.salesforce.metainfo.MetaInfoCollectorTestProvider;
 import com.salesforce.metainfo.VisualForceHandlerImpl;
 import com.salesforce.rules.AbstractRuleRunner;
@@ -19,6 +20,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -31,6 +33,12 @@ public class PathEntryPointUtilTest {
     @BeforeEach
     public void setup() {
         this.g = TestUtil.getGraph();
+        CliMessager.getInstance().resetMessages();
+    }
+
+    @AfterEach
+    public void teardown() {
+        CliMessager.getInstance().resetMessages();
     }
 
     @ValueSource(

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -31,6 +31,11 @@ export enum ENGINE {
 	SFGE = 'sfge'
 }
 
+export enum RuleType {
+	PATHLESS = "pathless",
+	DFA = "dfa"
+}
+
 /**
  * Main engine types that have more than one variation
  */

--- a/src/ioc.config.ts
+++ b/src/ioc.config.ts
@@ -8,7 +8,7 @@ import {LWCEslintEngine} from './lib/eslint/EslintEngine';
 import {TypescriptEslintEngine} from './lib/eslint/EslintEngine';
 import {CustomEslintEngine} from './lib/eslint/CustomEslintEngine';
 import {RetireJsEngine} from './lib/retire-js/RetireJsEngine';
-import {SfgeEngine} from './lib/sfge/SfgeEngine';
+import {SfgeDfaEngine} from './lib/sfge/SfgeDfaEngine';
 import {CustomPmdEngine, PmdEngine} from './lib/pmd/PmdEngine';
 import LocalCatalog from './lib/services/LocalCatalog';
 import {Config} from './lib/util/Config';
@@ -40,7 +40,7 @@ export function registerAll(): void {
 		container.registerSingleton(Services.RuleEngine, CustomEslintEngine);
 		container.registerSingleton(Services.RuleEngine, RetireJsEngine);
 		container.registerSingleton(Services.RuleEngine, CpdEngine);
-		container.registerSingleton(Services.RuleEngine, SfgeEngine);
+		container.registerSingleton(Services.RuleEngine, SfgeDfaEngine);
 		container.registerSingleton(Services.RuleCatalog, LocalCatalog);
 		container.registerSingleton(Services.RulePathManager, CustomRulePathManager);
 	}

--- a/src/lib/DefaultRuleManager.ts
+++ b/src/lib/DefaultRuleManager.ts
@@ -167,7 +167,11 @@ export class DefaultRuleManager implements RuleManager {
 		const dfaEngines = runDescriptorList.filter(descriptor => descriptor.engine.isDfaEngine()).map(descriptor => descriptor.engine.getName());
 		const pathlessEngines = runDescriptorList.filter(descriptor => !(descriptor.engine.isDfaEngine())).map(descriptor => descriptor.engine.getName());
 		if (dfaEngines.length > 0 && pathlessEngines.length > 0) {
-			throw new SfdxError(`DFA engines ${JSON.stringify(dfaEngines)} cannot be run concurrently with non-DFA engines ${JSON.stringify(pathlessEngines)}`);
+			throw SfdxError.create('@salesforce/sfdx-scanner',
+				'DefaultRuleManager',
+				'error.cannotRunDfaAndNonDfaConcurrently',
+				[JSON.stringify(dfaEngines), JSON.stringify(pathlessEngines)]
+			);
 		}
 	}
 

--- a/src/lib/DefaultRuleManager.ts
+++ b/src/lib/DefaultRuleManager.ts
@@ -167,7 +167,7 @@ export class DefaultRuleManager implements RuleManager {
 		const dfaEngines = runDescriptorList.filter(descriptor => descriptor.engine.isDfaEngine()).map(descriptor => descriptor.engine.getName());
 		const pathlessEngines = runDescriptorList.filter(descriptor => !(descriptor.engine.isDfaEngine())).map(descriptor => descriptor.engine.getName());
 		if (dfaEngines.length > 0 && pathlessEngines.length > 0) {
-			throw new SfdxError(messages.getMessage(`Pathless engines ${JSON.stringify(pathlessEngines)} cannot be run concurrently with DFA engines ${JSON.stringify(dfaEngines)}`));
+			throw new SfdxError(`DFA engines ${JSON.stringify(dfaEngines)} cannot be run concurrently with non-DFA engines ${JSON.stringify(pathlessEngines)}`);
 		}
 	}
 

--- a/src/lib/sfge/AbstractSfgeEngine.ts
+++ b/src/lib/sfge/AbstractSfgeEngine.ts
@@ -1,12 +1,12 @@
 import {Logger} from '@salesforce/core';
-import {SfgeWrapper} from './SfgeWrapper';
+import {SfgeCatalogWrapper, SfgeExecuteWrapper} from './SfgeWrapper';
 import {AbstractRuleEngine} from '../services/RuleEngine';
-import {CUSTOM_CONFIG, ENGINE, Severity} from '../../Constants';
+import {CUSTOM_CONFIG, ENGINE, RuleType, Severity} from '../../Constants';
 import {Controller} from '../../Controller';
-import {Catalog, Rule, RuleGroup, RuleResult, RuleTarget, SfgeConfig, TargetPattern} from '../../types';
+import {Catalog, Rule, RuleGroup, RuleResult, RuleTarget, RuleViolation, SfgeConfig, TargetPattern} from '../../types';
 import {Config} from '../util/Config';
 import * as EngineUtils from '../util/CommonEngineUtils';
-import { EventCreator } from '../util/EventCreator';
+import {EventCreator} from '../util/EventCreator';
 
 const CATALOG_START = 'CATALOG_START';
 const CATALOG_END = 'CATALOG_END';
@@ -21,7 +21,7 @@ type SfgePartialRule = {
 	category: string;
 }
 
-type SfgeViolation = {
+export type SfgeViolation = {
 	ruleName: string;
 	message: string;
 	severity: number;
@@ -37,52 +37,85 @@ type SfgeViolation = {
 	sinkFileName: string;
 };
 
-export class SfgeEngine extends AbstractRuleEngine {
-	private static ENGINE_ENUM: ENGINE = ENGINE.SFGE;
-	private static ENGINE_NAME: string = ENGINE.SFGE.valueOf();
+export abstract class AbstractSfgeEngine extends AbstractRuleEngine {
+	protected static ENGINE_ENUM: ENGINE = ENGINE.SFGE;
+	protected static ENGINE_NAME: string = ENGINE.SFGE.valueOf();
 
 	private logger: Logger;
 	private config: Config;
 	private eventCreator: EventCreator;
+	private catalog: Catalog;
 	private initialized: boolean;
 
+	protected abstract convertViolation(sfgeViolation: SfgeViolation): RuleViolation;
+
+	protected abstract getRuleType(): RuleType;
+
+	protected abstract getSubVariantName(): string;
+
 	/**
-	 * Invokes sync/async initialization required for the engine
+	 * Invokes sync/async initialization required for the engine.
+	 * @override
 	 */
 	public async init(): Promise<void> {
 		if (this.initialized) {
 			return;
 		}
-		this.logger = await Logger.child(this.getName());
+		// Make sure that the sub-variants have different names for their loggers.
+		// This way, we can implement the method at the abstract level instead of
+		// the concrete classes.
+		this.logger = await Logger.child(`${this.getSubVariantName()}`);
 		this.config = await Controller.getConfig();
 		this.eventCreator = await EventCreator.create({});
 		this.initialized = true;
 	}
 
 	/**
-	 * Returns the name of the engine as referenced everywhere within the code
+	 * Returns the name of the engine as referenced everywhere within the code.
+	 * NOTE: By defining this at the abstract class, all engines in this family
+	 * will share the same name and everything that comes with it (e.g., config).
+	 * @override
 	 */
 	public getName(): string {
-		return SfgeEngine.ENGINE_NAME;
+		return AbstractSfgeEngine.ENGINE_NAME;
 	}
 
+	/**
+	 * Get the patterns that this engine family can match against.
+	 * @override
+	 */
 	public async getTargetPatterns(): Promise<TargetPattern[]> {
-		return await this.config.getTargetPatterns(SfgeEngine.ENGINE_ENUM);
+		return await this.config.getTargetPatterns(AbstractSfgeEngine.ENGINE_ENUM);
 	}
 
 	/**
 	 * Fetches the default catalog of rules supported by this engine.
+	 * Different concrete implementations of this class will return
+	 * different catalogs.
+	 * @override
 	 */
 	public async getCatalog(): Promise<Catalog> {
-		const catalogOutput: string = await SfgeWrapper.getCatalog();
+		// If we've already got a catalog, return it immediately.
+		if (this.catalog) {
+			return this.catalog;
+		}
+		// Each engine sub-variant should only catalog rules it can execute.
+		const ruleType: RuleType = this.getRuleType();
+		const catalogOutput: string = await SfgeCatalogWrapper.getCatalog(ruleType);
 		const ruleOutputStart: number = catalogOutput.indexOf(CATALOG_START) + CATALOG_START.length;
 		const ruleOutputEnd: number = catalogOutput.indexOf(CATALOG_END);
 		const ruleOutput: string = catalogOutput.slice(ruleOutputStart, ruleOutputEnd);
 		const partialRules: SfgePartialRule[] = JSON.parse(ruleOutput) as SfgePartialRule[];
 
-		return this.createCatalogFromPartialRules(partialRules);
+		this.catalog = this.createCatalogFromPartialRules(partialRules);
+		return this.catalog;
 	}
 
+	/**
+	 * Convert the partial rule descriptions returned by Graph Engine into a {@link Catalog}
+	 * object that Code Analyzer can use.
+	 * @private
+	 */
 	private createCatalogFromPartialRules(partialRules: SfgePartialRule[]): Catalog {
 		// For each raw rule, we'll want to synthesize an actual rule object.
 		const completeRules: Rule[] = [];
@@ -91,17 +124,17 @@ export class SfgeEngine extends AbstractRuleEngine {
 
 		partialRules.forEach(({name, description, category}) => {
 			completeRules.push({
-				engine: ENGINE.SFGE,
+				engine: AbstractSfgeEngine.ENGINE_ENUM,
 				sourcepackage: "sfge",
 				name,
 				description,
-				// SFGE rules each belong to exactly one category, so the string must be converted to a singleton array.
+				// Graph Engine rules each belong to exactly one category, so the string must be converted to a singleton array.
 				categories: [category],
-				// SFGE does not use rulesets.
+				// Graph Engine does not use rulests.
 				rulesets: [],
-				// Currently, all SFGE rules are Apex-specific.
+				// Currently, all Graph Engine rules are Apex-specific.
 				languages: ["apex"],
-				// Currently, all SFGE rules are default-enabled.
+				// Currently, all Graph Engine rules are default-enabled.
 				defaultEnabled: true
 			});
 			categoryNames.add(category);
@@ -119,7 +152,7 @@ export class SfgeEngine extends AbstractRuleEngine {
 		return {
 			rules: completeRules,
 			categories: completeCategories,
-			// SFGE does not use rulesets.
+			// Graph Engine does not use rulesets.
 			rulesets: []
 		};
 	}
@@ -127,55 +160,84 @@ export class SfgeEngine extends AbstractRuleEngine {
 	/**
 	 * Helps make decision to run an engine or not based on the Rules, Target paths, and the Engine Options selected per
 	 * run. At this point, filtering should have already happened.
+	 * @override
 	 */
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	public shouldEngineRun(ruleGroups: RuleGroup[], rules: Rule[], target: RuleTarget[], engineOptions: Map<string,string>): boolean {
-		// If the engine isn't filtered out, there's no reason to not run it.
+		// If the engine wasn't filtered out, there's no reason not to run it.
+		// TODO: WE MAY WANT TO RE-ASSESS THIS.
 		return true;
 	}
 
 	/**
 	 * @param engineOptions - A mapping of keys to values for engineOptions. Not all key/value pairs will apply to all engines.
+	 * @override
 	 */
 	public async run(ruleGroups: RuleGroup[], rules: Rule[], targets: RuleTarget[], engineOptions: Map<string,string>): Promise<RuleResult[]> {
 		// Make sure we have actual targets to run against.
 		let targetCount = 0;
 		targets.forEach((t) => {
 			if (t.methods.length > 0) {
-				// If we're targeting individual methods, then each method is counted as a separate target for this purpose.
+				// If we're targeting individual methods, then each method is counted
+				// as a separate target for this purpose.
 				targetCount += t.methods.length;
 			} else {
 				targetCount += t.paths.length;
 			}
 		});
 
+		// If there are no targets, there's no point in running the rules.
 		if (targetCount === 0) {
-			this.logger.trace(`No targets from ${SfgeEngine.ENGINE_NAME} found. Nothing to execute. Returning early.`);
+			this.logger.trace(`No targets from ${AbstractSfgeEngine.ENGINE_NAME} found. Nothing to execute. Returning early.`);
 			return [];
 		}
 
-		this.logger.trace(`About to run ${SfgeEngine.ENGINE_NAME} rules. Targets: ${targetCount} files and/or methods, Selected rules: ${JSON.stringify(rules)}`);
+		// At this point, the rules have yet to be filtered by DFA/Non-DFA, so it's possible that some provided rules
+		// aren't actually compatible with this GraphEngine sub-variant. So we should filter out any rules that
+		// aren't in this engine's catalog.
+		const catalogRuleNames: Set<string> = new Set();
+		const catalog = await this.getCatalog();
+		for (const catalogRule of catalog.rules) {
+			catalogRuleNames.add(catalogRule.name);
+		}
+		const filteredRules: Rule[] = [];
+		for (const rule of rules) {
+			if (catalogRuleNames.has(rule.name)) {
+				filteredRules.push(rule);
+			} else {
+				this.logger.trace(`Rule ${rule.name} is ineligible to run with this ${this.getSubVariantName()}`);
+			}
+		}
 
+		// If there are no rules that can be run, there's nothing left to do.
+		if (filteredRules.length === 0) {
+			this.logger.trace(`No eligible rules for ${this.getSubVariantName()}. Nothing to execute. Returning early.`);
+			return [];
+		}
+
+		this.logger.trace(`About to run ${this.getSubVariantName()} rules. Targets: ${targetCount} files and/or methods, Selected rules: ${JSON.stringify(filteredRules)}`);
+
+		const sfgeConfig: SfgeConfig = JSON.parse(engineOptions.get(CUSTOM_CONFIG.SfgeConfig)) as SfgeConfig;
 		let results: RuleResult[];
 		try {
-			// Execute SFGE
-			const output = await SfgeWrapper.runSfge(targets, rules, JSON.parse(engineOptions.get(CUSTOM_CONFIG.SfgeConfig)) as SfgeConfig);
+			// Execute graph engine
+			const output = await SfgeExecuteWrapper.runSfge(targets, filteredRules, sfgeConfig);
 			results = this.processStdout(output);
 		} catch (e) {
 			// Handle errors thrown
 			const message = e instanceof Error ? e.message : e as string;
-			this.logger.trace(`${SfgeEngine.ENGINE_NAME} evaluation failed. ${message}`);
-			await this.eventCreator.createUxErrorMessage('error.external.sfgeIncompleteAnalysis', [SfgeEngine.processStderr(message)]);
-			// Handle output results no matter the outcome
+			this.logger.trace(`${this.getSubVariantName()} evaluation failed. ${message}`);
+			await this.eventCreator.createUxErrorMessage('error.external.sfgeIncompleteAnalysis', [AbstractSfgeEngine.processStderr(message)]);
+			// Handle output results no matter the outcome.
 			results = this.processStdout(message);
 		}
-
-		this.logger.trace(`Found ${results.length} results for ${SfgeEngine.ENGINE_NAME}`);
+		this.logger.trace(`Found ${results.length} results for ${this.getSubVariantName()}`);
 		return results;
 	}
 
 	/**
 	 * TODO: Not supported yet. Idea is to detect if a custom rule path is supported by this engine.
+	 * @override
 	 */
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	public matchPath(path: string): boolean {
@@ -185,41 +247,34 @@ export class SfgeEngine extends AbstractRuleEngine {
 
 	/**
 	 * Returns value of `isEngineEnabled` based on Config or an internal decision.
+	 * @override
 	 */
 	public async isEnabled(): Promise<boolean> {
-		return await this.config.isEngineEnabled(SfgeEngine.ENGINE_ENUM);
+		return await this.config.isEngineEnabled(AbstractSfgeEngine.ENGINE_ENUM);
 	}
 
 	/**
-	 * Helps decide if an instance of this engine should be included in a run based on the values provided in the --engine
-	 * filter and Engine Options.
+	 * Helps decide if an instance of this engine should be included in a run based on the values
+	 * provided in the --engine filter and Engine Options.
+	 * @override
 	 */
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	public isEngineRequested(filterValues: string[], engineOptions: Map<string,string>): boolean {
-		// If the engine was specifically requested, or there were no engine filters at all, then this engine should be
-		// treated as requested. That way:
-		// - SFGE will be included in cataloging for `scanner:rule:list` if no filters are provided or if it's requested,
-		// - SFGE will be manually excluded from `scanner:run` by virtue of being a DFA engine,
-		// - SFGE will be manually included in `scanner:run:dfa` by virtue of being a DFA engine.
+		// If `sfge` is requested or there are no engine filters at all, then all GraphEngine sub-variants
+		// should be treated as requested. This way, they can all be cataloged together.
 		return EngineUtils.isFilterEmptyOrNameInFilter(this.getName(), filterValues);
-	}
-
-	public isDfaEngine(): boolean {
-		// NOTE: If SFGE implements and exposes non-DFA rules, then this will no longer be accurate. In that case, the
-		// best course of action is probably to divide SFGE into two engines: one for DFA rules and one for pathless rules.
-		return true;
 	}
 
 	private static processStderr(output: string): string {
 		// We should handle errors by checking for our error start string.
 		const errorStart = output.indexOf(ERROR_START);
 		if (errorStart === -1) {
-			// If our error start string is missing altogether, then something went disastrously wrong, and we should
-			// assume that the entire stderr is relevant.
+			// If our error start string is missing altogether, then something went disastrously wrong,
+			// and we should assume that the entire stderr is relevant.
 			return output;
 		} else {
-			// If the error start string is present, it means we exited cleanly and everything prior to the string is noise
-			// that can be omitted.
+			// If the error start string is present, it means we exited cleanly and everything prior
+			// to the string is noise that can be omitted.
 			return output.slice(errorStart + ERROR_START.length);
 		}
 	}
@@ -240,32 +295,21 @@ export class SfgeEngine extends AbstractRuleEngine {
 			return [];
 		}
 
-		// Each file should have at most one result, with an array of violations. Use a map to guarantee uniqueness.
+		// Each file should have at most one result, with an array of violations.
+		// Use a map to guarantee uniqueness.
 		const resultMap: Map<string,RuleResult> = new Map();
 		for (const sfgeViolation of sfgeViolations) {
-			// Index violations by their source file, since the source files were what was actually targeted by the user
-			// and therefore the more logical choice for how to sort and display violations.
+			// Index violations by their source file, since the source files were what was
+			// actually targeted by the user and therefore the more logical choice for how
+			// to sort and display violations.
 			const indexFile = sfgeViolation.sourceFileName;
 			const result: RuleResult = resultMap.get(indexFile) || {
-				engine: ENGINE.SFGE.valueOf(),
+				engine: this.getName(),
 				fileName: indexFile,
 				violations: []
 			};
 
-			result.violations.push({
-				ruleName: sfgeViolation.ruleName,
-				severity: sfgeViolation.severity,
-				message: sfgeViolation.message,
-				category: sfgeViolation.category,
-				url: sfgeViolation.url,
-				sinkLine: sfgeViolation.sinkLineNumber || null,
-				sinkColumn: sfgeViolation.sinkColumnNumber || null,
-				sinkFileName: sfgeViolation.sinkFileName || "",
-				sourceLine: sfgeViolation.sourceLineNumber,
-				sourceColumn: sfgeViolation.sourceColumnNumber,
-				sourceType: sfgeViolation.sourceType,
-				sourceMethodName: sfgeViolation.sourceVertexName
-			});
+			result.violations.push(this.convertViolation(sfgeViolation));
 			resultMap.set(indexFile, result);
 		}
 		return [...resultMap.values()];

--- a/src/lib/sfge/SfgeDfaEngine.ts
+++ b/src/lib/sfge/SfgeDfaEngine.ts
@@ -1,0 +1,41 @@
+import {AbstractSfgeEngine, SfgeViolation} from './AbstractSfgeEngine';
+import {RuleType} from '../../Constants';
+import {RuleViolation} from '../../types';
+
+
+export class SfgeDfaEngine extends AbstractSfgeEngine {
+
+	protected getSubVariantName(): string {
+		return `${this.getName()}-${RuleType.DFA}`;
+	}
+
+	protected getRuleType(): RuleType {
+		return RuleType.DFA;
+	}
+
+	public isDfaEngine(): boolean {
+		return true;
+	}
+
+	/**
+	 * Convert one of GraphEngine's internal violations into a format usable by CodeAnalyzer.
+	 * @override
+	 * @protected
+	 */
+	protected convertViolation(sfgeViolation: SfgeViolation): RuleViolation {
+		return {
+			ruleName: sfgeViolation.ruleName,
+			severity: sfgeViolation.severity,
+			message: sfgeViolation.message,
+			category: sfgeViolation.category,
+			url: sfgeViolation.url,
+			sinkLine: sfgeViolation.sinkLineNumber || null,
+			sinkColumn: sfgeViolation.sinkColumnNumber || null,
+			sinkFileName: sfgeViolation.sinkFileName || "",
+			sourceLine: sfgeViolation.sourceLineNumber,
+			sourceColumn: sfgeViolation.sourceColumnNumber,
+			sourceType: sfgeViolation.sourceType,
+			sourceMethodName: sfgeViolation.sourceVertexName
+		};
+	}
+}

--- a/src/lib/sfge/SfgeWrapper.ts
+++ b/src/lib/sfge/SfgeWrapper.ts
@@ -2,6 +2,7 @@ import path = require('path');
 import {Messages, Logger} from '@salesforce/core';
 import {AsyncCreatable} from '@salesforce/kit';
 import {Controller} from '../../Controller';
+import {RuleType} from '../../Constants';
 import * as JreSetupManager from '../JreSetupManager';
 import {uxEvents, EVENTS} from '../ScannerEvents';
 import {Rule, SfgeConfig, RuleTarget} from '../../types';
@@ -13,8 +14,8 @@ import {FileHandler} from '../util/FileHandler';
 const SFGE_LIB = path.join(__dirname, '..', '..', '..', 'dist', 'sfge', 'lib');
 
 const MAIN_CLASS = "com.salesforce.Main";
-const EXEC_COMMAND = "execute";
-const CATALOG_COMMAND = "catalog";
+const EXEC_ACTION = "execute";
+const CATALOG_ACTION = "catalog";
 const SFGE_LOG_FILE = 'sfge.log';
 
 // Initialize Messages with the current plugin directory
@@ -33,13 +34,20 @@ const EXIT_NO_VIOLATIONS = 0;
  */
 const EXIT_WITH_VIOLATIONS = 4;
 
-interface SfgeWrapperOptions {
+type SfgeWrapperOptions = {
+	action: string;
+	spinnerManager: SpinnerManager;
+	jvmArgs?: string;
+}
+
+type SfgeCatalogOptions = SfgeWrapperOptions & {
+	ruleType: RuleType;
+}
+
+type SfgeExecuteOptions = SfgeWrapperOptions & {
 	targets: RuleTarget[];
 	projectDirs: string[];
-	command: string;
 	rules: Rule[];
-	spinnerManager: SpinnerManager;
-	jvmArgs?: string,
 	ruleThreadCount?: number;
 	ruleThreadTimeout?: number;
 	ruleDisableWarningViolation?: boolean;
@@ -89,32 +97,20 @@ class SfgeSpinnerManager extends AsyncCreatable implements SpinnerManager {
 	}
 }
 
-export class SfgeWrapper extends CommandLineSupport {
-	private logger: Logger;
-	private initialized: boolean;
-	private fh: FileHandler;
-	private targets: RuleTarget[];
-	private projectDirs: string[];
-	private command: string;
-	private rules: Rule[];
+abstract class AbstractSfgeWrapper extends CommandLineSupport {
+	protected logger: Logger;
+	protected initialized: boolean;
+	protected fh: FileHandler;
+	private action: string;
 	private logFilePath: string;
 	private spinnerManager: SpinnerManager;
 	private jvmArgs: string;
-	private ruleThreadCount: number;
-	private ruleThreadTimeout: number;
-	private ruleDisableWarningViolation: boolean;
 
-	constructor(options: SfgeWrapperOptions) {
+	protected constructor(options: SfgeWrapperOptions) {
 		super(options);
-		this.targets = options.targets;
-		this.projectDirs = options.projectDirs;
-		this.command = options.command;
-		this.rules = options.rules;
+		this.action = options.action;
 		this.spinnerManager = options.spinnerManager;
 		this.jvmArgs = options.jvmArgs;
-		this.ruleThreadCount = options.ruleThreadCount;
-		this.ruleThreadTimeout = options.ruleThreadTimeout;
-		this.ruleDisableWarningViolation = options.ruleDisableWarningViolation;
 	}
 
 	protected async init(): Promise<void> {
@@ -122,7 +118,7 @@ export class SfgeWrapper extends CommandLineSupport {
 			return;
 		}
 		await super.init();
-		this.logger = await Logger.child('SfgeWrapper');
+		this.logger = await Logger.child(this.constructor.name);
 		this.fh = new FileHandler();
 		this.logFilePath = path.join(Controller.getSfdxScannerPath(), SFGE_LOG_FILE);
 		this.initialized = true;
@@ -130,12 +126,6 @@ export class SfgeWrapper extends CommandLineSupport {
 
 	protected buildClasspath(): Promise<string[]> {
 		return Promise.resolve([`${SFGE_LIB}/*`]);
-	}
-
-	private async createInputFile(input: SfgeInput): Promise<string> {
-		const inputFile = await this.fh.tmpFileWithCleanup();
-		await this.fh.writeFile(inputFile, JSON.stringify(input));
-		return inputFile;
 	}
 
 	protected isSuccessfulExitCode(code: number): boolean {
@@ -146,12 +136,13 @@ export class SfgeWrapper extends CommandLineSupport {
 	 * While handling unsuccessful executions, include stdout
 	 * and stderr information.
 	 * @param args contains information on the outcome of execution
+	 * @override
 	 */
 	protected handleResults(args: ResultHandlerArgs) {
 		if (args.isSuccess) {
 			args.res(args.stdout);
 		} else {
-			// Pass in both stdout and stderr so that results can be salvaged
+			// Pass in both stdout and stderr so any partial results can be salvaged.
 			args.rej(args.stdout + ' ' + args.stderr);
 		}
 	}
@@ -171,45 +162,89 @@ export class SfgeWrapper extends CommandLineSupport {
 		const command = path.join(javaHome, 'bin', 'java');
 		const classpath = await this.buildClasspath();
 
+		const args = [`-Dsfge_log_name=${this.logFilePath}`, '-cp', classpath.join(path.delimiter)];
+		if (this.jvmArgs != null) {
+			args.push(this.jvmArgs);
+		}
+		args.push(...this.getSupplementalFlags(), MAIN_CLASS, this.action, ...(await this.getSupplementalArgs()));
+		this.logger.trace(`Preparing to execute sfge with command: "${command}", args: "${JSON.stringify(args)}"`);
+		return [command, args];
+	}
+	protected async execute(): Promise<string> {
+		return super.runCommand();
+	}
+
+	protected abstract getSupplementalFlags(): string[];
+
+	protected abstract getSupplementalArgs(): Promise<string[]>;
+}
+
+export class SfgeCatalogWrapper extends AbstractSfgeWrapper {
+	private ruleType: RuleType;
+
+	constructor(options: SfgeCatalogOptions) {
+		super(options);
+		this.ruleType = options.ruleType;
+	}
+
+	protected getSupplementalArgs(): Promise<string[]> {
+		return Promise.resolve([this.ruleType]);
+	}
+
+	protected getSupplementalFlags(): string[] {
+		return [];
+	}
+
+	public static async getCatalog(ruleType: RuleType): Promise<string> {
+		const wrapper = await SfgeCatalogWrapper.create({
+			action: CATALOG_ACTION,
+			ruleType,
+			// Cataloging shouldn't take very long, so no need for a functional spinner.
+			spinnerManager: new NoOpSpinnerManager()
+		});
+		return wrapper.execute();
+	}
+}
+
+export class SfgeExecuteWrapper extends AbstractSfgeWrapper {
+	private targets: RuleTarget[];
+	private projectDirs: string[];
+	private rules: Rule[];
+	private ruleThreadCount: number;
+	private ruleThreadTimeout: number;
+	private ruleDisableWarningViolation: boolean;
+
+	constructor(options: SfgeExecuteOptions) {
+		super(options);
+		this.targets = options.targets;
+		this.projectDirs = options.projectDirs;
+		this.rules = options.rules;
+		this.ruleThreadCount = options.ruleThreadCount;
+		this.ruleThreadTimeout = options.ruleThreadTimeout;
+		this.ruleDisableWarningViolation = options.ruleDisableWarningViolation;
+	}
+
+	protected getSupplementalFlags(): string[] {
+		const flags: string[] = [];
+		if (this.ruleThreadCount != null) {
+			flags.push(`-DSFGE_RULE_THREAD_COUNT=${this.ruleThreadCount}`);
+		}
+		if (this.ruleThreadTimeout != null) {
+			flags.push(`-DSFGE_RULE_THREAD_TIMEOUT=${this.ruleThreadTimeout}`);
+		}
+		if (this.ruleDisableWarningViolation != null) {
+			flags.push(`-DSFGE_RULE_DISABLE_WARNING_VIOLATION=${this.ruleDisableWarningViolation.toString()}`);
+		}
+		return flags;
+	}
+
+	protected async getSupplementalArgs(): Promise<string[]> {
 		const inputObject: SfgeInput = this.createInputJson();
 		const inputFile = await this.createInputFile(inputObject);
 
 		this.logger.trace(`Stored the names of ${this.targets.length} targeted files and ${this.projectDirs.length} source directories in ${inputFile}`);
 		this.logger.trace(`Rules to be executed: ${JSON.stringify(inputObject.rulesToRun)}`);
-
-		const args = [`-Dsfge_log_name=${this.logFilePath}`, '-cp', classpath.join(path.delimiter)];
-		if (this.jvmArgs != null) {
-			args.push(this.jvmArgs);
-		}
-		if (this.ruleThreadCount != null) {
-			args.push(`-DSFGE_RULE_THREAD_COUNT=${this.ruleThreadCount}`);
-		}
-		if (this.ruleThreadTimeout != null) {
-			args.push(`-DSFGE_RULE_THREAD_TIMEOUT=${this.ruleThreadTimeout}`);
-		}
-		if (this.ruleDisableWarningViolation != null) {
-			args.push(`-DSFGE_RULE_DISABLE_WARNING_VIOLATION=${this.ruleDisableWarningViolation.toString()}`);
-		}
-		args.push(MAIN_CLASS, this.command, inputFile);
-
-		this.logger.trace(`Preparing to execute sfge with command: "${command}", args: "${JSON.stringify(args)}"`);
-		return [command, args];
-	}
-
-	private async execute(): Promise<string> {
-		return super.runCommand();
-	}
-
-	public static async getCatalog() {
-		const wrapper = await SfgeWrapper.create({
-			targets: [],
-			projectDirs: [],
-			command: CATALOG_COMMAND,
-			rules: [],
-			// Cataloging shouldn't take very long, so no need for a functional spinner here.
-			spinnerManager: new NoOpSpinnerManager()
-		});
-		return wrapper.execute();
+		return [inputFile];
 	}
 
 	private createInputJson(): SfgeInput {
@@ -242,11 +277,17 @@ export class SfgeWrapper extends CommandLineSupport {
 		return inputJson;
 	}
 
+	private async createInputFile(input: SfgeInput): Promise<string> {
+		const inputFile = await this.fh.tmpFileWithCleanup();
+		await this.fh.writeFile(inputFile, JSON.stringify(input));
+		return inputFile;
+	}
+
 	public static async runSfge(targets: RuleTarget[], rules: Rule[], sfgeConfig: SfgeConfig): Promise<string> {
-		const wrapper = await SfgeWrapper.create({
+		const wrapper = await SfgeExecuteWrapper.create({
 			targets,
 			projectDirs: sfgeConfig.projectDirs,
-			command: EXEC_COMMAND,
+			action: EXEC_ACTION,
 			rules: rules,
 			// Running rules could take quite a while, so we should use a functional spinner.
 			spinnerManager: await SfgeSpinnerManager.create({}),

--- a/test/lib/RuleManager.test.ts
+++ b/test/lib/RuleManager.test.ts
@@ -15,7 +15,7 @@ import {RuleCatalog} from '../../src/lib/services/RuleCatalog';
 import {RuleEngine} from '../../src/lib/services/RuleEngine';
 
 import {RetireJsEngine} from '../../src/lib/retire-js/RetireJsEngine';
-import {SfgeEngine} from '../../src/lib/sfge/SfgeEngine';
+import {SfgeDfaEngine} from '../../src/lib/sfge/SfgeDfaEngine';
 
 import * as TestOverrides from '../test-related-lib/TestOverrides';
 import * as TestUtils from '../TestUtils';
@@ -552,7 +552,7 @@ describe('RuleManager', () => {
 
 			it('Positive method-level targets are properly matched', async () => {
 				// All tests will use the SFGE engine, since method-level targeting is intended for that engine anyway.
-				const engine = new SfgeEngine();
+				const engine = new SfgeDfaEngine();
 				await engine.init();
 
 				// Targets are all going to be normalized Unix paths, some of which also specify individual methods.

--- a/test/lib/sfge/SfgeDfaEngine.test.ts
+++ b/test/lib/sfge/SfgeDfaEngine.test.ts
@@ -3,20 +3,20 @@ import {RuleResult} from '../../../src/types';
 import path = require('path');
 import fs = require('fs');
 import {expect} from 'chai';
-import {SfgeEngine} from '../../../src/lib/sfge/SfgeEngine';
+import {SfgeDfaEngine} from '../../../src/lib/sfge/SfgeDfaEngine';
 import * as TestOverrides from '../../test-related-lib/TestOverrides';
 
 TestOverrides.initializeTestSetup();
 
-class TestableSfgeEngine extends SfgeEngine {
+class TestableSfgeEngine extends SfgeDfaEngine {
 	public processStdout(output: string): RuleResult[] {
 		return super.processStdout(output);
 	}
 }
 
-describe('SfgeEngine', () => {
+describe('SfgeDfaEngine', () => {
 	describe('#processStdout()', () => {
-		it('When Sfge finds violations, they are converted into RuleResult objects', async () => {
+		it('When GraphEngine finds violations, they are converted into RuleResult objects', async () => {
 			// ==== SETUP ====
 			const testEngine = new TestableSfgeEngine();
 			await testEngine.init();
@@ -29,7 +29,7 @@ describe('SfgeEngine', () => {
 			expect(results.length).to.equal(1, 'Should be results');
 		});
 
-		it('When sfge finds no violations, results are empty', async () => {
+		it('When GraphEngine finds no violations, results are empty', async () => {
 			// ==== SETUP ====
 			const testEngine = new TestableSfgeEngine();
 			await testEngine.init();


### PR DESCRIPTION
Note: This is the fourth of several PRs associated with W-11999008.
This PR refactors the `SfgeEngine.ts` into `AbstractSfgeEngine` and `SfgeDfaEngine`. No functionality changes should result from this PR. It's just laying groundwork for the next PR, which will add `SfgePathlessEngine` (or whatever we decided to name that).