### PR TITLE
NEW (GraphEngine): @W-11533657@: New 'missingOptionsBehavior' config property allows control over what happens if GraphEngine lacks proper config.

### DIFF
--- a/messages/Config.js
+++ b/messages/Config.js
@@ -3,6 +3,8 @@ module.exports = {
 	"InvalidStringArrayValue": "Specify a valid property for '%s' in %s for %s. Supply an array of strings: %s.",
 	"InvalidBooleanValue": "Specify a valid property for '%s' in %s for %s. Supply a boolean: %s.",
 	"InvalidNumberValue": "Specify a valid property for '%s' in %s for %s. Supply a number: %s.",
+	"InvalidStringValue": "Specify a valid property for '%s' in %s for %s. Supply a string: %s.",
+	"InvalidStringEnumValue": `Specify a valid property for '%s' in %s for %s. Valid options include: %s.`,
 	"UpgradeFailureTroubleshooting": `%s
 The upgrade wasn't successful and the original config was saved to %s. Try again. If the upgrade continues to fail, delete %s.`
 };

--- a/messages/SfgeEngine.js
+++ b/messages/SfgeEngine.js
@@ -1,4 +1,12 @@
 module.exports = {
-	"spinnerStart": "Analyzing with Salesforce Graph Engine. See %s for details.",
-	"pleaseWait": "Please wait"
+	"messages": {
+		"pleaseWait": "Please wait",
+		"spinnerStart": "Analyzing with Salesforce Graph Engine. See %s for details."
+	},
+	"errors": {
+		"failedWithoutProjectDir": `Salesforce Graph Engine cannot run without --projectdir/-p. You must rerun your command, and either use --projectdir/-p so Graph Engine can run, or use --engine/-e to exclude Graph Engine from execution.`
+	},
+	"warnings": {
+		"skippedWithoutProjectDir": `Salesforce Graph Engine cannot run without --projectdir/-p, and will be skipped due to your %s.%s value of %s in %s.`
+	}
 };

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -36,6 +36,12 @@ export enum RuleType {
 	DFA = "dfa"
 }
 
+export enum MissingOptionsBehavior {
+	HALT = 'halt',
+	WARN = 'warn',
+	SKIP = 'skip'
+}
+
 /**
  * Main engine types that have more than one variation
  */

--- a/src/lib/services/RuleEngine.ts
+++ b/src/lib/services/RuleEngine.ts
@@ -1,5 +1,7 @@
-import {Severity} from '../../Constants';
+import {SfdxError} from '@salesforce/core';
+import {MissingOptionsBehavior, Severity} from '../../Constants';
 import {Catalog, EngineExecutionDescriptor, Rule, RuleGroup, RuleResult, RuleTarget, TargetPattern} from '../../types';
+import {uxEvents, EVENTS} from '../ScannerEvents';
 
 export interface RuleEngine {
 
@@ -90,6 +92,18 @@ export abstract class AbstractRuleEngine implements RuleEngine {
 			for (const violation of result.violations) {
 				violation.normalizedSeverity = this.getNormalizedSeverity(violation.severity);
 			}
+		}
+	}
+
+	protected handleMissingOptionsBehavior(behavior: MissingOptionsBehavior, haltMessage: string, warnMessage: string): false {
+		switch (behavior) {
+			case MissingOptionsBehavior.HALT:
+				throw new SfdxError(haltMessage);
+			case MissingOptionsBehavior.WARN:
+				uxEvents.emit(EVENTS.WARNING_ALWAYS, warnMessage);
+				return false;
+			default:
+				return false;
 		}
 	}
 }

--- a/src/lib/sfge/AbstractSfgeEngine.ts
+++ b/src/lib/sfge/AbstractSfgeEngine.ts
@@ -41,11 +41,11 @@ export abstract class AbstractSfgeEngine extends AbstractRuleEngine {
 	protected static ENGINE_ENUM: ENGINE = ENGINE.SFGE;
 	protected static ENGINE_NAME: string = ENGINE.SFGE.valueOf();
 
-	private logger: Logger;
-	private config: Config;
+	protected logger: Logger;
+	protected config: Config;
+	protected initialized: boolean;
 	private eventCreator: EventCreator;
 	private catalog: Catalog;
-	private initialized: boolean;
 
 	protected abstract convertViolation(sfgeViolation: SfgeViolation): RuleViolation;
 
@@ -157,32 +157,6 @@ export abstract class AbstractSfgeEngine extends AbstractRuleEngine {
 			// Graph Engine does not use rulesets.
 			rulesets: []
 		};
-	}
-
-	/**
-	 * Helps make decision to run an engine or not based on the Rules, Target paths, and the Engine Options selected per
-	 * run. At this point, filtering should have already happened.
-	 * @override
-	 */
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	public shouldEngineRun(ruleGroups: RuleGroup[], rules: Rule[], target: RuleTarget[], engineOptions: Map<string,string>): boolean {
-		// By now, the thing to check is whether we have the necessary engineOptions information to actually
-		// run the engine.
-		// - For DFA, this should always be true, since the command itself requires the appropriate flags.
-		// - For non-DFA, this information may have been omitted either mistakenly or intentionally.
-		if (engineOptions.has(CUSTOM_CONFIG.SfgeConfig)) {
-			const sfgeConfig: SfgeConfig = JSON.parse(engineOptions.get(CUSTOM_CONFIG.SfgeConfig)) as SfgeConfig;
-			if (sfgeConfig.projectDirs && sfgeConfig.projectDirs.length > 0) {
-				// If the engineOptions entry exists and has a non-empty projectDirs, then we're good.
-				return true;
-			}
-		}
-		// TODO: To minimize test failures, we're just skipping GraphEngine if it's missing config info.
-		//       Upcoming story W-111533367 pertains to properly configuring pathless GraphEngine, and
-		//       during that story we can change this to either throw an error and halt, or log a warning/info
-		//       and skip the engine.
-		this.logger.info('GraphEngine missing critical parameters, skipping its execution');
-		return false;
 	}
 
 	/**

--- a/src/lib/sfge/SfgeDfaEngine.ts
+++ b/src/lib/sfge/SfgeDfaEngine.ts
@@ -1,9 +1,20 @@
 import {AbstractSfgeEngine, SfgeViolation} from './AbstractSfgeEngine';
 import {RuleType} from '../../Constants';
-import {RuleViolation} from '../../types';
+import {Rule, RuleGroup, RuleTarget, RuleViolation} from '../../types';
 
 
 export class SfgeDfaEngine extends AbstractSfgeEngine {
+
+	/**
+	 * Helps make decision to run an engine or not based on the Rules, Target paths, and the Engine Options selected per
+	 * run. At this point, filtering should have already happened.
+	 * @override
+	 */
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	public shouldEngineRun(ruleGroups: RuleGroup[], rules: Rule[], target: RuleTarget[], engineOptions: Map<string,string>): boolean {
+		// If the engine was requested, there's no reason not to run it.
+		return true;
+	}
 
 	protected getSubVariantName(): string {
 		return `${this.getName()}-${RuleType.DFA}`;

--- a/src/lib/sfge/SfgePathlessEngine.ts
+++ b/src/lib/sfge/SfgePathlessEngine.ts
@@ -1,8 +1,7 @@
-import {SfdxError, Messages} from '@salesforce/core';
+import {Messages} from '@salesforce/core';
 import {AbstractSfgeEngine, SfgeViolation} from "./AbstractSfgeEngine";
 import {Rule, RuleGroup, RuleTarget, RuleViolation, SfgeConfig} from '../../types';
 import {CUSTOM_CONFIG, MissingOptionsBehavior, RuleType} from '../../Constants';
-import {uxEvents, EVENTS} from '../ScannerEvents';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/sfdx-scanner', 'SfgeEngine');
@@ -40,24 +39,14 @@ export class SfgePathlessEngine extends AbstractSfgeEngine {
 				return true;
 			}
 		}
-		switch (this.missingOptionsBehavior) {
-			case MissingOptionsBehavior.HALT:
-				throw SfdxError.create('@salesforce/sfdx-scanner', 'SfgeEngine', 'errors.failedWithoutProjectDir', []);
-			case MissingOptionsBehavior.WARN:
-				uxEvents.emit(
-					EVENTS.WARNING_ALWAYS,
-					messages.getMessage('warnings.skippedWithoutProjectDir', [
-						this.getName(),
-						'missingOptionsBehavior',
-						MissingOptionsBehavior.WARN,
-						this.config.getConfigFilePath()
-					]
-				));
-				return false;
-			default:
-				// We know the enum is valid, so the only other option is SKIP, which just means we skip silently.
-				return false;
-		}
+		const haltString = messages.getMessage('errors.failedWithoutProjectDir', []);
+		const warnString = messages.getMessage('warnings.skippedWithoutProjectDir', [
+			this.getName(),
+			'missingOptionsBehavior',
+			MissingOptionsBehavior.WARN,
+			this.config.getConfigFilePath()
+		]);
+		return this.handleMissingOptionsBehavior(this.missingOptionsBehavior, haltString, warnString);
 	}
 
 	protected getSubVariantName(): string {

--- a/src/lib/sfge/SfgePathlessEngine.ts
+++ b/src/lib/sfge/SfgePathlessEngine.ts
@@ -44,8 +44,15 @@ export class SfgePathlessEngine extends AbstractSfgeEngine {
 			case MissingOptionsBehavior.HALT:
 				throw SfdxError.create('@salesforce/sfdx-scanner', 'SfgeEngine', 'errors.failedWithoutProjectDir', []);
 			case MissingOptionsBehavior.WARN:
-				const msg = messages.getMessage('warnings.skippedWithoutProjectDir', [this.getName(), 'missingOptionsBehavior', MissingOptionsBehavior.WARN, this.config.getConfigFilePath()]);
-				uxEvents.emit(EVENTS.WARNING_ALWAYS, msg);
+				uxEvents.emit(
+					EVENTS.WARNING_ALWAYS,
+					messages.getMessage('warnings.skippedWithoutProjectDir', [
+						this.getName(),
+						'missingOptionsBehavior',
+						MissingOptionsBehavior.WARN,
+						this.config.getConfigFilePath()
+					]
+				));
 				return false;
 			default:
 				// We know the enum is valid, so the only other option is SKIP, which just means we skip silently.

--- a/src/lib/sfge/SfgePathlessEngine.ts
+++ b/src/lib/sfge/SfgePathlessEngine.ts
@@ -1,8 +1,57 @@
+import {SfdxError, Messages} from '@salesforce/core';
 import {AbstractSfgeEngine, SfgeViolation} from "./AbstractSfgeEngine";
-import {RuleViolation} from '../../types';
-import {RuleType} from '../../Constants';
+import {Rule, RuleGroup, RuleTarget, RuleViolation, SfgeConfig} from '../../types';
+import {CUSTOM_CONFIG, MissingOptionsBehavior, RuleType} from '../../Constants';
+import {uxEvents, EVENTS} from '../ScannerEvents';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/sfdx-scanner', 'SfgeEngine');
 
 export class SfgePathlessEngine extends AbstractSfgeEngine {
+	private missingOptionsBehavior: MissingOptionsBehavior;
+
+	/**
+	 * Invokes sync/async initialization required for the engine.
+	 * @override
+	 */
+	public async init(): Promise<void> {
+		if (this.initialized) {
+			return;
+		}
+		await super.init();
+		this.missingOptionsBehavior = await this.config.getMissingOptionsBehavior(SfgePathlessEngine.ENGINE_ENUM);
+		this.initialized = true;
+	}
+
+	/**
+	 * Helps make decision to run an engine or not based on the Rules, Target paths, and the Engine Options selected per
+	 * run. At this point, filtering should have already happened.
+	 * @override
+	 */
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	public shouldEngineRun(ruleGroups: RuleGroup[], rules: Rule[], target: RuleTarget[], engineOptions: Map<string,string>): boolean {
+		// For the non-DFA Graph Engine variant, we need to make sure that we have the
+		// necessary info to run the engine, since the relevant flags aren't required
+		// for `scanner:run`.
+		if (engineOptions.has(CUSTOM_CONFIG.SfgeConfig)) {
+			const sfgeConfig: SfgeConfig = JSON.parse(engineOptions.get(CUSTOM_CONFIG.SfgeConfig)) as SfgeConfig;
+			if (sfgeConfig.projectDirs && sfgeConfig.projectDirs.length > 0) {
+				// If we've got a config with projectDirs, we're set.
+				return true;
+			}
+		}
+		switch (this.missingOptionsBehavior) {
+			case MissingOptionsBehavior.HALT:
+				throw SfdxError.create('@salesforce/sfdx-scanner', 'SfgeEngine', 'errors.failedWithoutProjectDir', []);
+			case MissingOptionsBehavior.WARN:
+				const msg = messages.getMessage('warnings.skippedWithoutProjectDir', [this.getName(), 'missingOptionsBehavior', MissingOptionsBehavior.WARN, this.config.getConfigFilePath()]);
+				uxEvents.emit(EVENTS.WARNING_ALWAYS, msg);
+				return false;
+			default:
+				// We know the enum is valid, so the only other option is SKIP, which just means we skip silently.
+				return false;
+		}
+	}
 
 	protected getSubVariantName(): string {
 		return `${this.getName()}-${RuleType.PATHLESS}`;

--- a/src/lib/sfge/SfgeWrapper.ts
+++ b/src/lib/sfge/SfgeWrapper.ts
@@ -81,8 +81,8 @@ class SfgeSpinnerManager extends AsyncCreatable implements SpinnerManager {
 	public startSpinner(): void {
 		uxEvents.emit(
 			EVENTS.START_SPINNER,
-			messages.getMessage("spinnerStart", [this.logFilePath]),
-			messages.getMessage("pleaseWait")
+			messages.getMessage("messages.spinnerStart", [this.logFilePath]),
+			messages.getMessage("messages.pleaseWait")
 		);
 
 		// TODO: This timer logic should ideally live inside waitOnSpinner()

--- a/src/lib/util/Config.ts
+++ b/src/lib/util/Config.ts
@@ -236,7 +236,7 @@ export class Config {
 	protected getStringEnumConfigValue(propertyName: string, engine: ENGINE, enumOptions: string[]): Promise<string> {
 		return this.getStringConfigValue(propertyName, engine)
 			.then(enumValue => {
-				if (enumOptions.includes(enumValue)) {
+				if (enumOptions.includes(enumValue.toLowerCase().trim())) {
 					return enumValue;
 				} else {
 					throw SfdxError.create('@salesforce/sfdx-scanner',

--- a/src/lib/util/Utils.ts
+++ b/src/lib/util/Utils.ts
@@ -22,8 +22,12 @@ const numberTypeGuard = (object): object is number => {
 	return typeof object === 'number';
 }
 
+const stringTypeGuard = (object): object is string => {
+	return typeof object === 'string';
+}
+
 const isPathlessViolation = (v: RuleViolation): v is PathlessRuleViolation => {
 	return 'line' in v;
 }
 
-export { booleanTypeGuard, deepCopy, numberTypeGuard, stringArrayTypeGuard, isPathlessViolation };
+export { booleanTypeGuard, deepCopy, numberTypeGuard, stringArrayTypeGuard, stringTypeGuard, isPathlessViolation };

--- a/test/lib/RuleManager.test.ts
+++ b/test/lib/RuleManager.test.ts
@@ -261,7 +261,9 @@ describe('RuleManager', () => {
 						parsedRes = JSON.parse(results);
 					}
 					expect(parsedRes).to.be.an("array").that.has.length(1);
-					Sinon.assert.callCount(uxSpy, 0);
+					// Because the engine options is empty, and based on our default settings,
+					// we expect a minimum of one UX event, namely the warning that GraphEngine couldn't evaluate.
+					Sinon.assert.callCount(uxSpy, 1);
 					Sinon.assert.callCount(telemetrySpy, 1);
 				});
 
@@ -407,7 +409,10 @@ describe('RuleManager', () => {
 					const {results} = await ruleManager.runRulesMatchingCriteria(filters, invalidTarget, runOptions, EMPTY_ENGINE_OPTIONS);
 
 					expect(results).to.equal('');
-					Sinon.assert.callCount(uxSpy, 1);
+					// Because the engine options are empty, and based on our settings, we expect
+					// 2 ux events. The first being that GraphEngine couldn't run, and the second
+					// being that a target didn't match.
+					Sinon.assert.callCount(uxSpy, 2);
 					Sinon.assert.calledWith(uxSpy, EVENTS.WARNING_ALWAYS, messages.getMessage("warning.targetSkipped", [invalidTarget.join(', ')]));
 					Sinon.assert.callCount(telemetrySpy, 1);
 				});
@@ -422,7 +427,10 @@ describe('RuleManager', () => {
 					const {results} = await ruleManager.runRulesMatchingCriteria(filters, invalidTarget, runOptions, EMPTY_ENGINE_OPTIONS);
 
 					expect(results).to.equal('');
-					Sinon.assert.callCount(uxSpy, 1);
+					// Because the engine options are empty, and based on our settings, we expect
+					// 2 ux events. The first being that GraphEngine couldn't run, and the second
+					// being that a target didn't match.
+					Sinon.assert.callCount(uxSpy, 2);
 					Sinon.assert.calledWith(uxSpy, EVENTS.WARNING_ALWAYS, messages.getMessage("warning.targetSkipped", [invalidTarget.join(', ')]));
 					Sinon.assert.callCount(telemetrySpy, 1);
 				});
@@ -436,7 +444,10 @@ describe('RuleManager', () => {
 					const {results} = await ruleManager.runRulesMatchingCriteria(filters, invalidTargets, runOptions, EMPTY_ENGINE_OPTIONS);
 
 					expect(results).to.equal('');
-					Sinon.assert.callCount(uxSpy, 1);
+					// Because the engine options are empty, and based on our settings, we expect
+					// 2 ux events. The first being that GraphEngine couldn't run, and the second
+					// being that a target didn't match.
+					Sinon.assert.callCount(uxSpy, 2);
 					Sinon.assert.calledWith(uxSpy, EVENTS.WARNING_ALWAYS, messages.getMessage("warning.targetsSkipped", [invalidTargets.join(', ')]));
 					Sinon.assert.callCount(telemetrySpy, 1);
 				});
@@ -456,7 +467,10 @@ describe('RuleManager', () => {
 						parsedRes = JSON.parse(results);
 					}
 					expect(parsedRes).to.be.an("array").that.has.length(1);
-					Sinon.assert.callCount(uxSpy, 1);
+					// Because the engine options are empty, and based on our settings, we expect
+					// 2 ux events. The first being that GraphEngine couldn't run, and the second
+					// being that a target didn't match.
+					Sinon.assert.callCount(uxSpy, 2);
 					Sinon.assert.calledWith(uxSpy, EVENTS.WARNING_ALWAYS, messages.getMessage('warning.targetsSkipped', [invalidTargets.join(', ')]));
 					Sinon.assert.callCount(telemetrySpy, 1);
 				});


### PR DESCRIPTION
This PR does the following:
- Adds a new config property called `missingOptionsBehavior` whose value can be "halt", "warn", or "skip".
- For GraphEngine, property defaults to "warn"
- If value is "halt", then non-DFA graph engine will throw error if you try to run `scanner:run` without `--projectdir`.
- For "warn", it will log a warning and skip GraphEngine.
- For "skip", it will silently skip GraphEngine.