### PR TITLE
CHANGE (CodeAnalyzer): @W-12278374@: Release activity for 3.8.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@salesforce/sfdx-scanner",
 	"description": "Static code scanner that applies quality and security rules to Apex code, and provides feedback.",
-	"version": "3.7.1",
+	"version": "3.8.0",
 	"author": "ISV SWAT",
 	"bugs": "https://github.com/forcedotcom/sfdx-scanner/issues",
 	"dependencies": {


### PR DESCRIPTION
This PR does the following:
- Updates `package.json`'s `version` property to `3.8.0`
No RetireJS changes were detected, so the `RetireJsVulns.json` remains unchanged.