### PR TITLE
NEW (CodeAnalyzer): @W-12413070@: scanner:rule:list and scanner:rule:describe include DFA/non-DFA info.

### DIFF
--- a/messages/list.js
+++ b/messages/list.js
@@ -17,8 +17,11 @@ module.exports = {
 		"languages": "languages",
 		"categories": "categories",
 		"rulesets": "rulesets [dep]",
+		"is-dfa": "is dfa",
 		"engine": "engine"
 	},
+	"yes": "Y",
+	"no": "N",
 	"examples": `
 This example invokes the command without filter criteria, which returns all rules.
 	$ sfdx scanner:rule:list

--- a/pmd-cataloger/src/main/java/sfdc/sfdx/scanner/pmd/catalog/PmdCatalogJson.java
+++ b/pmd-cataloger/src/main/java/sfdc/sfdx/scanner/pmd/catalog/PmdCatalogJson.java
@@ -18,6 +18,7 @@ public class PmdCatalogJson {
 	public static final String JSON_LANGUAGES = "languages";
 	public static final String JSON_SOURCEPACKAGE = "sourcepackage";
 	public static final String JSON_DEFAULTENABLED = "defaultEnabled";
+    public static final String JSON_ISDFA = "isDfa";
 
 	private final List<PmdCatalogRule> rules;
 	private final List<PmdCatalogCategory> categories;

--- a/pmd-cataloger/src/main/java/sfdc/sfdx/scanner/pmd/catalog/PmdCatalogRule.java
+++ b/pmd-cataloger/src/main/java/sfdc/sfdx/scanner/pmd/catalog/PmdCatalogRule.java
@@ -98,6 +98,7 @@ public class PmdCatalogRule {
 		m.put(JSON_DESCRIPTION, this.description);
 		m.put(JSON_SOURCEPACKAGE, this.sourceJar);
 		m.put(JSON_DEFAULTENABLED, true);
+        m.put(JSON_ISDFA, false);
 
 		// We want 'languages' to be represented as an array even though PMD rules only run against one language, because
 		// this way it's easier to integrate with the language-agnostic framework that we ultimately want.

--- a/src/commands/scanner/rule/describe.ts
+++ b/src/commands/scanner/rule/describe.ts
@@ -14,6 +14,7 @@ Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/sfdx-scanner', 'describe');
 
 type DescribeStyledRule = Rule & {
+	runWith: string;
 	enabled: boolean;
 };
 
@@ -78,6 +79,7 @@ export default class Describe extends ScannerCommand {
 		return rules.map(r => {
 			const styledRule: DescribeStyledRule = {
 				...r,
+				runWith: r.isDfa ? 'scanner:run:dfa' : 'scanner:run',
 				enabled: enabledEngineNames.has(r.engine)
 			};
 			// Strip any whitespace off of the description.
@@ -87,6 +89,6 @@ export default class Describe extends ScannerCommand {
 	}
 
 	private logStyledRule(rule: DescribeStyledRule): void {
-		this.ux.styledObject(rule, ['name', 'engine', 'enabled', 'categories', 'rulesets', 'languages', 'description', 'message']);
+		this.ux.styledObject(rule, ['name', 'engine', 'runWith', 'enabled', 'categories', 'rulesets', 'languages', 'description', 'message']);
 	}
 }

--- a/src/commands/scanner/rule/describe.ts
+++ b/src/commands/scanner/rule/describe.ts
@@ -5,6 +5,8 @@ import {Controller} from '../../../Controller';
 import {Rule} from '../../../types';
 import {ScannerCommand} from '../../../lib/ScannerCommand';
 import {deepCopy} from '../../../lib/util/Utils';
+import Run from '../run';
+import Dfa from '../run/dfa';
 
 // Initialize Messages with the current plugin directory
 Messages.importMessagesDirectory(__dirname);
@@ -79,7 +81,7 @@ export default class Describe extends ScannerCommand {
 		return rules.map(r => {
 			const styledRule: DescribeStyledRule = {
 				...r,
-				runWith: r.isDfa ? 'scanner:run:dfa' : 'scanner:run',
+				runWith: r.isDfa ? Dfa.id : Run.id,
 				enabled: enabledEngineNames.has(r.engine)
 			};
 			// Strip any whitespace off of the description.

--- a/src/commands/scanner/rule/list.ts
+++ b/src/commands/scanner/rule/list.ts
@@ -17,7 +17,10 @@ const columns = [messages.getMessage('columnNames.name'),
 				messages.getMessage('columnNames.languages'),
 				messages.getMessage('columnNames.categories'),
 				messages.getMessage('columnNames.rulesets'),
-				messages.getMessage('columnNames.engine')];
+				messages.getMessage('columnNames.engine'),
+				messages.getMessage('columnNames.is-dfa')];
+const DFA_YES = messages.getMessage('yes');
+const DFA_NO = messages.getMessage('no');
 
 export default class List extends ScannerCommand {
 	// These determine what's displayed when the --help/-h flag is supplied.
@@ -95,6 +98,7 @@ export default class List extends ScannerCommand {
 		transformedRule[columns[2]] = rule.categories.join(',');
 		transformedRule[columns[3]] = rule.rulesets.join(',');
 		transformedRule[columns[4]] = rule.engine;
+		transformedRule[columns[5]] = rule.isDfa ? DFA_YES : DFA_NO;
 		return transformedRule;
 	}
 

--- a/src/lib/cpd/CpdEngine.ts
+++ b/src/lib/cpd/CpdEngine.ts
@@ -77,6 +77,7 @@ export class CpdEngine extends AbstractRuleEngine {
 				description: CpdRuleDescription,
 				categories: [CpdRuleCategory],
 				rulesets: [],
+				isDfa: false,
 				languages: CpdLanguagesSupported,
 				defaultEnabled: true
 			}],

--- a/src/lib/eslint/BaseEslintEngine.ts
+++ b/src/lib/eslint/BaseEslintEngine.ts
@@ -159,6 +159,7 @@ export abstract class BaseEslintEngine extends AbstractRuleEngine {
 			description: meta.docs.description,
 			categories: [meta.type],
 			rulesets: [meta.type],
+			isDfa: false,
 			languages: [...this.strategy.getLanguages()],
 			defaultEnabled: this.strategy.ruleDefaultEnabled(key),
 			defaultConfig: this.strategy.getDefaultConfig(key),

--- a/src/lib/retire-js/RetireJsEngine.ts
+++ b/src/lib/retire-js/RetireJsEngine.ts
@@ -27,6 +27,7 @@ const retireJsCatalog: Catalog = {
 		categories: ['Insecure Dependencies'],
 		rulesets: [],
 		languages: ['javascript'],
+		isDfa: false,
 		defaultEnabled: true
 	}],
 	categories: [{

--- a/src/lib/sfge/AbstractSfgeEngine.ts
+++ b/src/lib/sfge/AbstractSfgeEngine.ts
@@ -135,6 +135,8 @@ export abstract class AbstractSfgeEngine extends AbstractRuleEngine {
 				rulesets: [],
 				// Currently, all Graph Engine rules are Apex-specific.
 				languages: ["apex"],
+				// Graph Engine rules are DFA if the engine is DFA.
+				isDfa: this.isDfaEngine(),
 				// Currently, all Graph Engine rules are default-enabled.
 				defaultEnabled: true
 			});

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -10,6 +10,7 @@ export type Rule = {
 	rulesets: string[];
 	languages: string[];
 	defaultEnabled: boolean;
+	isDfa: boolean;
 	// The expectation is that default configurations for other engines will be defined as their own types, which will
 	// be OR'd together in this property.
 	defaultConfig?: ESRuleConfigValue;

--- a/test/lib/RuleFilter.test.ts
+++ b/test/lib/RuleFilter.test.ts
@@ -171,6 +171,7 @@ describe('RuleFilter', () => {
 					name: null,
 					description: null,
 					rulesets: null,
+					isDfa: false,
 					languages: null,
 					defaultEnabled: true
 				};

--- a/test/lib/eslint/EslintTestDataGenerator.ts
+++ b/test/lib/eslint/EslintTestDataGenerator.ts
@@ -15,6 +15,7 @@ export function getDummyRule(myEngineName = engineName): Rule {
 		categories: ["some category"],
 		languages: ["language"],
 		sourcepackage: "MySourcePackage",
+		isDfa: false,
 		rulesets: [],
 		defaultEnabled: true
 	}

--- a/test/lib/util/PrettyPrinter.test.ts
+++ b/test/lib/util/PrettyPrinter.test.ts
@@ -33,6 +33,7 @@ function createRule(): {rule: Rule; expectedRuleString: string} {
 		rulesets: ["Ruleset1", "Ruleset2"],
 		languages: ["apex", "javascript"],
 		engine: "pmd",
+		isDfa: false,
 		sourcepackage: "/some/path/to/a/package.jar",
 		defaultEnabled: true
 	};


### PR DESCRIPTION
This PR does the following:
- scanner:rule:list includes a new `IS DFA` column whose value is either `Y` or `N`.
- scanner:rule:describe now includes a new `runsWith` property whose value is either `scanner:run` or `scanner:run:dfa`.