### PR TITLE
CHANGE (GraphEngine): @W-12423302@: Decreasing stack depth to a more helpful value

### DIFF
--- a/sfge/src/main/java/com/salesforce/config/EnvUtil.java
+++ b/sfge/src/main/java/com/salesforce/config/EnvUtil.java
@@ -11,6 +11,7 @@ public final class EnvUtil {
     private static final String ENV_IGNORE_PARSE_ERRORS = "SFGE_IGNORE_PARSE_ERRORS";
     private static final String ENV_LOG_WARNINGS_ON_VERBOSE = "SFGE_LOG_WARNINGS_ON_VERBOSE";
     private static final String ENV_PROGRESS_INCREMENTS = "SFGE_PROGRESS_INCREMENTS";
+    private static final String ENV_STACK_DEPTH_LIMIT = "SFGE_STACK_DEPTH_LIMIT";
 
     // TODO: These should move to SfgeConfigImpl and this class should return Optionals
     @VisibleForTesting
@@ -26,8 +27,8 @@ public final class EnvUtil {
     @VisibleForTesting static final boolean DEFAULT_LOG_WARNINGS_ON_VERBOSE = false;
     @VisibleForTesting static final int DEFAULT_PROGRESS_INCREMENTS = 10;
 
-    /** Keeping default Apex governor limit enforced on stack depth */
-    @VisibleForTesting static final int DEFAULT_STACK_DEPTH = 1000;
+    /** Artificial stack depth limit to keep path expansion under control. */
+    @VisibleForTesting static final int DEFAULT_STACK_DEPTH_LIMIT = 450;
 
     /**
      * Returns the value of the {@link #ENV_RULE_THREAD_COUNT} environment variable if set, else
@@ -80,11 +81,11 @@ public final class EnvUtil {
     }
 
     /**
-     * Returns stack depth limit that Apex's governor limits enforce. Cannot be overridden by a
-     * user-specified value.
+     * Returns stack depth limit upto which Graph Engine attempts to dig. Depths beyond this have a
+     * high probability of throwing a StackOverFlow exception.
      */
     static int getStackDepthLimit() {
-        return DEFAULT_STACK_DEPTH;
+        return getIntOrDefault(ENV_STACK_DEPTH_LIMIT, DEFAULT_STACK_DEPTH_LIMIT);
     }
 
     private static int getIntOrDefault(String name, int defaultValue) {

--- a/sfge/src/main/java/com/salesforce/config/SfgeConfig.java
+++ b/sfge/src/main/java/com/salesforce/config/SfgeConfig.java
@@ -26,6 +26,6 @@ public interface SfgeConfig {
      */
     int getProgressIncrements();
 
-    /** Stack depth that a path is allowed to grow. */
+    /** Stack depth upto which Graph Engine attempts to walk. */
     int getStackDepthLimit();
 }

--- a/sfge/src/main/java/com/salesforce/graph/ops/expander/StackDepthLimitExceededException.java
+++ b/sfge/src/main/java/com/salesforce/graph/ops/expander/StackDepthLimitExceededException.java
@@ -2,6 +2,7 @@ package com.salesforce.graph.ops.expander;
 
 import com.salesforce.graph.vertex.BaseSFVertex;
 
+/** Thrown when stack depth grows beyond Graph Engine's limit to handle. */
 public class StackDepthLimitExceededException extends ApexPathExpanderRuntimeException {
     public StackDepthLimitExceededException(int depthCount, BaseSFVertex vertex) {
         super("Stack depth limit exceeded: " + depthCount + " on vertex: " + vertex);

--- a/sfge/src/main/java/com/salesforce/graph/vertex/LiteralExpressionVertex.java
+++ b/sfge/src/main/java/com/salesforce/graph/vertex/LiteralExpressionVertex.java
@@ -119,8 +119,8 @@ public abstract class LiteralExpressionVertex<T> extends ChainedVertex
         }
 
         /**
-         * Return true if the provided vertex is equivalent to the literal False.
-         * E.g., `false`, `!true`, `!!false`.
+         * Return true if the provided vertex is equivalent to the literal False. E.g., `false`,
+         * `!true`, `!!false`.
          */
         public static boolean isLiterallyFalse(BaseSFVertex vertex) {
             return isExpectedLiteral(vertex, False.class, True.class);
@@ -153,8 +153,8 @@ public abstract class LiteralExpressionVertex<T> extends ChainedVertex
         }
 
         /**
-         * Return true if the provided vertex is equivalent to the literal True.
-         * E.g., `true`, `!false`, `!!true`.
+         * Return true if the provided vertex is equivalent to the literal True. E.g., `true`,
+         * `!false`, `!!true`.
          */
         public static boolean isLiterallyTrue(BaseSFVertex vertex) {
             return isExpectedLiteral(vertex, True.class, False.class);

--- a/sfge/src/main/java/com/salesforce/rules/fls/apex/operations/NegationContainmentUtil.java
+++ b/sfge/src/main/java/com/salesforce/rules/fls/apex/operations/NegationContainmentUtil.java
@@ -9,15 +9,16 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Util class for checking the negation depth of a given vertex.
- * By "negation depth", we mean the amount of times a given clause is negated either implicitly or explicitly.
+ * Util class for checking the negation depth of a given vertex. By "negation depth", we mean the
+ * amount of times a given clause is negated either implicitly or explicitly.
  */
 public final class NegationContainmentUtil {
     private NegationContainmentUtil() {}
 
     /**
-     * Returns true if this vertex represents or contains a non-negated clause.
-     * E.g., in the expressions `X`, `(!!X || !Y)`, and `(X == true)`, `X` is a non-negated clause.
+     * Returns true if this vertex represents or contains a non-negated clause. E.g., in the
+     * expressions `X`, `(!!X || !Y)`, and `(X == true)`, `X` is a non-negated clause.
+     *
      * @param vertex
      * @return
      */
@@ -28,8 +29,9 @@ public final class NegationContainmentUtil {
     }
 
     /**
-     * Returns true if this vertex represents or contains a negated clause.
-     * E.g., in the expressions `!X`, `(!!!X || Y)`, and `(X == false), `X` is a negated clause.
+     * Returns true if this vertex represents or contains a negated clause. E.g., in the expressions
+     * `!X`, `(!!!X || Y)`, and `(X == false), `X` is a negated clause.
+     *
      * @param vertex
      * @return
      */

--- a/sfge/src/main/java/com/salesforce/rules/fls/apex/operations/StandardConditionDecomposer.java
+++ b/sfge/src/main/java/com/salesforce/rules/fls/apex/operations/StandardConditionDecomposer.java
@@ -9,18 +9,21 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Util class for decomposing {@link StandardConditionVertex} objects into components that can
- * be evaluated by a path-based rule.
+ * Util class for decomposing {@link StandardConditionVertex} objects into components that can be
+ * evaluated by a path-based rule.
  */
 public final class StandardConditionDecomposer {
 
     private StandardConditionDecomposer() {}
 
     /**
-     * Decompose a {@link StandardConditionVertex} into a list of {@link BaseSFVertex} objects
-     * that must be satisfied in order for the condition to be met.
-     * @param vertex - A {@link StandardConditionVertex.Positive} or {@link StandardConditionVertex.Negative}.
-     * @return List containing {@link BaseSFVertex} objects that must be satisfied for the condition to achieve its expected outcome.
+     * Decompose a {@link StandardConditionVertex} into a list of {@link BaseSFVertex} objects that
+     * must be satisfied in order for the condition to be met.
+     *
+     * @param vertex - A {@link StandardConditionVertex.Positive} or {@link
+     *     StandardConditionVertex.Negative}.
+     * @return List containing {@link BaseSFVertex} objects that must be satisfied for the condition
+     *     to achieve its expected outcome.
      */
     public static List<BaseSFVertex> decomposeStandardCondition(StandardConditionVertex vertex) {
         final List<BaseSFVertex> children = vertex.getChildren();

--- a/sfge/src/test/java/com/salesforce/config/SfgeConfigProviderTest.java
+++ b/sfge/src/test/java/com/salesforce/config/SfgeConfigProviderTest.java
@@ -49,7 +49,7 @@ public class SfgeConfigProviderTest {
 
                         @Override
                         public int getStackDepthLimit() {
-                            return -1 * EnvUtil.DEFAULT_STACK_DEPTH;
+                            return -1 * EnvUtil.DEFAULT_STACK_DEPTH_LIMIT;
                         }
                     });
 
@@ -71,7 +71,8 @@ public class SfgeConfigProviderTest {
                     sfgeConfig.getProgressIncrements(),
                     equalTo(-1 * EnvUtil.getProgressIncrements()));
             MatcherAssert.assertThat(
-                    sfgeConfig.getStackDepthLimit(), equalTo(-1 * EnvUtil.DEFAULT_STACK_DEPTH));
+                    sfgeConfig.getStackDepthLimit(),
+                    equalTo(-1 * EnvUtil.DEFAULT_STACK_DEPTH_LIMIT));
         } finally {
             SfgeConfigTestProvider.remove();
         }
@@ -99,6 +100,6 @@ public class SfgeConfigProviderTest {
         MatcherAssert.assertThat(
                 sfgeConfig.getProgressIncrements(), equalTo(EnvUtil.DEFAULT_PROGRESS_INCREMENTS));
         MatcherAssert.assertThat(
-                sfgeConfig.getStackDepthLimit(), equalTo(EnvUtil.DEFAULT_STACK_DEPTH));
+                sfgeConfig.getStackDepthLimit(), equalTo(EnvUtil.DEFAULT_STACK_DEPTH_LIMIT));
     }
 }

--- a/sfge/src/test/java/com/salesforce/rules/fls/apex/CheckBasedFlsComplexBooleansTest.java
+++ b/sfge/src/test/java/com/salesforce/rules/fls/apex/CheckBasedFlsComplexBooleansTest.java
@@ -617,7 +617,8 @@ public class CheckBasedFlsComplexBooleansTest extends BaseFlsTest {
                         + "    }\n"
                         + "}";
         // spotless:on
-        // Checking `x == false` is equivalent to checking `!x`, so the operation inside the IF is unsafe.
+        // Checking `x == false` is equivalent to checking `!x`, so the operation inside the IF is
+        // unsafe.
         assertViolations(rule, sourceCode, expect(4, validationType, "Account").withField("Name"));
     }
 


### PR DESCRIPTION
While QA'g, Josh found out that Graph Engine throws a StackOverflowException at around 400 to 500 stack depth before it gets anywhere close to the 1000 governor limit. To help with OutOfMemory, this change decreases the stack depth limit to 450. This value can be overridden using an environment variable, `SFGE_STACK_DEPTH_LIMIT`. Paths that cross this stack depth will not be pursued further.