### PR TITLE
@W-12494075@: Modified rule hierarchy to properly support new rule.

### DIFF
--- a/sfge/src/main/java/com/salesforce/graph/ops/expander/ApexPathExpander.java
+++ b/sfge/src/main/java/com/salesforce/graph/ops/expander/ApexPathExpander.java
@@ -44,7 +44,7 @@ import com.salesforce.graph.vertex.VertexPredicate;
 import com.salesforce.graph.vertex.WhenBlockVertex;
 import com.salesforce.graph.visitor.PathVertex;
 import com.salesforce.graph.visitor.VertexPredicateVisitor;
-import com.salesforce.rules.AbstractPathBasedRule;
+import com.salesforce.rules.AbstractPathTraversalRule;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -531,7 +531,7 @@ class ApexPathExpander
                                                 }
 
                                                 @Override
-                                                public void visit(AbstractPathBasedRule rule) {
+                                                public void visit(AbstractPathTraversalRule rule) {
                                                     if (EngineDirectiveUtil.isRuleEnabled(
                                                             vertex, rule)) {
                                                         apexPathVertexMetaInfo.addVertex(

--- a/sfge/src/main/java/com/salesforce/graph/visitor/VertexPredicateVisitor.java
+++ b/sfge/src/main/java/com/salesforce/graph/visitor/VertexPredicateVisitor.java
@@ -1,8 +1,8 @@
 package com.salesforce.graph.visitor;
 
 import com.salesforce.graph.vertex.VertexPredicate;
-import com.salesforce.rules.AbstractPathBasedRule;
-import com.salesforce.rules.PathBasedRule;
+import com.salesforce.rules.AbstractPathTraversalRule;
+import com.salesforce.rules.PathTraversalRule;
 
 /** Use this class to avoid "instanceof" pattern */
 public class VertexPredicateVisitor {
@@ -14,11 +14,11 @@ public class VertexPredicateVisitor {
         defaultVisit(predicate);
     }
 
-    public void visit(PathBasedRule rule) {
+    public void visit(PathTraversalRule rule) {
         defaultVisit(rule);
     }
 
-    public void visit(AbstractPathBasedRule rule) {
+    public void visit(AbstractPathTraversalRule rule) {
         defaultVisit(rule);
     }
 }

--- a/sfge/src/main/java/com/salesforce/rules/AbstractPathAnomalyRule.java
+++ b/sfge/src/main/java/com/salesforce/rules/AbstractPathAnomalyRule.java
@@ -1,0 +1,6 @@
+package com.salesforce.rules;
+
+/**
+ * Abstract parent class for rules that act on anomalous events that occurred during path expansion.
+ */
+public abstract class AbstractPathAnomalyRule extends AbstractPathBasedRule {}

--- a/sfge/src/main/java/com/salesforce/rules/AbstractPathBasedRule.java
+++ b/sfge/src/main/java/com/salesforce/rules/AbstractPathBasedRule.java
@@ -1,23 +1,7 @@
 package com.salesforce.rules;
 
-import com.salesforce.graph.ApexPath;
-import com.salesforce.graph.vertex.BaseSFVertex;
-import com.salesforce.graph.visitor.VertexPredicateVisitor;
-import java.util.List;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
-
-public abstract class AbstractPathBasedRule extends AbstractRule implements PathBasedRule {
-    @Override
-    public final List<RuleThrowable> run(
-            GraphTraversalSource g, ApexPath path, BaseSFVertex vertex) {
-        return _run(g, path, vertex);
-    }
-
-    protected abstract List<RuleThrowable> _run(
-            GraphTraversalSource g, ApexPath path, BaseSFVertex vertex);
-
-    @Override
-    public void accept(VertexPredicateVisitor visitor) {
-        visitor.visit(this);
-    }
-}
+/**
+ * Abstract parent class for rules whose execution requires the construction and/or traversal of
+ * {@link com.salesforce.graph.ApexPath} instances.
+ */
+public abstract class AbstractPathBasedRule extends AbstractRule {}

--- a/sfge/src/main/java/com/salesforce/rules/AbstractPathBasedRule.java
+++ b/sfge/src/main/java/com/salesforce/rules/AbstractPathBasedRule.java
@@ -2,6 +2,7 @@ package com.salesforce.rules;
 
 /**
  * Abstract parent class for rules whose execution requires the construction and/or traversal of
- * {@link com.salesforce.graph.ApexPath} instances.
+ * {@link com.salesforce.graph.ApexPath} instances. Currently, this class has no methods, but exists
+ * because it's beneficial to have all path-based rules share a common parent class.
  */
 public abstract class AbstractPathBasedRule extends AbstractRule {}

--- a/sfge/src/main/java/com/salesforce/rules/AbstractPathTraversalRule.java
+++ b/sfge/src/main/java/com/salesforce/rules/AbstractPathTraversalRule.java
@@ -1,0 +1,25 @@
+package com.salesforce.rules;
+
+import com.salesforce.graph.ApexPath;
+import com.salesforce.graph.vertex.BaseSFVertex;
+import com.salesforce.graph.visitor.VertexPredicateVisitor;
+import java.util.List;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+
+/** Abstract parent class for rules that execute during the traversal of already-expanded paths. */
+public abstract class AbstractPathTraversalRule extends AbstractPathBasedRule
+        implements PathTraversalRule {
+    @Override
+    public final List<RuleThrowable> run(
+            GraphTraversalSource g, ApexPath path, BaseSFVertex vertex) {
+        return _run(g, path, vertex);
+    }
+
+    protected abstract List<RuleThrowable> _run(
+            GraphTraversalSource g, ApexPath path, BaseSFVertex vertex);
+
+    @Override
+    public void accept(VertexPredicateVisitor visitor) {
+        visitor.visit(this);
+    }
+}

--- a/sfge/src/main/java/com/salesforce/rules/ApexFlsViolationRule.java
+++ b/sfge/src/main/java/com/salesforce/rules/ApexFlsViolationRule.java
@@ -16,7 +16,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSo
  * FLS Violation rule that uses forward-path approach to detect missing FLS checks on CRUD
  * operations.
  */
-public final class ApexFlsViolationRule extends AbstractPathBasedRule {
+public final class ApexFlsViolationRule extends AbstractPathTraversalRule {
     private static final Logger LOGGER = LogManager.getLogger(ApexFlsViolationRule.class);
 
     /**

--- a/sfge/src/main/java/com/salesforce/rules/ApexNullPointerExceptionRule.java
+++ b/sfge/src/main/java/com/salesforce/rules/ApexNullPointerExceptionRule.java
@@ -1,14 +1,9 @@
 package com.salesforce.rules;
 
 import com.salesforce.config.UserFacingMessages;
-import com.salesforce.graph.ApexPath;
-import com.salesforce.graph.vertex.BaseSFVertex;
-import java.util.ArrayList;
-import java.util.List;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 
-// TODO: Long-term, this class will extend a different abstract class
-public final class ApexNullPointerExceptionRule extends AbstractPathBasedRule {
+/** */
+public final class ApexNullPointerExceptionRule extends AbstractPathAnomalyRule {
     private static final String URL =
             "https://forcedotcom.github.io./sfdx-scanner/en/v3.x/salesforce-graph-engine/rules/#ApexNullPointerExceptionRule";
 
@@ -18,18 +13,6 @@ public final class ApexNullPointerExceptionRule extends AbstractPathBasedRule {
 
     public static ApexNullPointerExceptionRule getInstance() {
         return LazyHolder.INSTANCE;
-    }
-
-    // TODO: Long-term, this method is unnecessary.
-    @Override
-    public boolean test(BaseSFVertex vertex) {
-        return false;
-    }
-
-    // TODO: Long-term, this method is unnecessary.
-    @Override
-    protected List<RuleThrowable> _run(GraphTraversalSource g, ApexPath path, BaseSFVertex vertex) {
-        return new ArrayList<>();
     }
 
     // TODO: ENABLE THIS RULE.

--- a/sfge/src/main/java/com/salesforce/rules/PathBasedRuleRunner.java
+++ b/sfge/src/main/java/com/salesforce/rules/PathBasedRuleRunner.java
@@ -88,8 +88,8 @@ public class PathBasedRuleRunner {
                 // Iterate over all vertices in the path...
                 for (ApexPathVertexMetaInfo.PredicateMatch predicateMatch :
                         path.getApexPathMetaInfo().get().getAllMatches()) {
-                    AbstractPathBasedRule rule =
-                            (AbstractPathBasedRule) predicateMatch.getPredicate();
+                    AbstractPathTraversalRule rule =
+                            (AbstractPathTraversalRule) predicateMatch.getPredicate();
                     BaseSFVertex vertex = predicateMatch.getPathVertex().getVertex();
                     List<RuleThrowable> ruleThrowables = rule.run(g, path, vertex);
                     for (RuleThrowable ruleThrowable : ruleThrowables) {
@@ -164,7 +164,10 @@ public class PathBasedRuleRunner {
         ApexPathExpanderConfig.Builder expanderConfigBuilder =
                 ApexPathUtil.getFullConfiguredPathExpanderConfigBuilder();
         for (AbstractPathBasedRule rule : rules) {
-            expanderConfigBuilder = expanderConfigBuilder.withVertexPredicate(rule);
+            if (rule instanceof AbstractPathTraversalRule) {
+                expanderConfigBuilder =
+                        expanderConfigBuilder.withVertexPredicate((AbstractPathTraversalRule) rule);
+            }
         }
         ApexPathExpanderConfig expanderConfig = expanderConfigBuilder.build();
         return expanderConfig;

--- a/sfge/src/main/java/com/salesforce/rules/PathTraversalRule.java
+++ b/sfge/src/main/java/com/salesforce/rules/PathTraversalRule.java
@@ -7,16 +7,16 @@ import java.util.List;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 
 /**
- * Implemented by rules that are path based. These rules typically have an interest in a specific
- * vertex. Whether or not that vertex violates the rule is dependent on the path that leads up to
- * the vertex.
+ * Implemented by rules that execute during path traversal. These rules typically have an interest
+ * in a specific vertex. Whether or not that vertex violates the rule is dependent on the path that
+ * leads up to the vertex.
  *
  * <p>The caller finds all paths, and invokes {@link #test(BaseSFVertex)} on the rule. The rule
  * indicates its interest in teh vertex by returning true. TODO: May need to extend this to provide
  * a way for the rule to provide the query for paths. We don't want each rule to search for paths
  * individually as this would be inefficient. For now, the paths are determined by the caller.
  */
-public interface PathBasedRule extends VertexPredicate {
+public interface PathTraversalRule extends VertexPredicate {
     /**
      * Run the rule against {@code path}. The rule should only return errors related to {@code
      * vertex}. This method is only called when {@link VertexPredicate#test(BaseSFVertex)} returns

--- a/sfge/src/main/java/com/salesforce/rules/Violation.java
+++ b/sfge/src/main/java/com/salesforce/rules/Violation.java
@@ -195,7 +195,7 @@ public abstract class Violation implements Comparable<Violation>, RuleThrowable 
         }
     }
 
-    /** Violations associated with a {@link PathBasedRule} */
+    /** Violations associated with an {@link AbstractPathBasedRule} */
     public static final class PathBasedRuleViolation extends RuleViolation {
         /**
          * The "sink" vertex is the vertex at which the violation occurs, as contrasted with the

--- a/sfge/src/test/java/com/salesforce/rules/RuleRunnerTest.java
+++ b/sfge/src/test/java/com/salesforce/rules/RuleRunnerTest.java
@@ -79,7 +79,7 @@ public class RuleRunnerTest {
 
         TestUtil.buildGraph(g, sourceCode, true);
         List<AbstractRule> rules = new ArrayList<>();
-        rules.add(new PathBasedTestRule());
+        rules.add(new PathTraversalTestRule());
 
         AbstractRuleRunner rr = new TestRuleRunner(g, VertexCacheProvider.get());
         final Result result = rr.runRules(rules);
@@ -105,7 +105,7 @@ public class RuleRunnerTest {
 
         TestUtil.buildGraph(g, sourceCode, true);
         List<AbstractRule> rules = new ArrayList<>();
-        rules.add(new PathBasedTestRule());
+        rules.add(new PathTraversalTestRule());
 
         AbstractRuleRunner rr = new TestRuleRunner(g, VertexCacheProvider.get());
         final Result result = rr.runRules(rules);
@@ -154,7 +154,7 @@ public class RuleRunnerTest {
         TestUtil.buildGraph(g, new String[] {sourceCode1, sourceCode2, sourceCode3}, true);
         List<AbstractRule> rules = new ArrayList<>();
         rules.add(new StaticTestRule());
-        rules.add(new PathBasedTestRule());
+        rules.add(new PathTraversalTestRule());
 
         AbstractRuleRunner rr = new TestRuleRunner(g, VertexCacheProvider.get());
         List<RuleRunnerTarget> targets = new ArrayList<>();
@@ -232,7 +232,7 @@ public class RuleRunnerTest {
         }
     }
 
-    private static class PathBasedTestRule extends AbstractPathBasedRule {
+    private static class PathTraversalTestRule extends AbstractPathTraversalRule {
         @Override
         protected List<RuleThrowable> _run(
                 GraphTraversalSource g, ApexPath path, BaseSFVertex vertex) {
@@ -268,13 +268,13 @@ public class RuleRunnerTest {
                     && vertex.getParentClass().get().getDefiningType().startsWith("MyClass");
         }
 
-        public static PathBasedTestRule getInstance() {
+        public static PathTraversalTestRule getInstance() {
             return LazyHolder.INSTANCE;
         }
 
         private static final class LazyHolder {
             // Postpone initialization until first use.
-            private static final PathBasedTestRule INSTANCE = new PathBasedTestRule();
+            private static final PathTraversalTestRule INSTANCE = new PathTraversalTestRule();
         }
     }
 


### PR DESCRIPTION
This PR does the following:
- Adds new abstract class, `AbstractPathAnomalyRule extends AbstractPathBasedRule`. This class has no methods yet.
- Adds new abstract class, `AbstractPathTraversalRule extends AbstractPathBasedRule`.
- Moves all methods from `AbstractPathBasedRule` into `AbstractPathTraversalRule`.
- Changes `ApexFlsViolationRule` to extend `AbstractPathTraversalRule`.
- Changes `ApexNullPointerExceptionRule` to extend `AbstractPathAnomalyRule` and deletes unnecessary methods.
- A few miscellaneous updates to variables, documentation, parameters, etc so the appropriate types are used.