### PR TITLE
CHANGE (GraphEngine): @W-12672065@: Handles backend changes to cover remaining NPE Rule cases.

### DIFF
--- a/sfge/src/main/java/com/salesforce/config/UserFacingMessages.java
+++ b/sfge/src/main/java/com/salesforce/config/UserFacingMessages.java
@@ -16,7 +16,7 @@ public final class UserFacingMessages {
 
     public static final class RuleViolationTemplates {
         public static final String APEX_NULL_POINTER_EXCEPTION_RULE =
-                "Operation [%s] is likely to throw a NullPointerException";
+                "%s is likely to throw a NullPointerException";
         /** CRUD/FLS Violation messages */
         // format: "CRUD" or "FLS", DML operation, Object type, Field information
         public static final String MISSING_CRUD_FLS_CHECK =

--- a/sfge/src/main/java/com/salesforce/graph/ops/expander/NullValueAccessedException.java
+++ b/sfge/src/main/java/com/salesforce/graph/ops/expander/NullValueAccessedException.java
@@ -1,7 +1,8 @@
 package com.salesforce.graph.ops.expander;
 
 import com.salesforce.graph.symbols.apex.ApexValue;
-import com.salesforce.graph.vertex.MethodCallExpressionVertex;
+import com.salesforce.graph.vertex.BaseSFVertex;
+import com.salesforce.graph.vertex.NullAccessCheckedVertex;
 import javax.annotation.Nullable;
 
 /**
@@ -14,20 +15,20 @@ import javax.annotation.Nullable;
  */
 public final class NullValueAccessedException extends ApexPathExpanderRuntimeException {
     private final ApexValue<?> apexValue;
-    private final MethodCallExpressionVertex vertex;
+    private final NullAccessCheckedVertex vertex;
 
     /**
      * @param apexValue that is explicitly set to null
-     * @param vertex {@link MethodCallExpressionVertex} that was executed when the object was null
+     * @param vertex {@link BaseSFVertex} that was invoked when the object was null
      */
     public NullValueAccessedException(
-            ApexValue<?> apexValue, @Nullable MethodCallExpressionVertex vertex) {
+            ApexValue<?> apexValue, @Nullable NullAccessCheckedVertex vertex) {
         super("ApexValue=" + apexValue + ", vertex=" + (vertex != null ? vertex : "<null>"));
         this.apexValue = apexValue;
         this.vertex = vertex;
     }
 
-    public MethodCallExpressionVertex getVertex() {
+    public NullAccessCheckedVertex getVertex() {
         return vertex;
     }
 

--- a/sfge/src/main/java/com/salesforce/graph/symbols/apex/ApexValue.java
+++ b/sfge/src/main/java/com/salesforce/graph/symbols/apex/ApexValue.java
@@ -220,9 +220,11 @@ public abstract class ApexValue<T extends ApexValue> implements DeepCloneable<T>
      * null or it is a an uninitialized variable which will be initialized to null by the system.
      */
     public boolean isNull() {
-        boolean returnValue = valueVertex instanceof LiteralExpressionVertex.Null
-            // A null constraint could also indicate that the value is null
-            || (positiveConstraints.contains(Constraint.Null) && !negativeConstraints.contains(Constraint.Null));
+        boolean returnValue =
+                valueVertex instanceof LiteralExpressionVertex.Null
+                        // A null constraint could also indicate that the value is null
+                        || (positiveConstraints.contains(Constraint.Null)
+                                && !negativeConstraints.contains(Constraint.Null));
 
         if (!returnValue) {
             if (ValueStatus.UNINITIALIZED.equals(status)) {

--- a/sfge/src/main/java/com/salesforce/graph/symbols/apex/ApexValue.java
+++ b/sfge/src/main/java/com/salesforce/graph/symbols/apex/ApexValue.java
@@ -220,16 +220,20 @@ public abstract class ApexValue<T extends ApexValue> implements DeepCloneable<T>
      * null or it is a an uninitialized variable which will be initialized to null by the system.
      */
     public boolean isNull() {
-        if (ValueStatus.UNINITIALIZED.equals(status)) {
-            // Uninitialized values are initialized to null by the compiler
-            return true;
-        } else if (ValueStatus.INDETERMINANT.equals(status)) {
-            return false;
+        boolean returnValue = valueVertex instanceof LiteralExpressionVertex.Null
+            // A null constraint could also indicate that the value is null
+            || (positiveConstraints.contains(Constraint.Null) && !negativeConstraints.contains(Constraint.Null));
+
+        if (!returnValue) {
+            if (ValueStatus.UNINITIALIZED.equals(status)) {
+                // Uninitialized values are initialized to null by the compiler
+                returnValue = true;
+            } else if (ValueStatus.INDETERMINANT.equals(status)) {
+                returnValue = false;
+            }
         }
 
-        return valueVertex instanceof LiteralExpressionVertex.Null
-                // A null constraint could also indicate that the value is null
-                || positiveConstraints.contains(Constraint.Null);
+        return returnValue;
     }
 
     /**

--- a/sfge/src/main/java/com/salesforce/graph/symbols/apex/ObjectPropertiesHolder.java
+++ b/sfge/src/main/java/com/salesforce/graph/symbols/apex/ObjectPropertiesHolder.java
@@ -167,7 +167,7 @@ public final class ObjectPropertiesHolder
              * <p>SObject sObj = new Account(); String keyName = null; for (some iteration) { if
              * (some comparison) { keyName = 'field1'; } } sObj.put(keyName, 'value');
              */
-            throw new NullValueAccessedException(key, null);
+            throw new NullValueAccessedException(key, (MethodCallExpressionVertex) null);
         }
 
         String stringKey = getKeyForCaseInsensitiveMap(key).orElse(null);

--- a/sfge/src/main/java/com/salesforce/graph/symbols/apex/ObjectPropertiesHolder.java
+++ b/sfge/src/main/java/com/salesforce/graph/symbols/apex/ObjectPropertiesHolder.java
@@ -167,7 +167,7 @@ public final class ObjectPropertiesHolder
              * <p>SObject sObj = new Account(); String keyName = null; for (some iteration) { if
              * (some comparison) { keyName = 'field1'; } } sObj.put(keyName, 'value');
              */
-            throw new NullValueAccessedException(key, (MethodCallExpressionVertex) null);
+            throw new NullValueAccessedException(key, null);
         }
 
         String stringKey = getKeyForCaseInsensitiveMap(key).orElse(null);

--- a/sfge/src/main/java/com/salesforce/graph/vertex/BinaryExpressionVertex.java
+++ b/sfge/src/main/java/com/salesforce/graph/vertex/BinaryExpressionVertex.java
@@ -11,9 +11,11 @@ import java.util.Map;
 import java.util.Optional;
 
 public class BinaryExpressionVertex extends TODO_FIX_HIERARCHY_ChainedVertex
-        implements OperatorVertex {
+        implements OperatorVertex, NullAccessCheckedVertex {
     private final ChainedVertex lhs;
     private final ChainedVertex rhs;
+
+    private static final String DISPLAY_TEMPLATE = "Operator [%s]";
 
     BinaryExpressionVertex(Map<Object, Object> properties) {
         this(properties, null);
@@ -83,5 +85,10 @@ public class BinaryExpressionVertex extends TODO_FIX_HIERARCHY_ChainedVertex
     @Override
     public String getOperator() {
         return getString(Schema.OPERATOR);
+    }
+
+    @Override
+    public String getDisplayName() {
+        return String.format(DISPLAY_TEMPLATE, getOperator());
     }
 }

--- a/sfge/src/main/java/com/salesforce/graph/vertex/MethodCallExpressionVertex.java
+++ b/sfge/src/main/java/com/salesforce/graph/vertex/MethodCallExpressionVertex.java
@@ -20,7 +20,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.Scope;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
-public class MethodCallExpressionVertex extends InvocableWithParametersVertex implements KeyVertex {
+public class MethodCallExpressionVertex extends InvocableWithParametersVertex
+        implements KeyVertex, NullAccessCheckedVertex {
     private static final Consumer<GraphTraversal<Vertex, Vertex>> TRAVERSAL_CONSUMER =
             traversal ->
                     traversal
@@ -29,6 +30,7 @@ public class MethodCallExpressionVertex extends InvocableWithParametersVertex im
                             .not(has(Schema.FIRST_CHILD, true))
                             .order(Scope.global)
                             .by(Schema.CHILD_INDEX, Order.asc);
+    private static final String DISPLAY_TEMPLATE = "Method call [%s]";
 
     private final LazyVertex<AbstractReferenceExpressionVertex> referenceExpression;
     // TODO: This might need to move back into InvocableWithParametersVertex for situations
@@ -162,6 +164,11 @@ public class MethodCallExpressionVertex extends InvocableWithParametersVertex im
      */
     public MethodCallExpressionVertex getFirst() {
         return firstInitializer.get();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return String.format(DISPLAY_TEMPLATE, this.getFullMethodName());
     }
 
     /** Thread safe initializer. This doesn't use LazyVertex since it is more complex. */

--- a/sfge/src/main/java/com/salesforce/graph/vertex/NullAccessCheckedVertex.java
+++ b/sfge/src/main/java/com/salesforce/graph/vertex/NullAccessCheckedVertex.java
@@ -1,0 +1,14 @@
+package com.salesforce.graph.vertex;
+
+public interface NullAccessCheckedVertex {
+    /**
+     * @return Display name to use while sharing information
+     * if vertex is affected by null-access.
+     */
+    String getDisplayName();
+
+    /**
+     * @return Id to represent the vertex in a collection.
+     */
+    Long getId();
+}

--- a/sfge/src/main/java/com/salesforce/graph/vertex/NullAccessCheckedVertex.java
+++ b/sfge/src/main/java/com/salesforce/graph/vertex/NullAccessCheckedVertex.java
@@ -1,9 +1,14 @@
 package com.salesforce.graph.vertex;
 
+/**
+ * Interface to mark vertices that can have null-access check performed on them. At some point in
+ * the analysis, they can have {@link com.salesforce.graph.ops.expander.NullValueAccessedException}
+ * thrown if the value is known to be null. These null access checks are surfaced through {@link
+ * com.salesforce.rules.ApexNullPointerExceptionRule}.
+ */
 public interface NullAccessCheckedVertex {
     /**
-     * @return Display name to use while sharing information
-     * if vertex is affected by null-access.
+     * @return Display name to use while sharing information if vertex is affected by null-access.
      */
     String getDisplayName();
 

--- a/sfge/src/main/java/com/salesforce/rules/ApexNullPointerExceptionRule.java
+++ b/sfge/src/main/java/com/salesforce/rules/ApexNullPointerExceptionRule.java
@@ -3,8 +3,7 @@ package com.salesforce.rules;
 import com.salesforce.config.UserFacingMessages;
 import com.salesforce.graph.ops.expander.NullValueAccessedException;
 import com.salesforce.graph.ops.expander.PathExpansionException;
-import com.salesforce.graph.vertex.MethodCallExpressionVertex;
-import com.salesforce.graph.vertex.MethodVertex;
+import com.salesforce.graph.vertex.*;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -36,19 +35,21 @@ public final class ApexNullPointerExceptionRule extends AbstractPathAnomalyRule 
             if (!(anomaly instanceof NullValueAccessedException)) {
                 continue;
             }
-            MethodCallExpressionVertex mcev = ((NullValueAccessedException) anomaly).getVertex();
-            if (vertexIds.contains(mcev.getId())) {
+            final NullAccessCheckedVertex affectedVertex =
+                    ((NullValueAccessedException) anomaly).getVertex();
+            if (vertexIds.contains(affectedVertex.getId())) {
                 continue;
             }
+            final String operationName = affectedVertex.getDisplayName();
             violations.add(
                     new Violation.PathBasedRuleViolation(
                             String.format(
                                     UserFacingMessages.RuleViolationTemplates
                                             .APEX_NULL_POINTER_EXCEPTION_RULE,
-                                    mcev.getFullMethodName()),
+                                    operationName),
                             methodVertex,
-                            mcev));
-            vertexIds.add(mcev.getId());
+                            (SFVertex) affectedVertex));
+            vertexIds.add(affectedVertex.getId());
         }
         return violations;
     }

--- a/sfge/src/test/java/com/salesforce/graph/ops/ApexValueUtilTest.java
+++ b/sfge/src/test/java/com/salesforce/graph/ops/ApexValueUtilTest.java
@@ -52,6 +52,20 @@ public class ApexValueUtilTest {
     }
 
     @Test
+    public void testApplyBinaryExpressionWithNullValue() {
+        String sourceCode =
+                "public class MyClass {\n"
+                        + "	public void doSomething() {\n"
+                        + "		String input = null;"
+                        + "		System.debug('hello' + input);\n"
+                        + "	}\n"
+                        + "}\n";
+
+        TestRunner.Result<SystemDebugAccumulator> result = TestRunner.walkPath(g, sourceCode);
+        assertThat(result, TestRunnerMatcher.hasValue("hellonull"));
+    }
+
+    @Test
     @Disabled // TODO: handle apex value for binary expressions with indeterminant portions
     public void testApplyBinaryExpressionWithIndeterminant() {
         String sourceCode =

--- a/sfge/src/test/java/com/salesforce/graph/symbols/apex/IndeterminantTest.java
+++ b/sfge/src/test/java/com/salesforce/graph/symbols/apex/IndeterminantTest.java
@@ -7,16 +7,23 @@ import static org.hamcrest.Matchers.instanceOf;
 import com.salesforce.TestRunner;
 import com.salesforce.TestUtil;
 import com.salesforce.graph.visitor.SystemDebugAccumulator;
+import java.util.List;
 import java.util.stream.Stream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public class IndeterminantTest {
+    private static final Logger LOGGER = LogManager.getLogger(IndeterminantTest.class);
+
     private GraphTraversalSource g;
 
     @BeforeEach
@@ -137,5 +144,74 @@ public class IndeterminantTest {
         MatcherAssert.assertThat(value, not(instanceOf(ApexSingleValue.class)));
         MatcherAssert.assertThat(value.isIndeterminant(), equalTo(true));
         value.getTypeVertex().get().getCanonicalType().equals(variableType);
+    }
+
+    @CsvSource({
+        //        "IF Conditional equals Null,str == null,true,false", //TODO: ApexPathWalker should
+        // also place null constraints
+        "IF Conditional NOT equals Null,str != null,false,true"
+    })
+    @ParameterizedTest(name = "{displayName}: {0}")
+    public void testNullConstraintOnIndeterminant_IfBranch(
+            String name, String conditional, boolean isNull, boolean isIndeterminant) {
+        String sourceCode =
+                "public class MyClass {\n"
+                        + "   public void doSomething(String str) {\n"
+                        + "       if ("
+                        + conditional
+                        + ") {\n"
+                        + "           System.debug(str);\n"
+                        + "       }\n"
+                        + "   }\n"
+                        + "}\n";
+
+        List<TestRunner.Result<SystemDebugAccumulator>> results =
+                TestRunner.walkPaths(g, sourceCode);
+        MatcherAssert.assertThat(results, Matchers.hasSize(2));
+        for (TestRunner.Result<SystemDebugAccumulator> result : results) {
+            SystemDebugAccumulator visitor = result.getVisitor();
+            LOGGER.info("Test result size = " + visitor.resultSize());
+            if (visitor.resultSize() > 0) {
+                ApexStringValue stringValue = visitor.getSingletonResult();
+                LOGGER.info("negative constraints: " + stringValue.negativeConstraints);
+                LOGGER.info("positive constraints: " + stringValue.positiveConstraints);
+                MatcherAssert.assertThat(stringValue.isNull(), equalTo(isNull));
+                MatcherAssert.assertThat(stringValue.isIndeterminant(), equalTo(isIndeterminant));
+            }
+        }
+    }
+
+    @CsvSource({
+        "Else part of IF Conditional equals Null,str == null,false,true",
+        //        "Else part of IF Conditional NOT equals Null,str != null,true,false" //TODO:
+        // ApexPathWalker should also place null constraints
+    })
+    @ParameterizedTest(name = "{displayName}: {0}")
+    public void testNullConstraintOnIndeterminant_ElseBranch(
+            String name, String conditional, boolean isNull, boolean isIndeterminant) {
+        String sourceCode =
+                "public class MyClass {\n"
+                        + "   public void doSomething(String str) {\n"
+                        + "       if ("
+                        + conditional
+                        + ") {\n"
+                        + "           //do nothing \n"
+                        + "       } else {\n"
+                        + "           System.debug(str);\n"
+                        + "       }\n"
+                        + "   }\n"
+                        + "}\n";
+
+        List<TestRunner.Result<SystemDebugAccumulator>> results =
+                TestRunner.walkPaths(g, sourceCode);
+        MatcherAssert.assertThat(results, Matchers.hasSize(2));
+        for (TestRunner.Result<SystemDebugAccumulator> result : results) {
+            SystemDebugAccumulator visitor = result.getVisitor();
+            if (visitor.resultSize() > 0) {
+                ApexStringValue stringValue = visitor.getSingletonResult();
+                MatcherAssert.assertThat(stringValue.isNull(), equalTo(isNull));
+                MatcherAssert.assertThat(stringValue.isIndeterminant(), equalTo(isIndeterminant));
+            }
+        }
     }
 }

--- a/sfge/src/test/java/com/salesforce/graph/symbols/apex/IndeterminantTest.java
+++ b/sfge/src/test/java/com/salesforce/graph/symbols/apex/IndeterminantTest.java
@@ -146,24 +146,26 @@ public class IndeterminantTest {
         value.getTypeVertex().get().getCanonicalType().equals(variableType);
     }
 
+    // spotless:off
     @CsvSource({
-        //        "IF Conditional equals Null,str == null,true,false", //TODO: ApexPathWalker should
-        // also place null constraints
+        // TODO: ApexPathWalker should also place null constraints
+        // "IF Conditional equals Null,str == null,true,false",
         "IF Conditional NOT equals Null,str != null,false,true"
     })
+    // spotless:on
     @ParameterizedTest(name = "{displayName}: {0}")
     public void testNullConstraintOnIndeterminant_IfBranch(
             String name, String conditional, boolean isNull, boolean isIndeterminant) {
+        // spotless:off
         String sourceCode =
                 "public class MyClass {\n"
                         + "   public void doSomething(String str) {\n"
-                        + "       if ("
-                        + conditional
-                        + ") {\n"
+                        + "       if (" + conditional + ") {\n"
                         + "           System.debug(str);\n"
                         + "       }\n"
                         + "   }\n"
                         + "}\n";
+        // spotless:on
 
         List<TestRunner.Result<SystemDebugAccumulator>> results =
                 TestRunner.walkPaths(g, sourceCode);
@@ -181,14 +183,17 @@ public class IndeterminantTest {
         }
     }
 
+    // spotless:off
     @CsvSource({
+        // TODO: ApexPathWalker should also place null constraints
         "Else part of IF Conditional equals Null,str == null,false,true",
-        //        "Else part of IF Conditional NOT equals Null,str != null,true,false" //TODO:
-        // ApexPathWalker should also place null constraints
+        // "Else part of IF Conditional NOT equals Null,str != null,true,false"
     })
+    // spotless:on
     @ParameterizedTest(name = "{displayName}: {0}")
     public void testNullConstraintOnIndeterminant_ElseBranch(
             String name, String conditional, boolean isNull, boolean isIndeterminant) {
+        // spotless: off
         String sourceCode =
                 "public class MyClass {\n"
                         + "   public void doSomething(String str) {\n"
@@ -201,6 +206,7 @@ public class IndeterminantTest {
                         + "       }\n"
                         + "   }\n"
                         + "}\n";
+        // spotless: on
 
         List<TestRunner.Result<SystemDebugAccumulator>> results =
                 TestRunner.walkPaths(g, sourceCode);

--- a/sfge/src/test/java/com/salesforce/rules/npe/ApexNullPointerExceptionRuleTest.java
+++ b/sfge/src/test/java/com/salesforce/rules/npe/ApexNullPointerExceptionRuleTest.java
@@ -296,8 +296,6 @@ public class ApexNullPointerExceptionRuleTest extends BasePathBasedRuleTest {
         // "i != null, i + 2, 6, i + 2"
     })
     @ParameterizedTest(name = "{displayName}: constraint is {0}")
-    // TODO: FIX THIS TEST.
-    @Disabled
     public void testNullConstrainedIndeterminant_expectViolation(
             String constraint, String reference, int line, String op) {
         // Use the same reference for both sides of the constraint.

--- a/sfge/src/test/java/com/salesforce/rules/npe/ApexNullPointerExceptionRuleTest.java
+++ b/sfge/src/test/java/com/salesforce/rules/npe/ApexNullPointerExceptionRuleTest.java
@@ -4,7 +4,6 @@ import com.salesforce.rules.AbstractPathBasedRule;
 import com.salesforce.rules.ApexNullPointerExceptionRule;
 import com.salesforce.testutils.BasePathBasedRuleTest;
 import com.salesforce.testutils.ViolationWrapper;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -93,14 +92,14 @@ public class ApexNullPointerExceptionRuleTest extends BasePathBasedRuleTest {
      */
     @CsvSource({
         // Initialization without assignment produces null value.
-        "String s, Integer problem = s.length(), s.length",
-        // "Integer i, Integer problem = i + 0, i + 0",
+        "String s, Integer problem = s.length(), Method call [s.length]",
+        "Integer i, Integer problem = i + 0, Operator [+]",
         // Explicit assignment to null produces null value.
-        "String s = null, Integer problem = s.length(), s.length",
-        // "Integer i = null, Integer problem = i + 0, i + 0",
+        "String s = null, Integer problem = s.length(), Method call [s.length]",
+        "Integer i = null, Integer problem = i + 0, Operator [+]",
         // Assigning to a null return produces a null value.
-        "String s = getNullStr(), Integer problem = s.length(), s.length",
-        // "Integer i = getNullInt(), Integer problem = i + 0, i + 0",
+        "String s = getNullStr(), Integer problem = s.length(), Method call [s.length]",
+        "Integer i = getNullInt(), Integer problem = i + 0, Operator [+]",
     })
     @ParameterizedTest(name = "{displayName}: {0}")
     public void testNullInitialization_expectViolation(
@@ -191,8 +190,8 @@ public class ApexNullPointerExceptionRuleTest extends BasePathBasedRuleTest {
      * @param op - The specific op we expect to see in a violation message.
      */
     @CsvSource({
-        "Integer i = getNullStr().length(), length",
-        // "Integer i = getNullInt() + 2, getNullInt() + 2"
+        "Integer i = getNullStr().length(), Method call [length]",
+        "Integer i = getNullInt() + 2, Operator [+]"
     })
     @ParameterizedTest(name = "{displayName}: {0}")
     public void testInlineNullMethodReturn_expectViolation(String reference, String op) {
@@ -236,10 +235,7 @@ public class ApexNullPointerExceptionRuleTest extends BasePathBasedRuleTest {
      * @param op - The specific op expected in the violation message. TODO: This may change slightly
      *     once the rule is implemented.
      */
-    @CsvSource({
-        "String s, s.length(), s.length",
-        //        "Integer i, i + 2, i + 2"
-    })
+    @CsvSource({"String s, s.length(), Method call [s.length]", "Integer i, i + 2, Operator [+]"})
     @ParameterizedTest(name = "{displayName}: {0}")
     public void testNullParamReference_expectViolation(String param, String reference, String op) {
         String sourceCode =
@@ -288,12 +284,12 @@ public class ApexNullPointerExceptionRuleTest extends BasePathBasedRuleTest {
      */
     @CsvSource({
         // Constraining to null should cause a violation in the IF-branch.
-        "s == null, s.length(), 4, s.length",
-        // "i == null, i + 2, 4, i + 2",
+        "s == null, s.length(), 4, Method call [s.length]",
+        "i == null, i + 2, 4, Operator [+]",
         // Constraining to generalized "not null" should cause a violation in the ELSE,
         // since failing a "not null" constraint is equivalent to passing a null constraint.
-        "s != null, s.length(), 6, s.length",
-        // "i != null, i + 2, 6, i + 2"
+        "s != null, s.length(), 6, Method call [s.length]",
+        "i != null, i + 2, 6, Operator [+]"
     })
     @ParameterizedTest(name = "{displayName}: constraint is {0}")
     public void testNullConstrainedIndeterminant_expectViolation(


### PR DESCRIPTION
1. Added fix to null check priorities on indeterminant values
2. Added changes to throw null access checks when evaluating binary expressions
3. Minor changes to ApexNullPointerExceptionRule to accommodate Binary expression vertices.
4. Test changes
5. Modified user-facing text to handle method calls and binary expressions.