### PR TITLE
FIX (GraphEngine): @W-12696959@: UnusedMethodRule now fully supports constructors.

### DIFF
--- a/sfge/src/main/java/com/salesforce/rules/UnusedMethodRule.java
+++ b/sfge/src/main/java/com/salesforce/rules/UnusedMethodRule.java
@@ -144,11 +144,9 @@ public class UnusedMethodRule extends AbstractStaticRule {
      * for filtering the list of all possible candidates into just the eligible ones.
      */
     private boolean methodIsIneligible(MethodVertex vertex) {
-        // TODO: At this time, only static methods, private instance methods, and private/protected
-        //       constructors are supported. This limit will be loosened over time, and eventually
-        //       removed entirely.
-        if (!vertex.isStatic()
-                && !(vertex.isPrivate() || (vertex.isProtected() && vertex.isConstructor()))) {
+        // TODO: At this time, only static methods, constructors, and private instance methods are
+        //       supported. This limit will be loosened over time, and eventually removed entirely.
+        if (!vertex.isStatic() && !vertex.isConstructor() && !vertex.isPrivate()) {
             return true;
         }
 

--- a/sfge/src/main/java/com/salesforce/rules/unusedmethod/ConstructorMethodCallValidator.java
+++ b/sfge/src/main/java/com/salesforce/rules/unusedmethod/ConstructorMethodCallValidator.java
@@ -68,7 +68,16 @@ public class ConstructorMethodCallValidator extends BaseMethodCallValidator {
      */
     @Override
     protected boolean externalUsageDetected() {
-        // TODO: IMPLEMENT THIS METHOD
+        // Get all `new Whatever()` calls for the defining type.
+        List<NewObjectExpressionVertex> potentialExternalCalls =
+                ruleStateTracker.getConstructionsOfType(targetMethod.getDefiningType());
+        // Test each one to see whether its parameters match.
+        for (NewObjectExpressionVertex potentialExternalCall : potentialExternalCalls) {
+            if (parametersAreValid(potentialExternalCall)) {
+                return true;
+            }
+        }
+        // If we're here, it's because we couldn't find any matches.
         return false;
     }
 }

--- a/sfge/src/test/java/com/salesforce/rules/unusedmethod/ConstructorsTest.java
+++ b/sfge/src/test/java/com/salesforce/rules/unusedmethod/ConstructorsTest.java
@@ -171,8 +171,8 @@ public class ConstructorsTest extends BaseUnusedMethodTest {
      *
      * @param constructor - The way the constructor is invoked.
      */
-    @CsvSource({"OuterClass.InnerClass", "InnerClass"})
-    @ParameterizedTest(name = "{displayName}: OuterClass.InnerClass constructed as new {1}()")
+    @ValueSource(strings = {"OuterClass.InnerClass", "InnerClass"})
+    @ParameterizedTest(name = "{displayName}: OuterClass.InnerClass constructed as new {0}()")
     public void innerConstructorUsedByOuter_expectNoViolation(String constructor) {
         // spotless:off
         String sourceCode =
@@ -196,8 +196,8 @@ public class ConstructorsTest extends BaseUnusedMethodTest {
      *
      * @param constructor - The way the constructor is invoked.
      */
-    @CsvSource({"OuterClass.InnerClass", "InnerClass"})
-    @ParameterizedTest(name = "{displayName}: OuterClass.InnerClass constructed as new {1}()")
+    @ValueSource(strings = {"OuterClass.InnerClass", "InnerClass"})
+    @ParameterizedTest(name = "{displayName}: OuterClass.InnerClass constructed as new {0}()")
     public void innerConstructorUsedBySiblingInner_expectNoViolation(String constructor) {
         // spotless:off
         String sourceCode =

--- a/sfge/src/test/java/com/salesforce/rules/unusedmethod/ConstructorsTest.java
+++ b/sfge/src/test/java/com/salesforce/rules/unusedmethod/ConstructorsTest.java
@@ -169,18 +169,24 @@ public class ConstructorsTest extends BaseUnusedMethodTest {
     /**
      * Tests for cases where an inner class's constructor is called in the outer class.
      *
+     * @param variable - The way the variable is declared.
      * @param constructor - The way the constructor is invoked.
      */
-    @ValueSource(strings = {"OuterClass.InnerClass", "InnerClass"})
-    @ParameterizedTest(name = "{displayName}: OuterClass.InnerClass constructed as new {0}()")
-    public void innerConstructorUsedByOuter_expectNoViolation(String constructor) {
+    @CsvSource({
+        "OuterClass.InnerClass, OuterClass.InnerClass",
+        "OuterClass.InnerClass, InnerClass",
+        "InnerClass, OuterClass.InnerClass",
+        "InnerClass, InnerClass"
+    })
+    @ParameterizedTest(name = "{displayName}: Declared as {0}, constructed as new {1}()")
+    public void innerConstructorUsedByOuter_expectNoViolation(String variable, String constructor) {
         // spotless:off
         String sourceCode =
             "global class OuterClass {\n"
             // Declare a method in the outer class to call the inner constructor, annotated to not trip the rule.
           + "    /* sfge-disable-stack UnusedMethodRule */\n"
           + "    public void invoker() {\n"
-          + "        InnerClass obj = new " + constructor + "(false);\n"
+          + "        " + variable + " obj = new " + constructor + "(false);\n"
           + "    }\n"
           + "    global class InnerClass {\n"
             // Declare a constructor for the inner class
@@ -194,11 +200,18 @@ public class ConstructorsTest extends BaseUnusedMethodTest {
     /**
      * Tests for cases where an inner class's constructor is called by a sibling inner class.
      *
+     * @param variable - The way the variable is declared.
      * @param constructor - The way the constructor is invoked.
      */
-    @ValueSource(strings = {"OuterClass.InnerClass", "InnerClass"})
-    @ParameterizedTest(name = "{displayName}: OuterClass.InnerClass constructed as new {0}()")
-    public void innerConstructorUsedBySiblingInner_expectNoViolation(String constructor) {
+    @CsvSource({
+        "OuterClass.InnerClass, OuterClass.InnerClass",
+        "OuterClass.InnerClass, InnerClass",
+        "InnerClass, OuterClass.InnerClass",
+        "InnerClass, InnerClass"
+    })
+    @ParameterizedTest(name = "{displayName}: Declared as {0}, constructed as new {1}()")
+    public void innerConstructorUsedBySiblingInner_expectNoViolation(
+            String variable, String constructor) {
         // spotless:off
         String sourceCode =
             "global class OuterClass {\n"
@@ -211,7 +224,7 @@ public class ConstructorsTest extends BaseUnusedMethodTest {
             // Declare a method on the sibling inner class that instantiates the tested one.
           + "        /* sfge-disable-stack UnusedMethodRule */\n"
           + "        public void invoker() {\n"
-          + "            OuterClass.InnerClass obj = new " + constructor + "(false);\n"
+          + "            " + variable + " obj = new " + constructor + "(false);\n"
           + "        }\n"
           + "    }\n"
           + "}";

--- a/sfge/src/test/java/com/salesforce/rules/unusedmethod/ConstructorsTest.java
+++ b/sfge/src/test/java/com/salesforce/rules/unusedmethod/ConstructorsTest.java
@@ -6,7 +6,6 @@ import com.salesforce.graph.vertex.MethodVertex;
 import com.salesforce.rules.Violation;
 import java.util.function.Consumer;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -23,13 +22,12 @@ public class ConstructorsTest extends BaseUnusedMethodTest {
      * @param declaration - The declaration of the tested constructor
      * @param arity - The constructor's arity
      */
-    // TODO: ENABLE MORE TESTS AS WE ADD MORE FUNCTIONALITY
     @CsvSource({
         // One test per constructor, per visibility scope.
         // EXCEPTION: No test for private 0-arity, since such methods are ineligible.
-        // "public MyClass(), 0",
+        "public MyClass(), 0",
         "protected MyClass(), 0",
-        // "public MyClass(boolean b), 1",
+        "public MyClass(boolean b), 1",
         "protected MyClass(boolean b), 1",
         "private MyClass(boolean b), 1"
     })
@@ -54,12 +52,7 @@ public class ConstructorsTest extends BaseUnusedMethodTest {
      *
      * @param visibility - The visibility of the target constructor.
      */
-    @ValueSource(
-            strings = {
-                // "public",
-                "protected",
-                "private"
-            })
+    @ValueSource(strings = {"public", "protected", "private"})
     @ParameterizedTest(name = "{displayName}: {0} constructor")
     public void constructorCalledViaThis_expectNoViolation(String visibility) {
         // spotless:off
@@ -85,12 +78,7 @@ public class ConstructorsTest extends BaseUnusedMethodTest {
      * @param visibility - Visibility of the parent constructor
      * @param arity - Arity of the parent constructor
      */
-    @CsvSource({
-        // "public, 0",
-        // "public, 1",
-        "protected, 0",
-        "protected, 1"
-    })
+    @CsvSource({"public, 0", "public, 1", "protected, 0", "protected, 1"})
     @ParameterizedTest(name = "{displayName}: {0} constructor with arity {1}")
     public void constructorCalledViaSuper_expectNoViolation(String visibility, Integer arity) {
         // spotless:off
@@ -150,27 +138,49 @@ public class ConstructorsTest extends BaseUnusedMethodTest {
     }
 
     /**
+     * Simple tests for cases where one class's constructor is called somewhere in another class.
+     *
+     * @param arity - The arity of the tested constructor.
+     */
+    @ValueSource(ints = {0, 1})
+    @ParameterizedTest(name = "{displayName}: Arity {0}")
+    public void constructorCalledViaNew_expectNoViolation(Integer arity) {
+        // spotless:off
+        String[] sourceCodes = new String[]{
+            // Declare our tested class.
+            "global class TestedClass {\n"
+            // Declare a constructor with the expected arity that does nothing in particular.
+          + "    public TestedClass(" + StringUtils.repeat("boolean b", arity) + ") {}\n"
+          + "}",
+            // Declare a class to invoke the tested constructor.
+            "global class InvokerClass {\n"
+            // Annotate the invoker method to avoid tripping the rule.
+          + "    /* sfge-disable-stack UnusedMethodRule */\n"
+          + "    public static TestedClass invokeTestedConstructor() {\n"
+            // Invoke the tested constructor with however many parameters it expects.
+          + "        return new TestedClass(" + StringUtils.repeat("true", arity) + ");\n"
+          + "    }\n"
+          + "}"
+        };
+        // spotless:on
+        assertNoViolations(sourceCodes, 1);
+    }
+
+    /**
      * Tests for cases where an inner class's constructor is called in the outer class.
      *
-     * @param variable - The way the variable is declared.
      * @param constructor - The way the constructor is invoked.
      */
-    @CsvSource({
-        "OuterClass.InnerClass, OuterClass.InnerClass",
-        "OuterClass.InnerClass, InnerClass",
-        "InnerClass, OuterClass.InnerClass",
-        "InnerClass, InnerClass"
-    })
-    @ParameterizedTest(name = "{displayName}: Declared as {0}, constructed as new {1}()")
-    @Disabled
-    public void innerConstructorUsedByOuter_expectNoViolation(String variable, String constructor) {
+    @CsvSource({"OuterClass.InnerClass", "InnerClass"})
+    @ParameterizedTest(name = "{displayName}: OuterClass.InnerClass constructed as new {1}()")
+    public void innerConstructorUsedByOuter_expectNoViolation(String constructor) {
         // spotless:off
         String sourceCode =
             "global class OuterClass {\n"
             // Declare a method in the outer class to call the inner constructor, annotated to not trip the rule.
           + "    /* sfge-disable-stack UnusedMethodRule */\n"
           + "    public void invoker() {\n"
-          + "        " + variable + " obj = new " + constructor + "(false);\n"
+          + "        InnerClass obj = new " + constructor + "(false);\n"
           + "    }\n"
           + "    global class InnerClass {\n"
             // Declare a constructor for the inner class
@@ -184,19 +194,11 @@ public class ConstructorsTest extends BaseUnusedMethodTest {
     /**
      * Tests for cases where an inner class's constructor is called by a sibling inner class.
      *
-     * @param variable - The way the variable is declared.
      * @param constructor - The way the constructor is invoked.
      */
-    @CsvSource({
-        "OuterClass.InnerClass, OuterClass.InnerClass",
-        "OuterClass.InnerClass, InnerClass",
-        "InnerClass, OuterClass.InnerClass",
-        "InnerClass, InnerClass"
-    })
-    @ParameterizedTest(name = "{displayName}: Declared as {0}, constructed as new {1}()")
-    @Disabled
-    public void innerConstructorUsedBySiblingInner_expectNoViolation(
-            String variable, String constructor) {
+    @CsvSource({"OuterClass.InnerClass", "InnerClass"})
+    @ParameterizedTest(name = "{displayName}: OuterClass.InnerClass constructed as new {1}()")
+    public void innerConstructorUsedBySiblingInner_expectNoViolation(String constructor) {
         // spotless:off
         String sourceCode =
             "global class OuterClass {\n"
@@ -209,11 +211,54 @@ public class ConstructorsTest extends BaseUnusedMethodTest {
             // Declare a method on the sibling inner class that instantiates the tested one.
           + "        /* sfge-disable-stack UnusedMethodRule */\n"
           + "        public void invoker() {\n"
-          + "            " + variable + " obj = new " + constructor + "(false);\n"
+          + "            OuterClass.InnerClass obj = new " + constructor + "(false);\n"
           + "        }\n"
           + "    }\n"
           + "}";
         // spotless:on
         assertNoViolations(sourceCode, 1);
+    }
+
+    /**
+     * These tests cover variants of a weird edge case: If an inner class and an outer class share
+     * the same name (e.g., {@code Whatever} and {@code Outer.Whatever}), then calling {@code new
+     * Whatever()} in the inner class's outer/sibling classes should count as an invocation for the
+     * inner class, not the outer class.
+     *
+     * @param arity - The arity of the tested constructor.
+     */
+    @ValueSource(ints = {0, 1})
+    @ParameterizedTest(name = "{displayName}: Constructor of arity {0}")
+    public void externalReferenceSyntaxCollision_expectViolation(Integer arity) {
+        // spotless:off
+        String[] sourceCodes = new String[]{
+            // Declare an outer class with a constructor.
+            "global class CollidingName {\n"
+          + "    public CollidingName(" + StringUtils.repeat("boolean b", arity) + ") {}\n"
+          + "}",
+            // Declare another outer class.
+            "global class OuterClass {\n"
+            // Give the outer class an inner class whose name collides with the tested outer class.
+          + "    global class CollidingName {\n"
+            // Give the inner class a constructor with the same params as the outer class.
+          + "        public CollidingName(" + StringUtils.repeat("boolean b", arity) + ") {}\n"
+          + "    }\n"
+          + "    \n"
+            // Give the outer class a static method that instantiates the inner class.
+          + "    /* sfge-disable-stack UnusedMethodRule */\n"
+          + "    public static boolean callConstructor() {\n"
+            // IMPORTANT: This is where the constructor is called.
+          + "        CollidingName obj = new CollidingName(" + StringUtils.repeat("true", arity) +");\n"
+          + "        return true;\n"
+          + "    }\n"
+          + "}"
+        };
+        // spotless:on
+        assertViolations(
+                sourceCodes,
+                v -> {
+                    assertEquals("<init>", v.getSourceVertexName());
+                    assertEquals("CollidingName", v.getSourceDefiningType());
+                });
     }
 }

--- a/sfge/src/test/java/com/salesforce/rules/unusedmethod/OverloadsTest.java
+++ b/sfge/src/test/java/com/salesforce/rules/unusedmethod/OverloadsTest.java
@@ -232,7 +232,6 @@ public class OverloadsTest extends BaseUnusedMethodTest {
         "private,  'new MyClass(true, true)',  1"
     })
     @ParameterizedTest(name = "{displayName}: {0} constructor {1}")
-    @Disabled
     public void callConstructorViaNewWithDifferentArityOverloads_expectViolation(
             String scope, String constructor, int arity) {
         String sourceCode =
@@ -298,14 +297,13 @@ public class OverloadsTest extends BaseUnusedMethodTest {
      * If there's different overloads of a constructor, then only the ones that are actually invoked
      * count as used. Specific case: Methods with different arities, invoked via the `this` keyword.
      */
-    // TODO: Enable subsequent tests as we implement functionality.
     @CsvSource({
         // Use the arity of the constructor that ISN'T being called,
         // and have one variant per visibility scope.
-        //        "public,  this(true),  2",
+        "public,  this(true),  2",
         "protected,  this(true),  2",
         "private,  this(true),  2",
-        //        "public,  'this(true, true)', 1",
+        "public,  'this(true, true)', 1",
         "protected,  'this(true, true)', 1",
         "private,  'this(true, true)', 1"
     })
@@ -319,7 +317,7 @@ public class OverloadsTest extends BaseUnusedMethodTest {
                         + String.format("    %s MyClass(boolean b, boolean c) {\n", scope)
                         + "    }\n"
                         // Use the engine directive to prevent this method from tripping the rule.
-                        + "    /* sfge-disable-stack UnusedMethodRule */"
+                        + "    /* sfge-disable-stack UnusedMethodRule */\n"
                         + "    public MyClass() {\n"
                         + String.format("        %s;\n", constructor)
                         + "    }\n"


### PR DESCRIPTION
This PR does the following:
- `UnusedMethodRule` now properly detects invocations of private/protected constructors via the `new` keyword (Thereby also resolving issue #1001)
- `UnusedMethodRule` now fully support public constructors