### PR TITLE
@W-12278342@: Loop Upgrades - Part 1: Handle for loop path with single value

### DIFF
--- a/sfge/src/main/java/com/salesforce/graph/ops/MethodTypeMatchUtil.java
+++ b/sfge/src/main/java/com/salesforce/graph/ops/MethodTypeMatchUtil.java
@@ -19,6 +19,9 @@ import java.util.Optional;
 
 import static com.salesforce.graph.ops.TypeableUtil.NOT_A_MATCH;
 
+/**
+ * Performs type-related operations while matching method calls with method definitions.
+ */
 public final class MethodTypeMatchUtil {
     private MethodTypeMatchUtil() {}
 

--- a/sfge/src/main/java/com/salesforce/graph/ops/MethodTypeMatchUtil.java
+++ b/sfge/src/main/java/com/salesforce/graph/ops/MethodTypeMatchUtil.java
@@ -1,0 +1,249 @@
+package com.salesforce.graph.ops;
+
+import com.salesforce.apex.jorje.ASTConstants;
+import com.salesforce.exception.UnexpectedException;
+import com.salesforce.graph.Schema;
+import com.salesforce.graph.build.CaseSafePropertyUtil;
+import com.salesforce.graph.symbols.AbstractClassInstanceScope;
+import com.salesforce.graph.symbols.SymbolProvider;
+import com.salesforce.graph.symbols.apex.ApexClassInstanceValue;
+import com.salesforce.graph.symbols.apex.ApexValue;
+import com.salesforce.graph.vertex.*;
+import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static com.salesforce.graph.ops.TypeableUtil.NOT_A_MATCH;
+
+public final class MethodTypeMatchUtil {
+    private MethodTypeMatchUtil() {}
+
+
+    static boolean methodVariableTypeMatches(
+        GraphTraversalSource g,
+        MethodVertex method,
+        String hostVariable,
+        SymbolProvider symbols) {
+        // Get the declaration of the variable, and make sure its type matches.
+        Typeable declaration = symbols.getTypedVertex(hostVariable).orElse(null);
+
+        // If there's a declaration vertex and it's of the exact right type, we're in the clear.
+        if (declaration != null
+                && declaration.getCanonicalType().equalsIgnoreCase(method.getDefiningType())) {
+            return true;
+        } else if (declaration != null) {
+            // If there's a declaration vertex, but the types don't exactly match, then we need to
+            // figure out whether
+            // inheritance is relevant.
+            // For that, we need the type where the method is defined, and we need the type of the
+            // declared variable.
+            String methodDefiningType = method.getDefiningType();
+            String declaredType = declaration.getCanonicalType();
+
+            List<BaseSFVertex> inheritedTypes =
+                    SFVertexFactory.loadVertices(
+                            g,
+                            g.V()
+                                    // Starting from the vertex that represents the method's
+                                    // defining class/interface...
+                                    .hasLabel(
+                                            P.within(ASTConstants.NodeType.USER_INTERFACE, ASTConstants.NodeType.USER_CLASS))
+                                    .where(
+                                            CaseSafePropertyUtil.H.has(
+                                                    Arrays.asList(
+                                                            ASTConstants.NodeType.USER_CLASS,
+                                                            ASTConstants.NodeType.USER_INTERFACE),
+                                                    Schema.NAME,
+                                                    methodDefiningType))
+                                    // ...follow edges to any supertypes...
+                                    .repeat(__.out(Schema.IMPLEMENTATION_OF, Schema.EXTENSION_OF))
+                                    // ...until we run into the declared type of the host variable.
+                                    .until(
+                                            CaseSafePropertyUtil.H.has(
+                                                    Arrays.asList(
+                                                            ASTConstants.NodeType.USER_CLASS,
+                                                            ASTConstants.NodeType.USER_INTERFACE),
+                                                    Schema.NAME,
+                                                    declaredType)));
+
+            // If any vertices were returned by the above query, then the method's defining type
+            // inherits from the variable's
+            // declared type, in which case we're good. If not, return false.
+            return !inheritedTypes.isEmpty();
+        } else {
+            // If there's no declaration, we can just return false.
+            return false;
+        }
+    }
+
+    static int parameterTypesMatch(
+        MethodVertex method, InvocableWithParametersVertex invocable, SymbolProvider symbols) {
+        int rank = 0;
+        // For each of the method's parameters...
+        for (int i = 0; i < method.getParameters().size(); i++) {
+            ParameterVertex methodParameter = method.getParameters().get(i);
+            ChainedVertex invokedParameter = invocable.getParameters().get(i);
+
+            // Look at the child of the Post/Prefix expression to determine the parameter's type
+            if (invokedParameter instanceof PostfixExpressionVertex
+                    || invokedParameter instanceof PrefixExpressionVertex) {
+                invokedParameter = invokedParameter.getOnlyChild();
+            }
+
+            // Choose one of the ternary results to match. Iteratively resolve in case there are
+            // multiple
+            // ternary vertices, i.e. s = x ? 'x' : y ? 'y' : 'z'
+            while (invokedParameter instanceof TernaryExpressionVertex) {
+                TernaryExpressionVertex ternaryExpression =
+                        (TernaryExpressionVertex) invokedParameter;
+                // Choose the first option.
+                invokedParameter = ternaryExpression.getTrueValue();
+            }
+
+            Typeable typeable;
+            // TODO: replace with visitor
+            if (invokedParameter instanceof LiteralExpressionVertex.Null) {
+                // Everything is considered a match to NULL
+                continue;
+            } else if (invokedParameter instanceof NewCollectionExpressionVertex) {
+                if (!methodParameter
+                        .getCanonicalType()
+                        .toLowerCase()
+                        .startsWith(
+                                ((NewCollectionExpressionVertex) invokedParameter)
+                                        .getTypePrefix())) {
+                    return TypeableUtil.NOT_A_MATCH;
+                }
+
+                rank = getMatchRank(rank, (Typeable) invokedParameter, methodParameter);
+            } else if (invokedParameter instanceof VariableExpressionVertex) {
+                typeable =
+                        getTypedVertex((VariableExpressionVertex) invokedParameter, symbols)
+                                .orElse(null);
+                rank = getMatchRank(rank, typeable, methodParameter);
+            } else if (invokedParameter instanceof SoqlExpressionVertex) {
+                typeable = (SoqlExpressionVertex) invokedParameter;
+                rank = getMatchRank(rank, typeable, methodParameter);
+            } else if (invokedParameter instanceof InvocableVertex) {
+                typeable =
+                        getTypeFromInvocableVertexReturnValue(
+                                symbols, (InvocableVertex) invokedParameter);
+                rank = getMatchRank(rank, typeable, methodParameter);
+            } else if (invokedParameter instanceof BinaryExpressionVertex) {
+                typeable =
+                        ((BinaryExpressionVertex) invokedParameter)
+                                .getTypedVertex(symbols)
+                                .orElse(null);
+                rank = getMatchRank(rank, typeable, methodParameter);
+            } else if (invokedParameter instanceof Typeable) {
+                typeable = (Typeable) invokedParameter;
+                rank = getMatchRank(rank, typeable, methodParameter);
+                // TODO: Why can't this be first?
+                // If the invocable uses literal parameters of the wrong type, then it's not a
+                // match.
+            } else {
+                typeable = getTypeFromSymbol(symbols, invokedParameter);
+                rank = getMatchRank(rank, typeable, methodParameter);
+            }
+
+            // If we hit a NOT_A_MATCH at any point, return immediately
+            if (rank == NOT_A_MATCH) {
+                return rank;
+            }
+        }
+        // If we couldn't find a reason to return false, then it's a match. Return true.
+        return rank;
+    }
+
+    private static Typeable getTypeFromSymbol(
+            SymbolProvider symbols, ChainedVertex invokedParameter) {
+        String symbolicName = invokedParameter.getSymbolicName().orElse(null);
+        if (symbolicName == null) {
+            throw new UnexpectedException(invokedParameter);
+        }
+        // If the desired variable has no declaration, or is declared as the wrong type, then it's
+        // not a match.
+        Typeable typeable = symbols.getTypedVertex(symbolicName).orElse(null);
+        return typeable;
+    }
+
+    private static Typeable getTypeFromInvocableVertexReturnValue(
+            SymbolProvider symbols, InvocableVertex invocableVertex) {
+        Typeable typeable = null;
+
+        ApexValue<?> apexValue = symbols.getReturnedValue(invocableVertex).orElse(null);
+        if (apexValue != null) {
+            typeable = apexValue.getTypeVertex().orElse(null);
+        }
+        return typeable;
+    }
+
+    private static int getMatchRank(int rank, Typeable typeable, ParameterVertex methodParameter) {
+        if (typeable == null || !typeable.matchesParameterType(methodParameter)) {
+            return NOT_A_MATCH;
+        }
+
+        rank += typeable.rankParameterMatch(methodParameter);
+        return rank;
+    }
+
+    /** Determine a variable expression's type if possible */
+    private static Optional<Typeable> getTypedVertex(
+            VariableExpressionVertex vertex, SymbolProvider symbols) {
+        Typeable typeable;
+
+        if (vertex instanceof VariableExpressionVertex.Standard) {
+            typeable = (VariableExpressionVertex.Standard) vertex;
+        } else {
+            List<String> symbolicNameChain = vertex.getSymbolicNameChain();
+            typeable = symbols.getTypedVertex(symbolicNameChain).orElse(null);
+            Optional<ApexValue<?>> apexValue = Optional.empty();
+
+            // Special casing FieldVertex since we don't get information about the class hierarchy
+            // unless we have the actual class scope in hand.
+            if (typeable instanceof FieldVertex) {
+                apexValue = symbols.getApexValue(((FieldVertex) typeable).getName());
+            }
+            typeable = getDeclarationTypeWhenAvailable(typeable, apexValue);
+        }
+
+        return Optional.ofNullable(typeable);
+    }
+
+    /**
+     * When matching method parameter types, we want to match based on declaration value rather than
+     * the initialization value. For example, SObject sobj = new Account(); matchMe(sobj);
+     *
+     * <p>void matchMe(SObject s) - should match void matchMe(Account a) - should not match
+     *
+     * @return declaration type if available. If not, same as the value provided.
+     */
+    private static Typeable getDeclarationTypeWhenAvailable(
+            Typeable typeable, Optional<ApexValue<?>> apexValue) {
+        if (typeable instanceof ApexValue
+                && ((ApexValue<?>) typeable).getDeclarationVertex().isPresent()) {
+            Typeable declarationType = ((ApexValue<?>) typeable).getDeclarationVertex().get();
+            if (!declarationType.getCanonicalType().equalsIgnoreCase(typeable.getCanonicalType())) {
+                // Prioritize declaration type over value type
+                typeable = declarationType;
+            }
+        }
+        if (apexValue.isPresent() && apexValue.get() instanceof ApexClassInstanceValue) {
+            final AbstractClassInstanceScope classType =
+                    ((ApexClassInstanceValue) apexValue.get()).getClassInstanceScope();
+            // If class type and the Typeable have the same canonical type, prefer class type
+            // since we get more information about class hierarchy.
+            if (classType.getCanonicalType().equalsIgnoreCase(typeable.getCanonicalType())) {
+                typeable = classType;
+            }
+        } else if (typeable instanceof DeclarationVertex) {
+            final ChainedVertex lhs = ((DeclarationVertex) typeable).getLhs();
+            typeable = (lhs instanceof Typeable) ? (Typeable) lhs : typeable;
+        }
+        return typeable;
+    }
+}

--- a/sfge/src/main/java/com/salesforce/graph/ops/MethodUtil.java
+++ b/sfge/src/main/java/com/salesforce/graph/ops/MethodUtil.java
@@ -12,13 +12,13 @@ import com.salesforce.graph.ApexPath;
 import com.salesforce.graph.Schema;
 import com.salesforce.graph.build.CaseSafePropertyUtil.H;
 import com.salesforce.graph.ops.expander.ApexPathExpanderConfig;
-import com.salesforce.graph.symbols.AbstractClassInstanceScope;
 import com.salesforce.graph.symbols.AbstractClassScope;
 import com.salesforce.graph.symbols.ContextProviders;
 import com.salesforce.graph.symbols.DefaultSymbolProviderVertexVisitor;
 import com.salesforce.graph.symbols.MethodInvocationScope;
 import com.salesforce.graph.symbols.SymbolProvider;
 import com.salesforce.graph.symbols.apex.ApexClassInstanceValue;
+import com.salesforce.graph.symbols.apex.ApexForLoopValue;
 import com.salesforce.graph.symbols.apex.ApexStandardValue;
 import com.salesforce.graph.symbols.apex.ApexValue;
 import com.salesforce.graph.symbols.apex.system.SystemSchema;
@@ -452,7 +452,7 @@ public final class MethodUtil {
                     }
                     continue;
                 }
-                final int matchRank = parameterTypesMatch(method, invocable, symbols);
+                final int matchRank = MethodTypeMatchUtil.parameterTypesMatch(method, invocable, symbols);
                 if (matchRank != NOT_A_MATCH) {
                     // Make sure we have only one method at a given rank.
                     // Multiple matches at the same rank would be a compilation error.
@@ -604,230 +604,6 @@ public final class MethodUtil {
         return mfv.isPathSatisfactory();
     }
 
-    private static boolean methodVariableTypeMatches(
-            GraphTraversalSource g,
-            MethodVertex method,
-            String hostVariable,
-            SymbolProvider symbols) {
-        // Get the declaration of the variable, and make sure its type matches.
-        Typeable declaration = symbols.getTypedVertex(hostVariable).orElse(null);
-
-        // If there's a declaration vertex and it's of the exact right type, we're in the clear.
-        if (declaration != null
-                && declaration.getCanonicalType().equalsIgnoreCase(method.getDefiningType())) {
-            return true;
-        } else if (declaration != null) {
-            // If there's a declaration vertex, but the types don't exactly match, then we need to
-            // figure out whether
-            // inheritance is relevant.
-            // For that, we need the type where the method is defined, and we need the type of the
-            // declared variable.
-            String methodDefiningType = method.getDefiningType();
-            String declaredType = declaration.getCanonicalType();
-
-            List<BaseSFVertex> inheritedTypes =
-                    SFVertexFactory.loadVertices(
-                            g,
-                            g.V()
-                                    // Starting from the vertex that represents the method's
-                                    // defining class/interface...
-                                    .hasLabel(
-                                            P.within(NodeType.USER_INTERFACE, NodeType.USER_CLASS))
-                                    .where(
-                                            H.has(
-                                                    Arrays.asList(
-                                                            NodeType.USER_CLASS,
-                                                            NodeType.USER_INTERFACE),
-                                                    Schema.NAME,
-                                                    methodDefiningType))
-                                    // ...follow edges to any supertypes...
-                                    .repeat(__.out(Schema.IMPLEMENTATION_OF, Schema.EXTENSION_OF))
-                                    // ...until we run into the declared type of the host variable.
-                                    .until(
-                                            H.has(
-                                                    Arrays.asList(
-                                                            NodeType.USER_CLASS,
-                                                            NodeType.USER_INTERFACE),
-                                                    Schema.NAME,
-                                                    declaredType)));
-
-            // If any vertices were returned by the above query, then the method's defining type
-            // inherits from the variable's
-            // declared type, in which case we're good. If not, return false.
-            return !inheritedTypes.isEmpty();
-        } else {
-            // If there's no declaration, we can just return false.
-            return false;
-        }
-    }
-
-    private static int parameterTypesMatch(
-            MethodVertex method, InvocableWithParametersVertex invocable, SymbolProvider symbols) {
-        int rank = 0;
-        // For each of the method's parameters...
-        for (int i = 0; i < method.getParameters().size(); i++) {
-            ParameterVertex methodParameter = method.getParameters().get(i);
-            ChainedVertex invokedParameter = invocable.getParameters().get(i);
-
-            // Look at the child of the Post/Prefix expression to determine the parameter's type
-            if (invokedParameter instanceof PostfixExpressionVertex
-                    || invokedParameter instanceof PrefixExpressionVertex) {
-                invokedParameter = invokedParameter.getOnlyChild();
-            }
-
-            // Choose one of the ternary results to match. Iteratively resolve in case there are
-            // multiple
-            // ternary vertices, i.e. s = x ? 'x' : y ? 'y' : 'z'
-            while (invokedParameter instanceof TernaryExpressionVertex) {
-                TernaryExpressionVertex ternaryExpression =
-                        (TernaryExpressionVertex) invokedParameter;
-                // Choose the first option.
-                invokedParameter = ternaryExpression.getTrueValue();
-            }
-
-            Typeable typeable;
-            // TODO: replace with visitor
-            if (invokedParameter instanceof LiteralExpressionVertex.Null) {
-                // Everything is considered a match to NULL
-                continue;
-            } else if (invokedParameter instanceof NewCollectionExpressionVertex) {
-                if (!methodParameter
-                        .getCanonicalType()
-                        .toLowerCase()
-                        .startsWith(
-                                ((NewCollectionExpressionVertex) invokedParameter)
-                                        .getTypePrefix())) {
-                    return TypeableUtil.NOT_A_MATCH;
-                }
-
-                rank = getMatchRank(rank, (Typeable) invokedParameter, methodParameter);
-            } else if (invokedParameter instanceof VariableExpressionVertex) {
-                typeable =
-                        getTypedVertex((VariableExpressionVertex) invokedParameter, symbols)
-                                .orElse(null);
-                rank = getMatchRank(rank, typeable, methodParameter);
-            } else if (invokedParameter instanceof SoqlExpressionVertex) {
-                typeable = (SoqlExpressionVertex) invokedParameter;
-                rank = getMatchRank(rank, typeable, methodParameter);
-            } else if (invokedParameter instanceof InvocableVertex) {
-                typeable =
-                        getTypeFromInvocableVertexReturnValue(
-                                symbols, (InvocableVertex) invokedParameter);
-                rank = getMatchRank(rank, typeable, methodParameter);
-            } else if (invokedParameter instanceof BinaryExpressionVertex) {
-                typeable =
-                        ((BinaryExpressionVertex) invokedParameter)
-                                .getTypedVertex(symbols)
-                                .orElse(null);
-                rank = getMatchRank(rank, typeable, methodParameter);
-            } else if (invokedParameter instanceof Typeable) {
-                typeable = (Typeable) invokedParameter;
-                rank = getMatchRank(rank, typeable, methodParameter);
-                // TODO: Why can't this be first?
-                // If the invocable uses literal parameters of the wrong type, then it's not a
-                // match.
-            } else {
-                typeable = getTypeFromSymbol(symbols, invokedParameter);
-                rank = getMatchRank(rank, typeable, methodParameter);
-            }
-
-            // If we hit a NOT_A_MATCH at any point, return immediately
-            if (rank == NOT_A_MATCH) {
-                return rank;
-            }
-        }
-        // If we couldn't find a reason to return false, then it's a match. Return true.
-        return rank;
-    }
-
-    private static Typeable getTypeFromSymbol(
-            SymbolProvider symbols, ChainedVertex invokedParameter) {
-        String symbolicName = invokedParameter.getSymbolicName().orElse(null);
-        if (symbolicName == null) {
-            throw new UnexpectedException(invokedParameter);
-        }
-        // If the desired variable has no declaration, or is declared as the wrong type, then it's
-        // not a match.
-        Typeable typeable = symbols.getTypedVertex(symbolicName).orElse(null);
-        return typeable;
-    }
-
-    private static Typeable getTypeFromInvocableVertexReturnValue(
-            SymbolProvider symbols, InvocableVertex invocableVertex) {
-        Typeable typeable = null;
-
-        ApexValue<?> apexValue = symbols.getReturnedValue(invocableVertex).orElse(null);
-        if (apexValue != null) {
-            typeable = apexValue.getTypeVertex().orElse(null);
-        }
-        return typeable;
-    }
-
-    private static int getMatchRank(int rank, Typeable typeable, ParameterVertex methodParameter) {
-        if (typeable == null || !typeable.matchesParameterType(methodParameter)) {
-            return NOT_A_MATCH;
-        }
-
-        rank += typeable.rankParameterMatch(methodParameter);
-        return rank;
-    }
-
-    /** Determine a variable expression's type if possible */
-    private static Optional<Typeable> getTypedVertex(
-            VariableExpressionVertex vertex, SymbolProvider symbols) {
-        Typeable typeable;
-
-        if (vertex instanceof VariableExpressionVertex.Standard) {
-            typeable = (VariableExpressionVertex.Standard) vertex;
-        } else {
-            List<String> symbolicNameChain = vertex.getSymbolicNameChain();
-            typeable = symbols.getTypedVertex(symbolicNameChain).orElse(null);
-            Optional<ApexValue<?>> apexValue = Optional.empty();
-
-            // Special casing FieldVertex since we don't get information about the class hierarchy
-            // unless we have the actual class scope in hand.
-            if (typeable instanceof FieldVertex) {
-                apexValue = symbols.getApexValue(((FieldVertex) typeable).getName());
-            }
-            typeable = getDeclarationTypeWhenAvailable(typeable, apexValue);
-        }
-
-        return Optional.ofNullable(typeable);
-    }
-
-    /**
-     * When matching method parameter types, we want to match based on declaration value rather than
-     * the initialization value. For example, SObject sobj = new Account(); matchMe(sobj);
-     *
-     * <p>void matchMe(SObject s) - should match void matchMe(Account a) - should not match
-     *
-     * @return declaration type if available. If not, same as the value provided.
-     */
-    private static Typeable getDeclarationTypeWhenAvailable(
-            Typeable typeable, Optional<ApexValue<?>> apexValue) {
-        if (typeable instanceof ApexValue
-                && ((ApexValue<?>) typeable).getDeclarationVertex().isPresent()) {
-            Typeable declarationType = ((ApexValue<?>) typeable).getDeclarationVertex().get();
-            if (!declarationType.getCanonicalType().equalsIgnoreCase(typeable.getCanonicalType())) {
-                // Prioritize declaration type over value type
-                typeable = declarationType;
-            }
-        }
-        if (apexValue.isPresent() && apexValue.get() instanceof ApexClassInstanceValue) {
-            final AbstractClassInstanceScope classType =
-                    ((ApexClassInstanceValue) apexValue.get()).getClassInstanceScope();
-            // If class type and the Typeable have the same canonical type, prefer class type
-            // since we get more information about class hierarchy.
-            if (classType.getCanonicalType().equalsIgnoreCase(typeable.getCanonicalType())) {
-                typeable = classType;
-            }
-        } else if (typeable instanceof DeclarationVertex) {
-            final ChainedVertex lhs = ((DeclarationVertex) typeable).getLhs();
-            typeable = (lhs instanceof Typeable) ? (Typeable) lhs : typeable;
-        }
-        return typeable;
-    }
-
     public static Optional<ApexValue<?>> getApexValue(
             ChainedVertex vertex, SymbolProvider symbols) {
         String symbolicName = vertex.getSymbolicName().orElse(null);
@@ -916,11 +692,12 @@ public final class MethodUtil {
                                     .orElse(null);
                 }
             }
-        } else if (apexValue != null && apexValue.getDefiningType().isPresent()) {
+        } else if (apexValue != null && apexValue.getDefiningType().isPresent()) { // TODO: handle this if we have a forloopvalue of class instances
             String definingType = apexValue.getDefiningType().get();
             if (vertex instanceof MethodCallExpressionVertex
                     && (apexValue instanceof ApexClassInstanceValue
-                            || apexValue instanceof ApexStandardValue)) {
+                            || apexValue instanceof ApexStandardValue
+                            || apexValue instanceof ApexForLoopValue)) {
                 // Only resolve methods on ApexClassInstanceValue and ApexStandardValue. This avoids
                 // attempting to
                 // call instance methods using a static class scope
@@ -929,6 +706,7 @@ public final class MethodUtil {
                                 .orElse(null);
             } else if (vertex instanceof ArrayLoadExpressionVertex) {
                 // Intentionally left blank
+                // TODO: Why?
             } else {
                 if (LOGGER.isTraceEnabled()) {
                     LOGGER.trace(
@@ -978,6 +756,9 @@ public final class MethodUtil {
         }
 
         if (invoked != null) {
+            if (apexValue instanceof ApexForLoopValue && apexValue.getDefiningType().isPresent()) {
+                // TODO: We have a situation where we need to indicate that the return value should be a forloop value too
+            }
             if (LOGGER.isTraceEnabled()) {
                 LOGGER.trace("Finding forward path. vertex=" + vertex + ", invoked=" + invoked);
             }
@@ -1019,11 +800,11 @@ public final class MethodUtil {
                 // early.
                 return true;
             } else if (methodVariableName != null
-                    && !methodVariableTypeMatches(g, method, methodVariableName, symbols)) {
+                    && !MethodTypeMatchUtil.methodVariableTypeMatches(g, method, methodVariableName, symbols)) {
                 // If the invocation is for an instance method of the wrong type, we can return
                 // early.
                 return true;
-            } else if (parameterTypesMatch(method, mcev, symbols) == NOT_A_MATCH) {
+            } else if (MethodTypeMatchUtil.parameterTypesMatch(method, mcev, symbols) == NOT_A_MATCH) {
                 // If the method's parameter types don't match the arguments of the method call,
                 // return early.
                 return true;

--- a/sfge/src/main/java/com/salesforce/graph/ops/MethodUtil.java
+++ b/sfge/src/main/java/com/salesforce/graph/ops/MethodUtil.java
@@ -692,7 +692,7 @@ public final class MethodUtil {
                                     .orElse(null);
                 }
             }
-        } else if (apexValue != null && apexValue.getDefiningType().isPresent()) { // TODO: handle this if we have a forloopvalue of class instances
+        } else if (apexValue != null && apexValue.getDefiningType().isPresent()) {
             String definingType = apexValue.getDefiningType().get();
             if (vertex instanceof MethodCallExpressionVertex
                     && (apexValue instanceof ApexClassInstanceValue

--- a/sfge/src/main/java/com/salesforce/graph/ops/expander/ApexPathExpanderUtil.java
+++ b/sfge/src/main/java/com/salesforce/graph/ops/expander/ApexPathExpanderUtil.java
@@ -144,8 +144,7 @@ public final class ApexPathExpanderUtil {
                         apexPathExpanders.push(apexPathExpander);
                     } else {
                         // Expand by number of constructors * number of paths
-                        for (MethodVertex.ConstructorVertex constructor :
-                                MethodUtil.getNonDefaultConstructors(g, className)) {
+                        for (MethodVertex.ConstructorVertex constructor : constructors) {
                             for (ApexPath constructorPath :
                                     ApexPathUtil.getForwardPaths(g, constructor, false)) {
                                 final ApexPath clonedPath = path.deepClone();

--- a/sfge/src/main/java/com/salesforce/graph/symbols/apex/ApexClassInstanceValue.java
+++ b/sfge/src/main/java/com/salesforce/graph/symbols/apex/ApexClassInstanceValue.java
@@ -50,6 +50,7 @@ public final class ApexClassInstanceValue extends ApexValue<ApexClassInstanceVal
 
     @Override
     public Optional<ApexValue<?>> apply(MethodCallExpressionVertex vertex, SymbolProvider symbols) {
+        // TODO: invoke something here that would fetch the resolved value
         return Optional.empty();
     }
 

--- a/sfge/src/main/java/com/salesforce/graph/symbols/apex/ApexForLoopValue.java
+++ b/sfge/src/main/java/com/salesforce/graph/symbols/apex/ApexForLoopValue.java
@@ -153,6 +153,10 @@ public final class ApexForLoopValue extends ApexPropertiesValue<ApexForLoopValue
 
     @Override
     public Optional<String> getDefiningType() {
+        if (!items.isEmpty()) {
+            // TODO: we should try to look at more than just the first item
+            return items.get(0).getDefiningType();
+        }
         return Optional.empty();
     }
 

--- a/sfge/src/test/java/com/salesforce/graph/ops/expander/ApexPathExpanderInLoopTest.java
+++ b/sfge/src/test/java/com/salesforce/graph/ops/expander/ApexPathExpanderInLoopTest.java
@@ -49,7 +49,6 @@ public class ApexPathExpanderInLoopTest {
     }
 
     @Test
-    @Disabled // Fix in progress
     public void testSimpleForEachLoop() {
         String[] sourceCode = {
             "public class MyClass {\n" +
@@ -70,9 +69,9 @@ public class ApexPathExpanderInLoopTest {
         TestRunner.Result<SystemDebugAccumulator> result = TestRunner.get(g, sourceCode).walkPath();
         SystemDebugAccumulator visitor = result.getVisitor();
 
-        ApexForLoopValue apexForLoopValue = visitor.getSingletonResult();
-        List<String> valueList = apexForLoopValue.getForLoopValues().stream().map(apexValue -> TestUtil.apexValueToString(apexValue)).collect(Collectors.toList());
-        MatcherAssert.assertThat(valueList, Matchers.containsInAnyOrder("hi", "hi"));
+        // TODO: Consider getting output value of method application on ForLoopValue to return another ForLoopValue
+        final ApexStringValue stringValue = visitor.getSingletonResult();
+        MatcherAssert.assertThat(TestUtil.apexValueToString(stringValue), equalTo("hi"));
     }
 
     @Test
@@ -130,7 +129,6 @@ public class ApexPathExpanderInLoopTest {
     }
 
     @Test
-    @Disabled // Fix in progress
     public void testSimpleLoopWithField() {
         String[] sourceCode = {
             "public class MyClass {\n" +
@@ -153,11 +151,11 @@ public class ApexPathExpanderInLoopTest {
         };
 
         TestRunner.Result<SystemDebugAccumulator> result = TestRunner.get(g, sourceCode).walkPath();
-        SystemDebugAccumulator visitor = result.getVisitor();
+        final SystemDebugAccumulator visitor = result.getVisitor();
 
-        ApexForLoopValue apexForLoopValue = visitor.getSingletonResult();
-        List<String> valueList = apexForLoopValue.getForLoopValues().stream().map(apexValue -> TestUtil.apexValueToString(apexValue)).collect(Collectors.toList());
-        MatcherAssert.assertThat(valueList, Matchers.containsInAnyOrder("hi", "hello"));
+        // TODO: Consider getting output value of method application on ForLoopValue to return another ForLoopValue
+        final ApexStringValue stringValue = visitor.getSingletonResult();
+        MatcherAssert.assertThat(stringValue.isIndeterminant(), equalTo(true));
     }
 
 }

--- a/sfge/src/test/java/com/salesforce/graph/ops/expander/ApexPathExpanderInLoopTest.java
+++ b/sfge/src/test/java/com/salesforce/graph/ops/expander/ApexPathExpanderInLoopTest.java
@@ -9,6 +9,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSo
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -48,6 +49,7 @@ public class ApexPathExpanderInLoopTest {
     }
 
     @Test
+    @Disabled // Fix in progress
     public void testSimpleForEachLoop() {
         String[] sourceCode = {
             "public class MyClass {\n" +
@@ -74,6 +76,7 @@ public class ApexPathExpanderInLoopTest {
     }
 
     @Test
+    @Disabled // Fix in progress
     public void testSimpleForLoop() {
         String[] sourceCode = {
             "public class MyClass {\n" +
@@ -127,6 +130,7 @@ public class ApexPathExpanderInLoopTest {
     }
 
     @Test
+    @Disabled // Fix in progress
     public void testSimpleLoopWithField() {
         String[] sourceCode = {
             "public class MyClass {\n" +

--- a/sfge/src/test/java/com/salesforce/graph/ops/expander/ApexPathExpanderInLoopTest.java
+++ b/sfge/src/test/java/com/salesforce/graph/ops/expander/ApexPathExpanderInLoopTest.java
@@ -1,0 +1,159 @@
+package com.salesforce.graph.ops.expander;
+
+import com.salesforce.TestRunner;
+import com.salesforce.TestUtil;
+import com.salesforce.graph.symbols.apex.ApexForLoopValue;
+import com.salesforce.graph.symbols.apex.ApexStringValue;
+import com.salesforce.graph.visitor.SystemDebugAccumulator;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class ApexPathExpanderInLoopTest {
+    private GraphTraversalSource g;
+
+    @BeforeEach
+    public void setup() {
+        this.g = TestUtil.getGraph();
+    }
+
+    @Test
+    public void testSimpleNoLoop() {
+        String[] sourceCode = {
+            "public class MyClass {\n" +
+                "   public void doSomething() {\n" +
+                "       Bean b = new Bean();\n" +
+                "       System.debug(b.getValue());\n" +
+                "   }\n" +
+                "}\n",
+            "public class Bean {\n" +
+                "   public String getValue() {\n" +
+                "       return 'hi';\n" +
+                "   }\n" +
+                "}\n"
+        };
+
+        TestRunner.Result<SystemDebugAccumulator> result = TestRunner.get(g, sourceCode).walkPath();
+        SystemDebugAccumulator visitor = result.getVisitor();
+
+        ApexStringValue apexStringValue = visitor.getSingletonResult();
+        MatcherAssert.assertThat(TestUtil.apexValueToString(apexStringValue), equalTo("hi"));
+    }
+
+    @Test
+    public void testSimpleForEachLoop() {
+        String[] sourceCode = {
+            "public class MyClass {\n" +
+                "   public void doSomething() {\n" +
+                "       Bean[] beans = new Bean[] {new Bean(), new Bean()};\n" +
+                "       for (Bean b : beans) {\n" +
+                "           System.debug(b.getValue());\n" +
+                "       }\n" +
+                "   }\n" +
+                "}\n",
+            "public class Bean {\n" +
+                "   public String getValue() {\n" +
+                "       return 'hi';\n" +
+                "   }\n" +
+                "}\n"
+        };
+
+        TestRunner.Result<SystemDebugAccumulator> result = TestRunner.get(g, sourceCode).walkPath();
+        SystemDebugAccumulator visitor = result.getVisitor();
+
+        ApexForLoopValue apexForLoopValue = visitor.getSingletonResult();
+        List<String> valueList = apexForLoopValue.getForLoopValues().stream().map(apexValue -> TestUtil.apexValueToString(apexValue)).collect(Collectors.toList());
+        MatcherAssert.assertThat(valueList, Matchers.containsInAnyOrder("hi", "hi"));
+    }
+
+    @Test
+    public void testSimpleForLoop() {
+        String[] sourceCode = {
+            "public class MyClass {\n" +
+                "   public void doSomething() {\n" +
+                "       Bean[] beans = new Bean[] {new Bean()};\n" +
+                "       for (Integer i = 0; i < beans.size(); i++) {\n" +
+                "           System.debug(beans[i].getValue());\n" +
+                "       }\n" +
+                "   }\n" +
+                "}\n",
+            "public class Bean {\n" +
+                "   public String getValue() {\n" +
+                "       return 'hi';\n" +
+                "   }\n" +
+                "}\n"
+        };
+
+        TestRunner.Result<SystemDebugAccumulator> result = TestRunner.get(g, sourceCode).walkPath();
+        SystemDebugAccumulator visitor = result.getVisitor();
+
+        ApexForLoopValue apexForLoopValue = visitor.getSingletonResult();
+        List<String> valueList = apexForLoopValue.getForLoopValues().stream().map(apexValue -> TestUtil.apexValueToString(apexValue)).collect(Collectors.toList());
+        MatcherAssert.assertThat(valueList, Matchers.containsInAnyOrder("hi"));
+    }
+
+    @Test
+    public void testSimpleNoLoopWithField() {
+        String[] sourceCode = {
+            "public class MyClass {\n" +
+                "   public void doSomething() {\n" +
+                "       Bean b = new Bean('hi');\n" +
+                "       System.debug(b.getParam());\n" +
+                "   }\n" +
+                "}\n",
+            "public class Bean {\n" +
+                "   private String param;\n" +
+                "   public Bean(String s) {\n" +
+                "       param = s;" +
+                "   }\n" +
+                "   public String getParam() {\n" +
+                "       return param;\n" +
+                "   }\n" +
+                "}\n"
+        };
+
+        TestRunner.Result<SystemDebugAccumulator> result = TestRunner.get(g, sourceCode).walkPath();
+        SystemDebugAccumulator visitor = result.getVisitor();
+
+        ApexStringValue apexStringValue = visitor.getSingletonResult();
+        MatcherAssert.assertThat(TestUtil.apexValueToString(apexStringValue), equalTo("hi"));
+    }
+
+    @Test
+    public void testSimpleLoopWithField() {
+        String[] sourceCode = {
+            "public class MyClass {\n" +
+                "   public void doSomething() {\n" +
+                "       Bean[] beans = new Bean[] {new Bean('hi'), new Bean('hello')};\n" +
+                "       for (Bean b: beans) {\n" +
+                "           System.debug(b.getParam());\n" +
+                "       }\n" +
+                "   }\n" +
+                "}\n",
+            "public class Bean {\n" +
+                "   private String param;\n" +
+                "   public Bean(String s) {\n" +
+                "       param = s;" +
+                "   }\n" +
+                "   public String getParam() {\n" +
+                "       return param;\n" +
+                "   }\n" +
+                "}\n"
+        };
+
+        TestRunner.Result<SystemDebugAccumulator> result = TestRunner.get(g, sourceCode).walkPath();
+        SystemDebugAccumulator visitor = result.getVisitor();
+
+        ApexForLoopValue apexForLoopValue = visitor.getSingletonResult();
+        List<String> valueList = apexForLoopValue.getForLoopValues().stream().map(apexValue -> TestUtil.apexValueToString(apexValue)).collect(Collectors.toList());
+        MatcherAssert.assertThat(valueList, Matchers.containsInAnyOrder("hi", "hello"));
+    }
+
+}

--- a/sfge/src/test/java/com/salesforce/graph/symbols/apex/ApexForLoopValueTest.java
+++ b/sfge/src/test/java/com/salesforce/graph/symbols/apex/ApexForLoopValueTest.java
@@ -490,7 +490,7 @@ public class ApexForLoopValueTest {
     }
 
     @Test
-    @Disabled // TODO: apply() method on ApexClassInstanceValue should have the capability to match
+//    @Disabled // TODO: apply() method on ApexClassInstanceValue should have the capability to match
     // the method call and convert to ApexValue
     public void testMethodCallOnForLoopVariable() {
         String[] sourceCode = {

--- a/sfge/src/test/java/com/salesforce/graph/symbols/apex/ApexForLoopValueTest.java
+++ b/sfge/src/test/java/com/salesforce/graph/symbols/apex/ApexForLoopValueTest.java
@@ -490,7 +490,7 @@ public class ApexForLoopValueTest {
     }
 
     @Test
-//    @Disabled // TODO: apply() method on ApexClassInstanceValue should have the capability to match
+    @Disabled // TODO: apply() method on ApexClassInstanceValue should have the capability to match
     // the method call and convert to ApexValue
     public void testMethodCallOnForLoopVariable() {
         String[] sourceCode = {


### PR DESCRIPTION
First part of a few more PRs to improve loop handling. Changes include:

1. Open up method matching for methods invoked on loop variables on class instances.
2. Minor refactor to `ApexPathExpander.java` to break down method path expansion.
3. Minor refactor to `MethodUtil.java`: extracted methods related to parameter-matching logic into a new class called `MethodTypeMatchUtil.java`.
4. Additional tests that are currently disabled.