### PR TITLE
CHANGE (GraphEngine): @W-13123571@: Handle method invocations made directly on iterated array item

### DIFF
--- a/sfge/src/main/java/com/salesforce/graph/ops/MethodUtil.java
+++ b/sfge/src/main/java/com/salesforce/graph/ops/MethodUtil.java
@@ -619,7 +619,6 @@ public final class MethodUtil {
                                 .orElse(null);
             } else if (vertex instanceof ArrayLoadExpressionVertex) {
                 // Intentionally left blank
-                // TODO: Why?
             } else {
                 if (LOGGER.isTraceEnabled()) {
                     LOGGER.trace(
@@ -641,7 +640,6 @@ public final class MethodUtil {
                 final String methodName = methodCallExpression.getMethodName();
                 String fullMethodName = methodCallExpression.getFullMethodName();
                 if (methodName.equals(fullMethodName)) {
-                    // TODO: Method invoked on ArrayLoadExpression is incorrectly getting in here
                     // The method is being called on a class onto itself
                     definingType = vertex.getDefiningType();
                 } else {

--- a/sfge/src/main/java/com/salesforce/graph/ops/MethodUtil.java
+++ b/sfge/src/main/java/com/salesforce/graph/ops/MethodUtil.java
@@ -12,11 +12,7 @@ import com.salesforce.graph.ApexPath;
 import com.salesforce.graph.Schema;
 import com.salesforce.graph.build.CaseSafePropertyUtil.H;
 import com.salesforce.graph.ops.expander.ApexPathExpanderConfig;
-import com.salesforce.graph.symbols.AbstractClassScope;
-import com.salesforce.graph.symbols.ContextProviders;
-import com.salesforce.graph.symbols.DefaultSymbolProviderVertexVisitor;
-import com.salesforce.graph.symbols.MethodInvocationScope;
-import com.salesforce.graph.symbols.SymbolProvider;
+import com.salesforce.graph.symbols.*;
 import com.salesforce.graph.symbols.apex.ApexClassInstanceValue;
 import com.salesforce.graph.symbols.apex.ApexForLoopValue;
 import com.salesforce.graph.symbols.apex.ApexStandardValue;
@@ -531,6 +527,16 @@ public final class MethodUtil {
             apexValue = symbols.getReturnedValue((InvocableVertex) vertex).orElse(null);
         }
 
+        if (apexValue == null && vertex instanceof MethodCallExpressionVertex) {
+            final Optional<ArrayLoadExpressionVertex> arrayExpressionVertex =
+                    ((MethodCallExpressionVertex) vertex).getArrayInvocation();
+            if (arrayExpressionVertex.isPresent()) {
+                apexValue =
+                        ScopeUtil.resolveToApexValue(symbols, arrayExpressionVertex.get())
+                                .orElse(null);
+            }
+        }
+
         return Optional.ofNullable(apexValue);
     }
 
@@ -635,6 +641,7 @@ public final class MethodUtil {
                 final String methodName = methodCallExpression.getMethodName();
                 String fullMethodName = methodCallExpression.getFullMethodName();
                 if (methodName.equals(fullMethodName)) {
+                    // TODO: Method invoked on ArrayLoadExpression is incorrectly getting in here
                     // The method is being called on a class onto itself
                     definingType = vertex.getDefiningType();
                 } else {

--- a/sfge/src/main/java/com/salesforce/graph/symbols/PathScopeVisitor.java
+++ b/sfge/src/main/java/com/salesforce/graph/symbols/PathScopeVisitor.java
@@ -1427,6 +1427,7 @@ public abstract class PathScopeVisitor extends BaseScopeVisitor<PathScopeVisitor
         ApexValue<?> apexValue = null;
 
         InvocableWithParametersVertex previous = vertex.getPrevious().orElse(null);
+        ArrayLoadExpressionVertex arrayInvocation = vertex.getArrayInvocation().orElse(null);
         if (previous instanceof SoqlExpressionVertex) {
             // Handle chained SOQL expressions that were not assigned to a variable
             // i.e. return [SELECT Id FROM MyObject__c].isEmpty();
@@ -1435,6 +1436,10 @@ public abstract class PathScopeVisitor extends BaseScopeVisitor<PathScopeVisitor
             // The method is being called on a chain
             // SObjectType sot = Schema.getGlobalDescribe().get('Account');
             apexValue = getReturnedValue(previous).orElse(null);
+        } else if (arrayInvocation != null) {
+            // The method call is made on an array expression
+            // items[i].toLowerCase();
+            apexValue = ScopeUtil.resolveToApexValue(this, arrayInvocation).orElse(null);
         } else {
             String symbolicName = vertex.getSymbolicName().orElse(null);
             if (symbolicName != null) {

--- a/sfge/src/main/java/com/salesforce/graph/vertex/MethodCallExpressionVertex.java
+++ b/sfge/src/main/java/com/salesforce/graph/vertex/MethodCallExpressionVertex.java
@@ -273,6 +273,17 @@ public class MethodCallExpressionVertex extends InvocableWithParametersVertex
         return (String) properties.get(Schema.METHOD_NAME);
     }
 
+    /**
+     * @return Optional value of ArrayLoadExpressionVertex if the method call was made on an array
+     *     expression such as list[i].doSomething().
+     */
+    public Optional<ArrayLoadExpressionVertex> getArrayInvocation() {
+        AbstractReferenceExpressionVertex referenceExpression = getReferenceExpression();
+        ArrayLoadExpressionVertex arrayExpressionVertex =
+                referenceExpression.getOnlyChildOrNull(NodeType.ARRAY_LOAD_EXPRESSION);
+        return Optional.ofNullable(arrayExpressionVertex);
+    }
+
     @Override
     public <T> T accept(TypedVertexVisitor<T> visitor) {
         return visitor.visit(this);

--- a/sfge/src/test/java/com/salesforce/TestUtil.java
+++ b/sfge/src/test/java/com/salesforce/TestUtil.java
@@ -69,7 +69,7 @@ public final class TestUtil {
     public static final String RENDER_XML_ENV_VAR_NAME = "SFGE_RENDER_XML";
 
     private static final boolean RENDER_XML =
-            Boolean.parseBoolean(System.getenv().getOrDefault(RENDER_XML_ENV_VAR_NAME, "true"));
+            Boolean.parseBoolean(System.getenv().getOrDefault(RENDER_XML_ENV_VAR_NAME, "false"));
 
     /** Support for multi threaded tests requires its own GraphTraversalSource */
     private static final ThreadLocal<GraphTraversalSource> THREAD_LOCAL_GRAPHS =

--- a/sfge/src/test/java/com/salesforce/TestUtil.java
+++ b/sfge/src/test/java/com/salesforce/TestUtil.java
@@ -69,7 +69,7 @@ public final class TestUtil {
     public static final String RENDER_XML_ENV_VAR_NAME = "SFGE_RENDER_XML";
 
     private static final boolean RENDER_XML =
-            Boolean.parseBoolean(System.getenv().getOrDefault(RENDER_XML_ENV_VAR_NAME, "false"));
+            Boolean.parseBoolean(System.getenv().getOrDefault(RENDER_XML_ENV_VAR_NAME, "true"));
 
     /** Support for multi threaded tests requires its own GraphTraversalSource */
     private static final ThreadLocal<GraphTraversalSource> THREAD_LOCAL_GRAPHS =

--- a/sfge/src/test/java/com/salesforce/graph/build/MethodUtilCollectionTest.java
+++ b/sfge/src/test/java/com/salesforce/graph/build/MethodUtilCollectionTest.java
@@ -1,11 +1,13 @@
 package com.salesforce.graph.build;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.*;
 
 import com.salesforce.TestRunner;
 import com.salesforce.TestUtil;
+import com.salesforce.graph.symbols.apex.ApexClassInstanceValue;
+import com.salesforce.graph.symbols.apex.ApexForLoopValue;
+import com.salesforce.graph.symbols.apex.ApexStringValue;
 import com.salesforce.graph.symbols.apex.ApexValue;
 import com.salesforce.graph.visitor.SystemDebugAccumulator;
 import java.util.List;
@@ -560,5 +562,52 @@ public class MethodUtilCollectionTest {
         SystemDebugAccumulator visitor = result.getVisitor();
 
         assertThat(visitor.getSingletonResult(), Matchers.notNullValue());
+    }
+
+    @Test
+    public void testForLoopOnArrayExpressionLookup() {
+        String sourceCode =
+                "public class MyClass {\n"
+                        + "   void doSomething() {\n"
+                        + "       String[] myList = new String[] {'hi'};\n"
+                        + "       for (Integer i = 0; i < myList.size(); i++) {\n"
+                        + "           System.debug(myList[i]);\n"
+                        + "       }\n"
+                        + "   }\n"
+                        + "}\n";
+
+        TestRunner.Result<SystemDebugAccumulator> result = TestRunner.walkPath(g, sourceCode);
+        SystemDebugAccumulator visitor = result.getVisitor();
+
+        // TODO: Why doesn't this get treated as a ApexForLoopValue?
+        final ApexForLoopValue forLoopValue = visitor.getSingletonResult();
+        final List<ApexValue<?>> items = forLoopValue.getForLoopValues();
+        assertThat(items.size(), equalTo(1));
+        final ApexStringValue stringValue = (ApexStringValue) items.get(0);
+        assertThat(TestUtil.apexValueToString(stringValue), equalTo("hi"));
+    }
+
+    @Test
+    public void testForLoopOnArrayExpressionLookup_classInstance() {
+        String sourceCode[] = {
+            "public class MyClass {\n"
+                    + "   void doSomething() {\n"
+                    + "       Bean[] beans = new Bean[] {new Bean()};\n"
+                    + "       for (Integer i = 0; i < beans.size(); i++) {\n"
+                    + "           System.debug(beans[i]);\n"
+                    + "       }\n"
+                    + "   }\n"
+                    + "}\n",
+            "public class Bean {}\n"
+        };
+
+        TestRunner.Result<SystemDebugAccumulator> result = TestRunner.walkPath(g, sourceCode);
+        SystemDebugAccumulator visitor = result.getVisitor();
+
+        final ApexForLoopValue forLoopValue = visitor.getSingletonResult();
+        List<ApexValue<?>> items = forLoopValue.getForLoopValues();
+        assertThat(items.size(), equalTo(1));
+        final ApexClassInstanceValue classInstanceValue = (ApexClassInstanceValue) items.get(0);
+        assertThat(classInstanceValue.getDefiningType().orElse(""), equalTo("Bean"));
     }
 }

--- a/sfge/src/test/java/com/salesforce/graph/build/MethodUtilCollectionTest.java
+++ b/sfge/src/test/java/com/salesforce/graph/build/MethodUtilCollectionTest.java
@@ -579,7 +579,6 @@ public class MethodUtilCollectionTest {
         TestRunner.Result<SystemDebugAccumulator> result = TestRunner.walkPath(g, sourceCode);
         SystemDebugAccumulator visitor = result.getVisitor();
 
-        // TODO: Why doesn't this get treated as a ApexForLoopValue?
         final ApexForLoopValue forLoopValue = visitor.getSingletonResult();
         final List<ApexValue<?>> items = forLoopValue.getForLoopValues();
         assertThat(items.size(), equalTo(1));

--- a/sfge/src/test/java/com/salesforce/graph/ops/expander/ApexPathExpanderInLoopTest.java
+++ b/sfge/src/test/java/com/salesforce/graph/ops/expander/ApexPathExpanderInLoopTest.java
@@ -9,6 +9,7 @@ import com.salesforce.graph.symbols.apex.ApexBooleanValue;
 import com.salesforce.graph.symbols.apex.ApexForLoopValue;
 import com.salesforce.graph.symbols.apex.ApexStringValue;
 import com.salesforce.graph.symbols.apex.ApexValue;
+import com.salesforce.graph.vertex.ChainedVertex;
 import com.salesforce.graph.vertex.MethodCallExpressionVertex;
 import com.salesforce.graph.visitor.SystemDebugAccumulator;
 import java.util.List;
@@ -31,12 +32,15 @@ import org.junit.jupiter.api.Test;
  * </ul>
  *
  * Even though we'd ideally prefer to have all of them treated the same way, we are currently
- * treating them differently. Category 3 (Method invocation on instances of classes) require path
- * expansion to understand what value is returned, but Categories 1 and 2 have predetermined methods
- * whose value we derive directly within Graph Engine (for example, toLowerCase() on a String
- * primitive). This leads to Categories 1 & 2 returning an ApexForLoopValue when a method is invoked
- * on them during iteration (see {@link ApexForLoopValue#apply(MethodCallExpressionVertex,
- * SymbolProvider)}) and Category 3 returning a non-loop value when a method is invoked on it.
+ * treating them differently. Category 3 (Method invocation on instances of classes) requires path
+ * expansion to understand what value is returned, but Categories 1 and 2 have a known set of
+ * methods - we derive their return values directly within Graph Engine (for example, toLowerCase()
+ * on a String primitive). This leads to Categories 1 & 2 returning an ApexForLoopValue when a
+ * method is invoked on them during iteration (see {@link
+ * ApexForLoopValue#apply(MethodCallExpressionVertex, SymbolProvider)}) and Category 3 returning a
+ * non-loop value when a method is invoked on it (see {@link
+ * com.salesforce.graph.ops.MethodUtil#getPaths(GraphTraversalSource, ChainedVertex,
+ * SymbolProvider)}).
  *
  * <p>While For-loop and ForEach-loop are well-structured, While-loops don't clearly state what's
  * iterated. Because of this shortcoming, we don't give loop-treatment to method calls made inside a

--- a/sfge/src/test/java/com/salesforce/graph/ops/expander/ApexPathExpanderInLoopTest.java
+++ b/sfge/src/test/java/com/salesforce/graph/ops/expander/ApexPathExpanderInLoopTest.java
@@ -4,8 +4,12 @@ import static org.hamcrest.Matchers.equalTo;
 
 import com.salesforce.TestRunner;
 import com.salesforce.TestUtil;
+import com.salesforce.graph.symbols.SymbolProvider;
+import com.salesforce.graph.symbols.apex.ApexBooleanValue;
 import com.salesforce.graph.symbols.apex.ApexForLoopValue;
 import com.salesforce.graph.symbols.apex.ApexStringValue;
+import com.salesforce.graph.symbols.apex.ApexValue;
+import com.salesforce.graph.vertex.MethodCallExpressionVertex;
 import com.salesforce.graph.visitor.SystemDebugAccumulator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -13,9 +17,33 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSo
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+/**
+ * Tests verifying behavior of method calls made on iterated items. The types of values iterated
+ * belong to three categories:
+ *
+ * <ul>
+ *   <li>1. Primitives such as String, Integer.
+ *   <li>2. Apex Standard Library classes such as Schema.DescribeFieldResult, Schema.SObjectType,
+ *       etc.
+ *   <li>3. Instances of classes defined within source code.
+ * </ul>
+ *
+ * Even though we'd ideally prefer to have all of them treated the same way, we are currently
+ * treating them differently. Category 3 (Method invocation on instances of classes) require path
+ * expansion to understand what value is returned, but Categories 1 and 2 have predetermined methods
+ * whose value we derive directly within Graph Engine (for example, toLowerCase() on a String
+ * primitive). This leads to Categories 1 & 2 returning an ApexForLoopValue when a method is invoked
+ * on them during iteration (see {@link ApexForLoopValue#apply(MethodCallExpressionVertex,
+ * SymbolProvider)}) and Category 3 returning a non-loop value when a method is invoked on it.
+ *
+ * <p>While For-loop and ForEach-loop are well-structured, While-loops don't clearly state what's
+ * iterated. Because of this shortcoming, we don't give loop-treatment to method calls made inside a
+ * While-loop. This should be addressed in the future.
+ *
+ * <p>The tests in this class have various cases enumerating the explanation above.
+ */
 public class ApexPathExpanderInLoopTest {
     private GraphTraversalSource g;
 
@@ -69,13 +97,113 @@ public class ApexPathExpanderInLoopTest {
         SystemDebugAccumulator visitor = result.getVisitor();
 
         // TODO: Consider getting output value of method application on ForLoopValue to return
-        // another ForLoopValue
+        //  another ForLoopValue
         final ApexStringValue stringValue = visitor.getSingletonResult();
         MatcherAssert.assertThat(TestUtil.apexValueToString(stringValue), equalTo("hi"));
     }
 
     @Test
-    @Disabled // Fix in progress
+    public void testForLoopWithPrimitive() {
+        String[] sourceCode = {
+            "public class MyClass {\n"
+                    + "   public void doSomething() {\n"
+                    + "       String[] myList = new String[] {' hi '};\n"
+                    + "       for (Integer i = 0; i < myList.size(); i++) {\n"
+                    + "           System.debug(myList[i].trim());\n"
+                    + "       }\n"
+                    + "   }\n"
+                    + "}\n"
+        };
+
+        TestRunner.Result<SystemDebugAccumulator> result = TestRunner.get(g, sourceCode).walkPath();
+        SystemDebugAccumulator visitor = result.getVisitor();
+
+        ApexForLoopValue apexForLoopValue = visitor.getSingletonResult();
+        List<String> valueList =
+                apexForLoopValue.getForLoopValues().stream()
+                        .map(apexValue -> TestUtil.apexValueToString(apexValue))
+                        .collect(Collectors.toList());
+        MatcherAssert.assertThat(valueList, Matchers.containsInAnyOrder("hi"));
+    }
+
+    @Test
+    public void testWhileLoopWithPrimitive() {
+        String[] sourceCode = {
+            "public class MyClass {\n"
+                    + "   public void doSomething() {\n"
+                    + "       String[] myList = new String[] {' hi '};\n"
+                    + "       Integer i = 0;\n"
+                    + "       while (i < myList.size()) {\n"
+                    + "           System.debug(myList[i].trim());\n"
+                    + "           i++;\n"
+                    + "       }\n"
+                    + "   }\n"
+                    + "}\n"
+        };
+
+        TestRunner.Result<SystemDebugAccumulator> result = TestRunner.get(g, sourceCode).walkPath();
+        SystemDebugAccumulator visitor = result.getVisitor();
+
+        // TODO: Detect while-loop iteration and create ApexForLoopValue (new name?) for the
+        // iterated item.
+        final ApexStringValue stringValue = visitor.getSingletonResult();
+        MatcherAssert.assertThat(TestUtil.apexValueToString(stringValue), equalTo("hi"));
+    }
+
+    @Test
+    public void testForEachLoopWithPrimitive() {
+        String[] sourceCode = {
+            "public class MyClass {\n"
+                    + "   public void doSomething() {\n"
+                    + "       String[] myList = new String[] {' hi '};\n"
+                    + "       for (String s : myList) {\n"
+                    + "           System.debug(s.trim());\n"
+                    + "       }\n"
+                    + "   }\n"
+                    + "}\n"
+        };
+
+        TestRunner.Result<SystemDebugAccumulator> result = TestRunner.get(g, sourceCode).walkPath();
+        SystemDebugAccumulator visitor = result.getVisitor();
+
+        ApexForLoopValue apexForLoopValue = visitor.getSingletonResult();
+        List<String> valueList =
+                apexForLoopValue.getForLoopValues().stream()
+                        .map(apexValue -> TestUtil.apexValueToString(apexValue))
+                        .collect(Collectors.toList());
+        MatcherAssert.assertThat(valueList, Matchers.containsInAnyOrder("hi"));
+    }
+
+    @Test
+    public void testSimpleForLoop_withTempVariable() {
+        String[] sourceCode = {
+            "public class MyClass {\n"
+                    + "   public void doSomething() {\n"
+                    + "       Bean[] beans = new Bean[] {new Bean()};\n"
+                    + "       for (Integer i = 0; i < beans.size(); i++) {\n"
+                    + "           Bean bean1 = beans[i];"
+                    + "           System.debug(bean1.getValue());\n"
+                    + "       }\n"
+                    + "   }\n"
+                    + "}\n",
+            "public class Bean {\n"
+                    + "   public String getValue() {\n"
+                    + "       return 'hi';\n"
+                    + "   }\n"
+                    + "}\n"
+        };
+
+        TestRunner.Result<SystemDebugAccumulator> result = TestRunner.get(g, sourceCode).walkPath();
+        SystemDebugAccumulator visitor = result.getVisitor();
+
+        // TODO: Consider getting output value of method application on ForLoopValue to return
+        //  another ForLoopValue
+
+        ApexStringValue stringValue = visitor.getSingletonResult();
+        MatcherAssert.assertThat(TestUtil.apexValueToString(stringValue), equalTo("hi"));
+    }
+
+    @Test
     public void testSimpleForLoop() {
         String[] sourceCode = {
             "public class MyClass {\n"
@@ -96,12 +224,11 @@ public class ApexPathExpanderInLoopTest {
         TestRunner.Result<SystemDebugAccumulator> result = TestRunner.get(g, sourceCode).walkPath();
         SystemDebugAccumulator visitor = result.getVisitor();
 
-        ApexForLoopValue apexForLoopValue = visitor.getSingletonResult();
-        List<String> valueList =
-                apexForLoopValue.getForLoopValues().stream()
-                        .map(apexValue -> TestUtil.apexValueToString(apexValue))
-                        .collect(Collectors.toList());
-        MatcherAssert.assertThat(valueList, Matchers.containsInAnyOrder("hi"));
+        // TODO: Consider getting output value of method application on ForLoopValue to return
+        //  another ForLoopValue
+
+        ApexStringValue stringValue = visitor.getSingletonResult();
+        MatcherAssert.assertThat(TestUtil.apexValueToString(stringValue), equalTo("hi"));
     }
 
     @Test
@@ -132,7 +259,7 @@ public class ApexPathExpanderInLoopTest {
     }
 
     @Test
-    public void testSimpleLoopWithField() {
+    public void testForEachLoopWithField() {
         String[] sourceCode = {
             "public class MyClass {\n"
                     + "   public void doSomething() {\n"
@@ -157,8 +284,107 @@ public class ApexPathExpanderInLoopTest {
         final SystemDebugAccumulator visitor = result.getVisitor();
 
         // TODO: Consider getting output value of method application on ForLoopValue to return
+        //  another ForLoopValue
+        final ApexStringValue stringValue = visitor.getSingletonResult();
+        MatcherAssert.assertThat(stringValue.isIndeterminant(), equalTo(true));
+    }
+
+    @Test
+    public void testForLoopWithField() {
+        String[] sourceCode = {
+            "public class MyClass {\n"
+                    + "   public void doSomething() {\n"
+                    + "       Bean[] beans = new Bean[] {new Bean('hi'), new Bean('hello')};\n"
+                    + "       for (Integer i = 0; i < beans.size(); i++) {\n"
+                    + "           System.debug(beans[i].getParam());\n"
+                    + "       }\n"
+                    + "   }\n"
+                    + "}\n",
+            "public class Bean {\n"
+                    + "   private String param;\n"
+                    + "   public Bean(String s) {\n"
+                    + "       param = s;"
+                    + "   }\n"
+                    + "   public String getParam() {\n"
+                    + "       return param;\n"
+                    + "   }\n"
+                    + "}\n"
+        };
+
+        TestRunner.Result<SystemDebugAccumulator> result = TestRunner.get(g, sourceCode).walkPath();
+        final SystemDebugAccumulator visitor = result.getVisitor();
+
+        // TODO: Consider getting output value of method application on ForLoopValue to return
         // another ForLoopValue
         final ApexStringValue stringValue = visitor.getSingletonResult();
         MatcherAssert.assertThat(stringValue.isIndeterminant(), equalTo(true));
+    }
+
+    @Test
+    public void testForLoopWithStandardClass() {
+        String[] sourceCode = {
+            "public class MyClass {\n"
+                    + "   public void doSomething() {\n"
+                    + "       Schema.DescribeFieldResult[] fieldResults = new Schema.DescribeFieldResult[] {Account.Name.getDescribe(), Account.description.getDescribe()};\n"
+                    + "       for (Integer i = 0; i < fieldResults.size(); i++) {\n"
+                    + "           System.debug(fieldResults[i].isAccessible());\n"
+                    + "       }\n"
+                    + "   }\n"
+                    + "}\n"
+        };
+
+        TestRunner.Result<SystemDebugAccumulator> result = TestRunner.get(g, sourceCode).walkPath();
+        final SystemDebugAccumulator visitor = result.getVisitor();
+
+        final ApexForLoopValue forLoopValue = visitor.getSingletonResult();
+        List<ApexValue<?>> forLoopValues = forLoopValue.getForLoopValues();
+        MatcherAssert.assertThat(forLoopValues.size(), equalTo(2));
+        MatcherAssert.assertThat(forLoopValues.get(0).isIndeterminant(), equalTo(true));
+    }
+
+    @Test
+    public void testWhileLoopWithStandardClass() {
+        String[] sourceCode = {
+            "public class MyClass {\n"
+                    + "   public void doSomething() {\n"
+                    + "       Schema.DescribeFieldResult[] fieldResults = new Schema.DescribeFieldResult[] {Account.Name.getDescribe(), Account.description.getDescribe()};\n"
+                    + "       Integer i = 0;\n"
+                    + "       while (i < fieldResults.size()) {\n"
+                    + "           System.debug(fieldResults[i].isAccessible());\n"
+                    + "           i++;\n"
+                    + "       }\n"
+                    + "   }\n"
+                    + "}\n"
+        };
+
+        TestRunner.Result<SystemDebugAccumulator> result = TestRunner.get(g, sourceCode).walkPath();
+        final SystemDebugAccumulator visitor = result.getVisitor();
+
+        // TODO: Detect while-loop iteration and create ApexForLoopValue (new name?) for the
+        // iterated item.
+        final ApexBooleanValue booleanValue = visitor.getSingletonResult();
+        MatcherAssert.assertThat(booleanValue.isIndeterminant(), equalTo(true));
+    }
+
+    @Test
+    public void testForEachLoopWithStandardClass() {
+        String[] sourceCode = {
+            "public class MyClass {\n"
+                    + "   public void doSomething() {\n"
+                    + "       Schema.DescribeFieldResult[] fieldResults = new Schema.DescribeFieldResult[] {Account.Name.getDescribe(), Account.description.getDescribe()};\n"
+                    + "       for (Schema.DescribeFieldResult fieldResult : fieldResults) {\n"
+                    + "           System.debug(fieldResult.isAccessible());\n"
+                    + "       }\n"
+                    + "   }\n"
+                    + "}\n"
+        };
+
+        TestRunner.Result<SystemDebugAccumulator> result = TestRunner.get(g, sourceCode).walkPath();
+        final SystemDebugAccumulator visitor = result.getVisitor();
+
+        final ApexForLoopValue forLoopValue = visitor.getSingletonResult();
+        List<ApexValue<?>> forLoopValues = forLoopValue.getForLoopValues();
+        MatcherAssert.assertThat(forLoopValues.size(), equalTo(2));
+        MatcherAssert.assertThat(forLoopValues.get(0).isIndeterminant(), equalTo(true));
     }
 }


### PR DESCRIPTION
Previously, this worked as expected:
```
Bean b1 = beans[i];
System.debug(b1.getValue());
```

But this wouldn't:
```
System.debug(beans[i].getValue());
```

Changes ensure that paths are expanded when a method call is made directly on an array item. Also includes tests to cover various aspects of loops and method calls on iterated items.