### PR TITLE
FIX (GraphEngine): @W-13363157@: Exclude method calls from ForEach loop definition in MMSLookupRule

### DIFF
--- a/sfge/src/main/java/com/salesforce/graph/vertex/DmlStatementVertex.java
+++ b/sfge/src/main/java/com/salesforce/graph/vertex/DmlStatementVertex.java
@@ -31,7 +31,7 @@ public abstract class DmlStatementVertex extends BaseSFVertex {
         // If AccessLevel is included in the syntax, it's usually the last child. It shows up in the
         // form of a VariableExpression with a ReferenceExpression child.
 
-        // spotless: off
+        // spotless:off
         // Example:
         //<DmlUpdateStatement BeginColumn="9" BeginLine="6" DefiningType="MyClass" DefiningType_CaseSafe="myclass" EndLine="6" EndScopes="[BlockStatement]" FirstChild="false" LastChild="true" childIdx="2">
         //  <VariableExpression BeginColumn="24" BeginLine="6" DefiningType="MyClass" DefiningType_CaseSafe="myclass" EndLine="6" FirstChild="true" LastChild="false" Name="a" Name_CaseSafe="a" childIdx="0">
@@ -42,7 +42,7 @@ public abstract class DmlStatementVertex extends BaseSFVertex {
         //  </VariableExpression>
         //</DmlUpdateStatement>
 
-        // spotless: on
+        // spotless:on
 
         final List<VariableExpressionVertex> children =
                 vertex.getChildren(ASTConstants.NodeType.VARIABLE_EXPRESSION);

--- a/sfge/src/main/java/com/salesforce/rules/multiplemassschemalookup/RuleConstants.java
+++ b/sfge/src/main/java/com/salesforce/rules/multiplemassschemalookup/RuleConstants.java
@@ -35,7 +35,7 @@ public class RuleConstants {
         }
 
         public String getMessage(String... params) {
-            return String.format(messageTemplate, params);
+            return String.format(messageTemplate, (Object[]) params);
         }
     }
 }

--- a/sfge/src/test/java/com/salesforce/rules/multiplemassschemalookup/BaseAvoidMultipleMassSchemaLookupTest.java
+++ b/sfge/src/test/java/com/salesforce/rules/multiplemassschemalookup/BaseAvoidMultipleMassSchemaLookupTest.java
@@ -7,6 +7,9 @@ import com.salesforce.testutils.ViolationWrapper;
 /** Base class to tests for {@link MultipleMassSchemaLookupRule} */
 public abstract class BaseAvoidMultipleMassSchemaLookupTest extends BasePathBasedRuleTest {
 
+    protected static final MultipleMassSchemaLookupRule RULE =
+            MultipleMassSchemaLookupRule.getInstance();
+
     protected ViolationWrapper.MassSchemaLookupInfoBuilder expect(
             int sinkLine,
             String sinkMethodName,

--- a/sfge/src/test/java/com/salesforce/rules/multiplemassschemalookup/SchemaLookupInAnotherMethodTest.java
+++ b/sfge/src/test/java/com/salesforce/rules/multiplemassschemalookup/SchemaLookupInAnotherMethodTest.java
@@ -1,0 +1,58 @@
+package com.salesforce.rules.multiplemassschemalookup;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+public class SchemaLookupInAnotherMethodTest extends BaseAvoidMultipleMassSchemaLookupTest {
+    @Test
+    @Disabled // TODO: Address Schema calls that happen through indirection
+    public void testMethodCallWithinForEachLoopIsSafe() {
+        // spotless:off
+        String sourceCode[] = {
+            "public class MyClass {\n"
+                + "   void foo() {\n"
+                + "       String[] objectList = new String[] {'Account','Contact'};\n"
+                + "       for (Schema.DescribeSObjectResult objDesc: getObjectDescribes(objectList)) {\n"
+                + "           System.debug(objDesc.getLabel());\n"
+                + "       }\n"
+                + "   }\n"
+                + "   List<Schema.DescribeSObjectResult> getObjectDescribes(String[] objectList) {\n"
+                + "     return Schema.describeSObjects(objectList);\n"
+                + "   }\n"
+                + "}\n"
+        };
+        // spotless:on
+
+        assertNoViolation(RULE, sourceCode);
+    }
+
+    @Test
+    @Disabled // TODO: Address Schema calls that happen through indirection
+    public void testMultipleCallsToExternalSchemaMethod() {
+        // spotless:off
+        String sourceCode[] = {
+            "public class MyClass {\n"
+                + "   void foo() {\n"
+                + "       String[] objectList = new String[] {'Account','Contact'};\n" +
+                "       getObjectDescribes(objectList);\n" +
+                "       getObjectDescribes(objectList);\n"
+                + "   }\n"
+                + "   List<Schema.DescribeSObjectResult> getObjectDescribes(String[] objectList) {\n"
+                + "     return Schema.describeSObjects(objectList);\n"
+                + "   }\n"
+                + "}\n"
+        };
+        // spotless:on
+
+        assertViolations(
+                RULE,
+                sourceCode,
+                expect(
+                        5,
+                        "getObjectDescribes",
+                        1,
+                        "MyClass",
+                        RuleConstants.RepetitionType.MULTIPLE,
+                        "Schema.describeSObjects"));
+    }
+}


### PR DESCRIPTION
Addresses a bug in MultipleMassSchemaLookupRule where an expensive schema lookup made from ForEach value definition was incorrectly considered to be called multiple times.