### PR TITLE
CHANGE (GraphEngine): @W-13363157@: Handles multiple levels of method call from loop definition

### DIFF
--- a/sfge/src/main/java/com/salesforce/rules/multiplemassschemalookup/MultipleMassSchemaLookupVisitor.java
+++ b/sfge/src/main/java/com/salesforce/rules/multiplemassschemalookup/MultipleMassSchemaLookupVisitor.java
@@ -2,7 +2,6 @@ package com.salesforce.rules.multiplemassschemalookup;
 
 import com.salesforce.graph.symbols.SymbolProvider;
 import com.salesforce.graph.vertex.*;
-import com.salesforce.rules.ops.boundary.LoopBoundary;
 import com.salesforce.rules.ops.visitor.LoopDetectionVisitor;
 import java.util.HashSet;
 import java.util.Optional;
@@ -37,6 +36,7 @@ class MultipleMassSchemaLookupVisitor extends LoopDetectionVisitor {
 
     @Override
     public void afterVisit(MethodCallExpressionVertex vertex, SymbolProvider symbols) {
+        super.afterVisit(vertex, symbols);
         if (vertex.equals(sinkVertex)) {
             // Mark sink as visited. From this point on, we don't need to
             // look for anymore loops or additional calls.
@@ -49,13 +49,10 @@ class MultipleMassSchemaLookupVisitor extends LoopDetectionVisitor {
     }
 
     private void checkIfInsideLoop(MethodCallExpressionVertex vertex, SymbolProvider symbols) {
-        final Optional<LoopBoundary> loopBoundaryOptional = loopBoundaryDetector.peek();
-        if (loopBoundaryOptional.isPresent()) {
-            if (!isLoopOutlier(vertex, symbols)) {
-                // Method has been invoked inside a loop. Create a violation.
-                final SFVertex loopVertex = loopBoundaryOptional.get().getBoundaryItem();
-                createViolation(RuleConstants.RepetitionType.LOOP, loopVertex);
-            }
+        final Optional<? extends SFVertex> loopedVertexOpt = isInsideLoop();
+        if (loopedVertexOpt.isPresent()) {
+            // Method has been invoked inside a loop. Create a violation.
+            createViolation(RuleConstants.RepetitionType.LOOP, loopedVertexOpt.get());
         }
     }
 

--- a/sfge/src/main/java/com/salesforce/rules/multiplemassschemalookup/MultipleMassSchemaLookupVisitor.java
+++ b/sfge/src/main/java/com/salesforce/rules/multiplemassschemalookup/MultipleMassSchemaLookupVisitor.java
@@ -36,7 +36,6 @@ class MultipleMassSchemaLookupVisitor extends LoopDetectionVisitor {
 
     @Override
     public void afterVisit(MethodCallExpressionVertex vertex, SymbolProvider symbols) {
-        super.afterVisit(vertex, symbols);
         if (vertex.equals(sinkVertex)) {
             // Mark sink as visited. From this point on, we don't need to
             // look for anymore loops or additional calls.
@@ -46,6 +45,9 @@ class MultipleMassSchemaLookupVisitor extends LoopDetectionVisitor {
         } else if (RuleConstants.isSchemaExpensiveMethod(vertex) && shouldContinue()) {
             createViolation(RuleConstants.RepetitionType.MULTIPLE, vertex);
         }
+
+        // Perform super method's logic as well to remove exclusion boundary if needed.
+        super.afterVisit(vertex, symbols);
     }
 
     private void checkIfInsideLoop(MethodCallExpressionVertex vertex, SymbolProvider symbols) {

--- a/sfge/src/main/java/com/salesforce/rules/ops/boundary/BoundaryDetector.java
+++ b/sfge/src/main/java/com/salesforce/rules/ops/boundary/BoundaryDetector.java
@@ -44,7 +44,9 @@ public abstract class BoundaryDetector<T extends Boundary<R>, R> {
      * @param boundary item that governs this extent.
      */
     public void pushBoundary(T boundary) {
-        LOGGER.debug("Entering loop boundary with boundaryItem=" + boundary.getBoundaryItem());
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Entering loop boundary with boundaryItem=" + boundary.getBoundaryItem());
+        }
         push(boundary);
     }
 
@@ -54,7 +56,9 @@ public abstract class BoundaryDetector<T extends Boundary<R>, R> {
      * @param boundaryItem that is expected to govern the current boundary that's to be ended.
      */
     public void popBoundary(R boundaryItem) {
-        LOGGER.debug("Exiting boundary with boundaryItem=" + boundaryItem);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Exiting boundary with boundaryItem=" + boundaryItem);
+        }
 
         // Check if a boundary is actually in place
         Optional<T> boundaryOptional = peek();

--- a/sfge/src/main/java/com/salesforce/rules/ops/boundary/LoopBoundaryDetector.java
+++ b/sfge/src/main/java/com/salesforce/rules/ops/boundary/LoopBoundaryDetector.java
@@ -1,8 +1,24 @@
 package com.salesforce.rules.ops.boundary;
 
 import com.salesforce.graph.vertex.SFVertex;
+import java.util.Optional;
 
 /** Implementation of boundary detection for loops. */
 public class LoopBoundaryDetector extends BoundaryDetector<LoopBoundary, SFVertex> {
-    // Intentionally blank
+    public Optional<? extends SFVertex> isInsideLoop() {
+        final Optional<LoopBoundary> loopBoundaryOpt = peek();
+        if (loopBoundaryOpt.isPresent()) {
+            // Check if we are inside a loop exclusion.
+            if (loopBoundaryOpt.get() instanceof LoopExclusionBoundary) {
+                // This is exclusion zone. We consider this not a loop.
+                return Optional.empty();
+            }
+
+            // Inside a loop.
+            return Optional.of(loopBoundaryOpt.get().getBoundaryItem());
+        }
+
+        // Not inside a loop
+        return Optional.empty();
+    }
 }

--- a/sfge/src/main/java/com/salesforce/rules/ops/boundary/LoopExclusionBoundary.java
+++ b/sfge/src/main/java/com/salesforce/rules/ops/boundary/LoopExclusionBoundary.java
@@ -1,0 +1,17 @@
+package com.salesforce.rules.ops.boundary;
+
+import com.salesforce.graph.vertex.SFVertex;
+
+/**
+ * Indicates parts of the loop that get run only once. For example:
+ *
+ * <ul>
+ *   <li>getValues() method in: <code>for (String s: getValues())</code>
+ *   <li>Static initialization of a class
+ * </ul>
+ */
+public class LoopExclusionBoundary extends LoopBoundary {
+    public LoopExclusionBoundary(SFVertex loopVertex) {
+        super(loopVertex);
+    }
+}

--- a/sfge/src/test/java/com/salesforce/rules/multiplemassschemalookup/SchemaLookupInAnotherMethodTest.java
+++ b/sfge/src/test/java/com/salesforce/rules/multiplemassschemalookup/SchemaLookupInAnotherMethodTest.java
@@ -2,11 +2,47 @@ package com.salesforce.rules.multiplemassschemalookup;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 public class SchemaLookupInAnotherMethodTest extends BaseAvoidMultipleMassSchemaLookupTest {
+
+    @CsvSource({
+        "ForEachStatement, for (String s : myList)",
+        "ForLoopStatement, for (Integer i; i < s.size; s++)",
+        "WhileLoopStatement, while(true)"
+    })
+    @ParameterizedTest(name = "{displayName}: {0}")
+    public void testExternalInvocationFromLoop(String loopAstLabel, String loopStructure) {
+        // spotless:off
+        String sourceCode =
+            "public class MyClass {\n" +
+                "   void foo() {\n" +
+                "       List<String> myList = new String[] {'Account','Contact'};\n" +
+                "       " + loopStructure + " {\n" +
+                "           getObjectDescribes(myList);\n" +
+                "       }\n" +
+                "   }\n"
+                + "   List<Schema.DescribeSObjectResult> getObjectDescribes(String[] objectList) {\n"
+                + "     return Schema.describeSObjects(objectList);\n"
+                + "   }\n"
+                + "}\n";
+        // spotless:on
+
+        assertViolations(
+                RULE,
+                sourceCode,
+                expect(
+                        9,
+                        RuleConstants.METHOD_SCHEMA_DESCRIBE_SOBJECTS,
+                        4,
+                        "MyClass",
+                        RuleConstants.RepetitionType.LOOP,
+                        loopAstLabel));
+    }
+
     @Test
-    @Disabled // TODO: Address Schema calls that happen through indirection
-    public void testMethodCallWithinForEachLoopIsSafe() {
+    public void testMethodCallWithinForEachLoopIsSafe_Level1() {
         // spotless:off
         String sourceCode[] = {
             "public class MyClass {\n"
@@ -27,7 +63,31 @@ public class SchemaLookupInAnotherMethodTest extends BaseAvoidMultipleMassSchema
     }
 
     @Test
-    @Disabled // TODO: Address Schema calls that happen through indirection
+    public void testMethodCallWithinForEachLoopIsSafe_Level2() {
+        // spotless:off
+        String sourceCode[] = {
+            "public class MyClass {\n"
+                + "   void foo() {\n"
+                + "       String[] objectList = new String[] {'Account','Contact'};\n"
+                + "       for (Schema.DescribeSObjectResult objDesc: getObjectDescribes(objectList)) {\n"
+                + "           System.debug(objDesc.getLabel());\n"
+                + "       }\n"
+                + "   }\n"
+                + "   List<Schema.DescribeSObjectResult> getObjectDescribes(String[] objectList) {\n"
+                + "     return getObjectDescribesLevel2(objectList);\n"
+                + "   }\n"
+                + "   List<Schema.DescribeSObjectResult> getObjectDescribesLevel2(String[] objectList) {\n"
+                + "     return Schema.describeSObjects(objectList);\n"
+                + "   }\n"
+                + "}\n"
+        };
+        // spotless:on
+
+        assertNoViolation(RULE, sourceCode);
+    }
+
+    @Test
+    @Disabled // TODO: Handle tracking multiple calls to the same method
     public void testMultipleCallsToExternalSchemaMethod() {
         // spotless:off
         String sourceCode[] = {
@@ -51,6 +111,71 @@ public class SchemaLookupInAnotherMethodTest extends BaseAvoidMultipleMassSchema
                         5,
                         "getObjectDescribes",
                         1,
+                        "MyClass",
+                        RuleConstants.RepetitionType.MULTIPLE,
+                        "Schema.describeSObjects"));
+    }
+
+    @Test
+    @Disabled // TODO: Handle tracking multiple calls to the same method
+    public void testMultipleCallsToExternalSchemaMethod_differentPaths() {
+        // spotless:off
+        String sourceCode[] = {
+            "public class MyClass {\n"
+                + "   void foo() {\n"
+                + "       String[] objectList = new String[] {'Account','Contact'};\n" +
+                "       getObjectDescribes1(objectList);\n" +
+                "       getObjectDescribes2(objectList);\n"
+                + "   }\n"
+                + "   List<Schema.DescribeSObjectResult> getObjectDescribes1(String[] objectList) {\n"
+                + "     return getObjectDescribes2(objectList);\n"
+                + "   }\n"
+                + "   List<Schema.DescribeSObjectResult> getObjectDescribes2(String[] objectList) {\n"
+                + "     return Schema.describeSObjects(objectList);\n"
+                + "   }\n"
+                + "}\n"
+        };
+        // spotless:on
+
+        assertViolations(
+                RULE,
+                sourceCode,
+                expect(
+                        5,
+                        "getObjectDescribes",
+                        1,
+                        "MyClass",
+                        RuleConstants.RepetitionType.MULTIPLE,
+                        "Schema.describeSObjects"));
+    }
+
+    @Test
+    public void testMultipleCallsToExternalSchemaMethod_differentMethods() {
+        // spotless:off
+        String sourceCode[] = {
+            "public class MyClass {\n"
+                + "   void foo() {\n"
+                + "       String[] objectList = new String[] {'Account','Contact'};\n" +
+                "       getObjectDescribes1(objectList);\n" +
+                "       getObjectDescribes2(objectList);\n"
+                + "   }\n"
+                + "   List<Schema.DescribeSObjectResult> getObjectDescribes1(String[] objectList) {\n"
+                + "     return Schema.describeSObjects(objectList);\n"
+                + "   }\n"
+                + "   List<Schema.DescribeSObjectResult> getObjectDescribes2(String[] objectList) {\n"
+                + "     return Schema.describeSObjects(objectList);\n"
+                + "   }\n"
+                + "}\n"
+        };
+        // spotless:on
+
+        assertViolations(
+                RULE,
+                sourceCode,
+                expect(
+                        11,
+                        RuleConstants.METHOD_SCHEMA_DESCRIBE_SOBJECTS,
+                        8,
                         "MyClass",
                         RuleConstants.RepetitionType.MULTIPLE,
                         "Schema.describeSObjects"));


### PR DESCRIPTION
The previous fix looked at excluding only the first level of method invocations from loop definitions. This approach covers more edge cases.