### PR TITLE
Improve Custom Rule Compilation Instructions

### DIFF
--- a/docs/_articles/en/custom-rules/author.md
+++ b/docs/_articles/en/custom-rules/author.md
@@ -18,29 +18,243 @@ PMD and Eslint's custom rules work very differently. This causes Scanner plugin 
 Here are the [instructions](https://pmd.github.io/latest/pmd_userdocs_extending_writing_rules_intro.html) on how to write PMD Custom Rules. PMD Rules may be either XPath-based or Java-based, and these rule types must be authored differently.
 <br>
 To be compatible with the Salesforce CLI Scanner, PMD custom rules must also meet the following criteria:
-- Rules must  be __defined__ in XML files whose path matches the format ```<some base dir>/category/<language>/<filename>.xml```.
-- XPath-based rules can be contained in standalone XML files.
-- Java-based rules must be compiled, and bundled into a JAR.
-- Custom rulesets consisting of references to existing rules may be contained in standalone XML files whose path matches the format ```<some base dir>/rulesets/<language>/<filename>.xml```
+
+-   Rules must be **defined** in XML files whose path matches the format `<some base dir>/category/<language>/<filename>.xml`.
+-   XPath-based rules can be contained in standalone XML files.
+-   Java-based rules must be compiled, and bundled into a JAR.
+-   Custom rulesets consisting of references to existing rules may be contained in standalone XML files whose path matches the format `<some base dir>/rulesets/<language>/<filename>.xml`
 
 ### Compiling Java-Based PMD Custom Rules
-When you compile your new rule(s), make sure ```$PMD_BIN_HOME/lib/*``` is in your CLASSPATH. Also make sure that your Java setup reflects the java-home path in ```<HOME_DIR>/.sfdx-scanner/Config.json```.  
 
-If you are using an IDE, add ```$PMD_BIN_HOME/lib/*``` to its CLASSPATH. To compile from the command line, use the ```javac``` command. For example:
+Compiling custom rules using Java can be accomplished using [Maven](https://maven.apache.org/guides/getting-started/maven-in-five-minutes.html).
 
-```$ javac -cp ".:$PMD_BIN_HOME/lib/*" /path/to/your/Rule.java```
+NOTE: The below instructions are written for Unix based operating systems.
 
-Use only [version {{ site.data.versions.pmd }}](https://github.com/pmd/pmd/releases/download/pmd_releases%2F{{ site.data.versions.pmd }}/pmd-bin-{{ site.data.versions.pmd }}.zip) of PMD for writing the custom rules. 
+#### Directory Structure
 
-### Bundling Java-Based PMD Custom Rules
-If you haven't already, create the XML rule [definition file](https://pmd.github.io/latest/pmd_userdocs_extending_writing_rules_intro.html#xml-rule-definition) for your new rule(s). Add them to a directory structure like this: 
-```<some base dir>/category/<language>/yourRuleDefinition.xml```
+Create a directory to hold your custom rules with a structure that matches the tree below, substituting your organization's name for `organization`:
 
-When your new Java files compile and your XML rule definition matches your new custom rule(s) that you’ve created, create a JAR file that contains both the xml and the class files. Be sure to use the correct directory structure according to its package name and the XML file in the directory path as described in the previous step. A single JAR file can contain multiple custom rule classes.
+```
+.
+├── pom.xml
+└── src
+    └── main
+        ├── java
+        │   └── com
+        │       └── organization
+        │           └── pmd
+        │               └── MyRule.java
+        └── resources
+            └── category
+                └── apex
+                    └── customRules.xml
+```
 
-Here's an example of using ```jar``` to create a JAR file: 
+##### `MyRule.java`
 
-```$ jar -cp <customRule.jar> <rule_package_base_dir> <xml_base_dir>```
+Here is a sample rule for demonstration. To learn more about which classes are available for custom rule compilation, please view the [PMD documentation](https://javadoc.io/static/net.sourceforge.pmd/pmd-apex/{{ site.data.versions.pmd }}/index.html).
+
+```java
+package com.organization.pmd;
+
+import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
+import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+
+public class MyRule extends AbstractApexRule {
+
+  @Override
+  public Object visit(ASTUserClass theClass, Object data) {
+    asCtx(data).addViolation(theClass);
+    return data;
+  }
+
+}
+```
+
+##### `customRules.xml`
+
+Create a custom XML rule [definition file](https://pmd.github.io/latest/pmd_userdocs_extending_writing_rules_intro.html#xml-rule-definition) which references the rule.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    name="CustomRules"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+    <description>Custom Rules</description>
+    <rule
+        name="MyRule"
+        language="apex"
+        class="com.organization.pmd.MyRule"
+        message="This is a demonstration rule"
+        externalInfoUrl="http://foo.com/bar/MyRule"
+    >
+        <description>Demonstration</description>
+        <priority>1</priority>
+    </rule>
+</ruleset>
+```
+
+#### Compilation using Maven
+
+The `pom.xml` file is an integral part of a Maven project. It tells Maven which dependencies to fetch from the Maven repository and how to build the artifacts for the project. Below is a `pom.xml` file which you can use to compile Java-based custom rules.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.organization.pmd</groupId>
+  <artifactId>custom-pmd-rules</artifactId>
+  <version>1.0.0</version>
+
+  <name>custom-pmd-rules</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>net.sourceforge.pmd</groupId>
+      <artifactId>pmd</artifactId>
+      <version>{{ site.data.versions.pmd }}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>net.sourceforge.pmd</groupId>
+      <artifactId>pmd-apex</artifactId>
+      <version>{{ site.data.versions.pmd }}</version>
+    </dependency>
+    <dependency>
+      <groupId>net.sourceforge.pmd</groupId>
+      <artifactId>pmd-apex-jorje</artifactId>
+      <version>{{ site.data.versions.pmd }}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+      <version>9.4</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <release>11</release>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>com/**/*.class</include>
+            <include>category/apex/*.xml</include>
+          </includes>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+            </manifest>
+            <addMavenDescriptor>false</addMavenDescriptor>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+```
+
+With the `pom.xml` defined, we can now compile our rules:
+
+```shell
+$ mvn package
+```
+
+This will produce a directory called `target` which contains a file called `custom-pmd-rules-1.0.0.jar`. This `.jar` file contains the compiled version of our rule along with the XML rule definition:
+
+```shell
+$ unzip -l target/custom-pmd-rules-1.0.0.jar
+
+# produces the following output:
+
+Archive:  target/custom-pmd-rules-1.0.0.jar
+  Length      Date    Time    Name
+---------  ---------- -----   ----
+        0  01-01-2023 00:00   META-INF/
+      697  01-01-2023 00:00   META-INF/MANIFEST.MF
+        0  01-01-2023 00:00   category/
+        0  01-01-2023 00:00   category/apex/
+      641  01-01-2023 00:00   category/apex/customRules.xml
+        0  01-01-2023 00:00   com/
+        0  01-01-2023 00:00   com/organization/
+        0  01-01-2023 00:00   com/organization/pmd/
+      775  01-01-2023 00:00   com/organization/pmd/MyRule.class
+---------                     -------
+     2113                     9 files
+```
+
+### Adding Compiled Java-based Rules
+
+Now that our custom rule is defined, referenced in an XML rule definition file, and compiled into a `.jar`, we can add the rule to the scanner:
+
+```shell
+$ sfdx scanner:rule:add \
+  --language apex \
+  --path /path/to/rules/directory/target/custom-pmd-rules-1.0.0.jar
+```
+
+#### Executing Java-based Rules
+
+To validate that our custom rules are executing properly, execute the sfdx-scanner plugin on a sample class and reference the XML rule definition file using the `--pmdconfig` flag:
+
+```shell
+$ sfdx scanner:run \
+  --target /path/to/salesforce/directory/force-app/main/default/classes/MyClass.cls \
+  --pmdconfig /path/to/rules/directory/src/main/resources/category/apex/customRules.xml
+
+```
+
+##### XML Rule Definition Composition
+
+Referencing a specific rule's XML definition file is less than ideal as it limits the scope of the findings to only the specific rules we have defined.
+
+Because we included the `category/apex/customRules.xml` in the compiled `.jar`, we can compose our our rule definitions into one `all-rules.xml` file which references other XML rule definition file(s):
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    name="AllRules"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+    <description>All Rules</description>
+    <!-- Standard Rules -->
+    <rule ref="category/apex/bestpractices.xml" />
+    <rule ref="category/apex/codestyle.xml" />
+    <rule ref="category/apex/design.xml" />
+    <rule ref="category/apex/documentation.xml" />
+    <rule ref="category/apex/errorprone.xml" />
+    <rule ref="category/apex/multithreading.xml" />
+    <rule ref="category/apex/performance.xml" />
+    <rule ref="category/apex/security.xml" />
+    <!-- Custom Rules -->
+    <rule ref="category/apex/customRules.xml" />
+</ruleset>
+```
+
+```shell
+$ sfdx scanner:run \
+  --target /path/to/salesforce/directory/force-app/main/default/classes/MyClass.cls \
+  --pmdconfig /path/to/salesforce/directory/all-rules.xml
+```
 
 ---
 
@@ -53,6 +267,7 @@ Writing custom Eslint rules requires creating a custom Eslint plugin and definin
 ### Adding Rule as NPM Dependency
 
 While writing the rule, please make sure the rule definition contains documentation. We are specifically looking for a format like this:
+
 ```bash
 // Rule definition in index.js or where you choose to store it
 ...
@@ -66,6 +281,7 @@ While writing the rule, please make sure the rule definition contains documentat
 ```
 
 Once the rule is ready and tested, add it as a dependency to the NPM setup in the directory where you to plan to run the Scanner plugin from. You can use `npm` or `yarn` version of this command:
+
 ```bash
 yarn add file:/path/to/eslint-plugin-my-custom
 ```

--- a/docs/_data/versions.yml
+++ b/docs/_data/versions.yml
@@ -1,5 +1,5 @@
 scanner: '3.0.0'
 releasedon: '02-23-2022'
-pmd: '6.42.0'
+pmd: '6.55.0'
 eslint: '6.8.0'
 retirejs: '2.2.5'


### PR DESCRIPTION
Improves the instructions for custom Java-based rule compilation.

Provides sample directory structure, Java based rule, `pom.xml` and commands for compilation, registration within the scanner plugin, and validation.

Fixes #1025 