### PR TITLE
Improve Custom Rule Compilation Instructions

### DIFF
--- a/docs/_articles/en/v3.x/custom-rules/author.md
+++ b/docs/_articles/en/v3.x/custom-rules/author.md
@@ -8,7 +8,7 @@ redirect_from: /en/custom-rules/author
 
 Let’s say your codebase has specific and repetitive coding issues that you want to address. You use the built-in rules of the Salesforce Code Analyzer (Code Analyzer) to find these rule violations. But sometimes the problems exist only in the context of your codebase, and sometimes Code Analyzer’s built-in rules don’t catch them. In this case, create your own custom rules to highlight these issues as rule violations when you scan your code.
 
-Because PMD and ESLint custom rules work differently, Code Analyzer deals with each in distinct ways. 
+Because PMD and ESLint custom rules work differently, Code Analyzer deals with each in distinct ways.
 
 ---
 
@@ -18,47 +18,245 @@ Because PMD and ESLint custom rules work differently, Code Analyzer deals with e
 
 To be compatible with Code Analyzer, your PMD custom rules must meet these criteria.
 
-* PMD Rules must be XPath-based or Java-based. 
-* Define rules in XML files with a path that matches this format: ```<some base dir>/category/<language>/<filename>.xml```.
-* XPath-based rules can be contained in standalone XML files.
-* Java-based rules must be compiled and bundled into a JAR.
-* Custom rulesets consisting of references to existing rules can be contained in standalone XML files with a path that matches this format: ```<some base dir>/rulesets/<language>/<filename>.xml```.
+-   PMD Rules must be XPath-based or Java-based.
+-   Define rules in XML files with a path that matches this format: `<some base dir>/category/<language>/<filename>.xml`.
+-   XPath-based rules can be contained in standalone XML files.
+-   Java-based rules must be compiled and bundled into a JAR.
+-   Custom rulesets consisting of references to existing rules can be contained in standalone XML files with a path that matches this format: `<some base dir>/rulesets/<language>/<filename>.xml`.
 
-### Compile Java-Based PMD Custom Rules
-To compile your new Java-based PMD rules:
+### Compiling Java-Based PMD Custom Rules
 
-* Add ```$PMD_BIN_HOME/lib/*``` to your CLASSPATH. 
-* Reflect the ```java-home path``` in your Java setup in ```<HOME_DIR>/.sfdx-scanner/Config.json```.
-* Use {{ site.data.versions-v3.pmd }} to write your custom rules.
-* If you’re using an integrated development environment (IDE), add ```$PMD_BIN_HOME/lib/*``` to its CLASSPATH. To compile from the command line, use the ```javac``` command. 
+Compiling custom rules using Java can be accomplished using [Maven](https://maven.apache.org/guides/getting-started/maven-in-five-minutes.html).
 
-	Example:
-	
-	```
-	$ javac -cp ".:$PMD_BIN_HOME/lib/*" /path/to/your/Rule.java
-	```
+NOTE: The below instructions are written for Unix based operating systems.
 
-### Bundle Java-Based PMD Custom Rules
-If you haven’t already, create an XML rule definition file for your new rules. Add your rules to a directory structure like this: 
+#### Directory Structure
+
+Create a directory to hold your custom rules with a structure that matches the tree below, substituting your organization's name for `organization`:
 
 ```
-<some base dir>/category/<language>/yourRuleDefinition.xml
+.
+├── pom.xml
+└── src
+    └── main
+        ├── java
+        │   └── com
+        │       └── organization
+        │           └── pmd
+        │               └── MyRule.java
+        └── resources
+            └── category
+                └── apex
+                    └── customRules.xml
 ```
 
-After your new Java files compile and your XML rule definition matches your new custom rules that you created, create a JAR file that contains the XML and the class files. Use the correct directory structure according to its package name and the XML file in the directory path. A single JAR file can contain multiple custom rule classes.
+##### `MyRule.java`
 
-Example:
+Here is a sample rule for demonstration. To learn more about which classes are available for custom rule compilation, please view the [PMD documentation](https://javadoc.io/static/net.sourceforge.pmd/pmd-apex/{{ site.data.versions-v3.pmd }}/index.html).
+
+```java
+package com.organization.pmd;
+
+import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
+import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+
+public class MyRule extends AbstractApexRule {
+
+  @Override
+  public Object visit(ASTUserClass theClass, Object data) {
+    asCtx(data).addViolation(theClass);
+    return data;
+  }
+
+}
+```
+
+##### `customRules.xml`
+
+Create a custom XML rule [definition file](https://pmd.github.io/latest/pmd_userdocs_extending_writing_rules_intro.html#xml-rule-definition) which references the rule.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    name="CustomRules"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+    <description>Custom Rules</description>
+    <rule
+        name="MyRule"
+        language="apex"
+        class="com.organization.pmd.MyRule"
+        message="This is a demonstration rule"
+        externalInfoUrl="http://foo.com/bar/MyRule"
+    >
+        <description>Demonstration</description>
+        <priority>1</priority>
+    </rule>
+</ruleset>
+```
+
+#### Compilation using Maven
+
+The `pom.xml` file is an integral part of a Maven project. It tells Maven which dependencies to fetch from the Maven repository and how to build the artifacts for the project. Below is a `pom.xml` file which you can use to compile Java-based custom rules.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.organization.pmd</groupId>
+  <artifactId>custom-pmd-rules</artifactId>
+  <version>1.0.0</version>
+
+  <name>custom-pmd-rules</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>net.sourceforge.pmd</groupId>
+      <artifactId>pmd</artifactId>
+      <version>{{ site.data.versions-v3.pmd }}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>net.sourceforge.pmd</groupId>
+      <artifactId>pmd-apex</artifactId>
+      <version>{{ site.data.versions-v3.pmd }}</version>
+    </dependency>
+    <dependency>
+      <groupId>net.sourceforge.pmd</groupId>
+      <artifactId>pmd-apex-jorje</artifactId>
+      <version>{{ site.data.versions-v3.pmd }}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+      <version>9.4</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <release>11</release>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>com/**/*.class</include>
+            <include>category/apex/*.xml</include>
+          </includes>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+            </manifest>
+            <addMavenDescriptor>false</addMavenDescriptor>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+```
+
+With the `pom.xml` defined, we can now compile our rules:
+
+```shell
+$ mvn package
+```
+
+This will produce a directory called `target` which contains a file called `custom-pmd-rules-1.0.0.jar`. This `.jar` file contains the compiled version of our rule along with the XML rule definition:
+
+```shell
+$ unzip -l target/custom-pmd-rules-1.0.0.jar
+
+# produces the following output:
+
+Archive:  target/custom-pmd-rules-1.0.0.jar
+  Length      Date    Time    Name
+---------  ---------- -----   ----
+        0  01-01-2023 00:00   META-INF/
+      697  01-01-2023 00:00   META-INF/MANIFEST.MF
+        0  01-01-2023 00:00   category/
+        0  01-01-2023 00:00   category/apex/
+      641  01-01-2023 00:00   category/apex/customRules.xml
+        0  01-01-2023 00:00   com/
+        0  01-01-2023 00:00   com/organization/
+        0  01-01-2023 00:00   com/organization/pmd/
+      775  01-01-2023 00:00   com/organization/pmd/MyRule.class
+---------                     -------
+     2113                     9 files
+```
+
+### Adding Compiled Java-based Rules
+
+Now that our custom rule is defined, referenced in an XML rule definition file, and compiled into a `.jar`, we can add the rule to the scanner:
+
+```shell
+$ sfdx scanner:rule:add \
+  --language apex \
+  --path /path/to/rules/directory/target/custom-pmd-rules-1.0.0.jar
+```
+
+#### Executing Java-based Rules
+
+To validate that our custom rules are executing properly, execute the sfdx-scanner plugin on a sample class and reference the XML rule definition file using the `--pmdconfig` flag:
+
+```shell
+$ sfdx scanner:run \
+  --target /path/to/salesforce/directory/force-app/main/default/classes/MyClass.cls \
+  --pmdconfig /path/to/rules/directory/src/main/resources/category/apex/customRules.xml
 
 ```
-$ jar -cp <customRule.jar> <rule_package_base_dir> <xml_base_dir>
+
+##### XML Rule Definition Composition
+
+Referencing a specific rule's XML definition file is less than ideal as it limits the scope of the findings to only the specific rules we have defined.
+
+Because we included the `category/apex/customRules.xml` in the compiled `.jar`, we can compose our our rule definitions into one `all-rules.xml` file which references other XML rule definition file(s):
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    name="AllRules"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+    <description>All Rules</description>
+    <!-- Standard Rules -->
+    <rule ref="category/apex/bestpractices.xml" />
+    <rule ref="category/apex/codestyle.xml" />
+    <rule ref="category/apex/design.xml" />
+    <rule ref="category/apex/documentation.xml" />
+    <rule ref="category/apex/errorprone.xml" />
+    <rule ref="category/apex/multithreading.xml" />
+    <rule ref="category/apex/performance.xml" />
+    <rule ref="category/apex/security.xml" />
+    <!-- Custom Rules -->
+    <rule ref="category/apex/customRules.xml" />
+</ruleset>
 ```
+
+```shell
+$ sfdx scanner:run \
+  --target /path/to/salesforce/directory/force-app/main/default/classes/MyClass.cls \
+  --pmdconfig /path/to/salesforce/directory/all-rules.xml
+```
+
 ---
-
-## See Also
-
-- [PMD Source Code Analyzer Project: Introduction to writing PMD rules](https://pmd.github.io/latest/pmd_userdocs_extending_writing_rules_intro.html)
-- [PMD Source Code Analyzer Project: XML rule definition](https://pmd.github.io/latest/pmd_userdocs_extending_writing_rules_intro.html#xml-rule-definition)
-
 
 ## ESLint Custom Rules
 
@@ -82,16 +280,18 @@ ESLint rule definitions must contain documentation. Format your documentation li
 ...
 ```
 
-After your rule is ready and tested, add it as a dependency to the ```npm``` setup in the same directory where Code Analyzer runs. Use the ```npm``` or ```yarn``` version of this command.
+After your rule is ready and tested, add it as a dependency to the `npm` setup in the same directory where Code Analyzer runs. Use the `npm` or `yarn` version of this command.
 
 ```bash
 yarn add file:/path/to/ESLint-plugin-my-custom
 npm install file:/path/to/ESLint-plugin-my-custom
 ```
 
-After your rule is added, ensure that the ```node_modules``` directory:
-* Has a child directory with your plug-in’s name. 
-* Contains the ```package.json```, ```index.js``` and other files that you created.
+After your rule is added, ensure that the `node_modules` directory:
+
+-   Has a child directory with your plug-in’s name.
+-   Contains the `package.json`, `index.js` and other files that you created.
 
 ## See Also
-- [ESLint: Working with Rules](https://eslint.org/docs/latest/developer-guide/working-with-rules)
+
+-   [ESLint: Working with Rules](https://eslint.org/docs/latest/developer-guide/working-with-rules)


### PR DESCRIPTION
Improves the instructions for custom Java-based rule compilation.

Provides the following: 
- sample directory structure
- Java based rule
- usable `pom.xml`
-  commands for:
   -  registration within the scanner plugin
   - execution

Fixes #1025 