### PR TITLE
CHANGE (ESLint): @W-8458220@: Custom ESLint config discards noisy violations from ignorefile.

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -36,6 +36,12 @@ export enum RuleType {
 	DFA = "dfa"
 }
 
+export enum TargetType {
+	FILE,
+	DIRECTORY,
+	GLOB
+}
+
 /**
  * Main engine types that have more than one variation
  */
@@ -107,6 +113,10 @@ export enum CUSTOM_CONFIG {
 export const HARDCODED_RULES = {
 	FILES_MUST_COMPILE: {
 		name: 'files-must-compile',
+		category: 'Scanner Internal'
+	},
+	FILE_IGNORED: {
+		name: 'file-ignored',
 		category: 'Scanner Internal'
 	}
 };

--- a/src/lib/eslint/BaseEslintEngine.ts
+++ b/src/lib/eslint/BaseEslintEngine.ts
@@ -1,12 +1,24 @@
 import {Logger, SfError} from '@salesforce/core';
-import { Catalog, ESRuleConfig, ESRuleConfigValue, LooseObject, Rule, RuleGroup, RuleResult, RuleTarget, ESRule, TargetPattern, ESRuleMetadata } from '../../types';
-import {ENGINE, Severity} from '../../Constants';
+import {
+	Catalog,
+	ESRule,
+	ESRuleConfig,
+	ESRuleConfigValue,
+	ESRuleMetadata,
+	LooseObject,
+	Rule,
+	RuleGroup,
+	RuleResult,
+	RuleTarget,
+	TargetPattern
+} from '../../types';
+import {ENGINE, Severity, TargetType} from '../../Constants';
 import {OutputProcessor} from '../services/OutputProcessor';
 import {AbstractRuleEngine} from '../services/RuleEngine';
 import {Config} from '../util/Config';
 import {Controller} from '../../Controller';
 import {deepCopy} from '../util/Utils';
-import {StaticDependencies, EslintProcessHelper, ProcessRuleViolationType} from './EslintCommons';
+import {EslintProcessHelper, ProcessRuleViolationType, StaticDependencies} from './EslintCommons';
 import * as engineUtils from '../util/CommonEngineUtils';
 import {ESLint} from 'eslint';
 
@@ -204,7 +216,7 @@ export abstract class BaseEslintEngine extends AbstractRuleEngine {
 			// Process one target path at a time to trigger eslint
 			for (const target of targets) {
 				// TODO: Will this break the typescript parser cwd setting?
-				const cwd = target.isDirectory ? this.baseDependencies.resolveTargetPath(target.target) : this.baseDependencies.getCurrentWorkingDirectory();
+				const cwd = target.targetType === TargetType.DIRECTORY ? this.baseDependencies.resolveTargetPath(target.target) : this.baseDependencies.getCurrentWorkingDirectory();
 				this.logger.trace(`Using current working directory in config as ${cwd}`);
 				const config: ESLint.Options = {cwd};
 

--- a/src/lib/eslint/JavascriptEslintStrategy.ts
+++ b/src/lib/eslint/JavascriptEslintStrategy.ts
@@ -84,11 +84,13 @@ export class JavascriptEslintStrategy implements EslintStrategy {
 
 	processRuleViolation(): ProcessRuleViolationType {
 		/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-		return (fileName: string, ruleViolation: RuleViolation): void => {
+		return (fileName: string, ruleViolation: RuleViolation): boolean => {
 			if (ruleViolation.message.startsWith('Parsing error:')) {
 				ruleViolation.ruleName = HARDCODED_RULES.FILES_MUST_COMPILE.name;
 				ruleViolation.category = HARDCODED_RULES.FILES_MUST_COMPILE.category;
 			}
+			// Always keep our violations.
+			return true;
 		}
 	}
 }

--- a/src/lib/eslint/LWCEslintStrategy.ts
+++ b/src/lib/eslint/LWCEslintStrategy.ts
@@ -95,7 +95,7 @@ export class LWCEslintStrategy implements EslintStrategy {
 
 	// TODO: Submit PR against eslint-plugin-lwc
 	processRuleViolation(): ProcessRuleViolationType {
-		return (fileName: string, ruleViolation: RuleViolation): void => {
+		return (fileName: string, ruleViolation: RuleViolation): boolean => {
 			const url: string = ruleViolation.url || '';
 			const repoName = 'eslint-plugin-lwc';
 
@@ -115,6 +115,8 @@ export class LWCEslintStrategy implements EslintStrategy {
 				ruleViolation.category = HARDCODED_RULES.FILES_MUST_COMPILE.category;
 				ruleViolation.message = ruleViolation.message.split('\n')[0];
 			}
+			// Always keep our violations.
+			return true;
 		}
 	}
 }

--- a/src/lib/eslint/TypescriptEslintStrategy.ts
+++ b/src/lib/eslint/TypescriptEslintStrategy.ts
@@ -178,7 +178,7 @@ export class TypescriptEslintStrategy implements EslintStrategy {
 	 * Converts the eslint message that requires the scanned files to be a subset of the files specified by tsconfig.json
 	 */
 	processRuleViolation(): ProcessRuleViolationType {
-		return (fileName: string, ruleViolation: RuleViolation): void => {
+		return (fileName: string, ruleViolation: RuleViolation): boolean => {
 			const message: string = ruleViolation.message;
 
 			const inclusionRegex = /^Parsing error: ESLint was configured to run on `.*` using `parserOptions.project`:.*\nHowever, (that TSConfig does not|none of those TSConfigs) include this file./;
@@ -190,6 +190,8 @@ export class TypescriptEslintStrategy implements EslintStrategy {
 				ruleViolation.category = HARDCODED_RULES.FILES_MUST_COMPILE.category;
 				ruleViolation.exception = true;
 			}
+			// Always keep our violations.
+			return true;
 		}
 	}
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,5 +1,6 @@
 import {JSONSchema4} from 'json-schema';
 import {Linter} from 'eslint';
+import {TargetType} from './Constants';
 
 export type Rule = {
 	engine: string;
@@ -50,7 +51,7 @@ export type RuleGroup = {
 
 export type RuleTarget = {
 	target: string;
-	isDirectory?: boolean;
+	targetType: TargetType;
 	paths: string[];
 	methods?: string[];
 }

--- a/test/lib/RuleManager.test.ts
+++ b/test/lib/RuleManager.test.ts
@@ -4,7 +4,7 @@ import {Lifecycle} from '@salesforce/core';
 
 import {Controller} from '../../src/Controller';
 import {Rule, RuleGroup, RuleTarget, TelemetryData} from '../../src/types';
-import {ENGINE, CONFIG_FILE} from '../../src/Constants';
+import {ENGINE, CONFIG_FILE, TargetType} from '../../src/Constants';
 
 import {CategoryFilter, EngineFilter, LanguageFilter, RuleFilter, RulesetFilter} from '../../src/lib/RuleFilter';
 import {DefaultRuleManager} from '../../src/lib/DefaultRuleManager';
@@ -520,10 +520,10 @@ describe('RuleManager', () => {
 				// Validate the results.
 				expect(results.length).to.equal(2, 'Wrong number of targets matched');
 				expect(results[0].target).to.equal(targets[0], 'Wrong file matched');
-				expect(results[0].isDirectory).to.not.equal(true, 'Should not be flagged as directory');
+				expect(results[0].targetType).to.equal(TargetType.FILE, 'Should be matched as file');
 				expect(results[0].paths.length).to.equal(1, 'Wrong number of paths matched');
 				expect(results[1].target).to.equal(targets[1], 'Wrong file matched');
-				expect(results[1].isDirectory).to.not.equal(true, 'Should not be flagged as directory');
+				expect(results[1].targetType).to.equal(TargetType.FILE, 'Should be matched as file');
 				expect(results[1].paths.length).to.equal(1, 'Wrong number of paths matched');
 			});
 
@@ -547,7 +547,7 @@ describe('RuleManager', () => {
 				// Validate the results.
 				expect(results.length).to.equal(1, 'Wrong number of targets matched');
 				expect(results[0].target).to.equal(targets[0], 'Wrong directory matched');
-				expect(results[0].isDirectory).to.equal(true, 'Should be flagged as directory');
+				expect(results[0].targetType).to.equal(TargetType.DIRECTORY, 'Should be flagged as directory');
 				expect(results[0].paths.length).to.equal(2, 'Wrong number of paths matched');
 			});
 
@@ -601,7 +601,7 @@ describe('RuleManager', () => {
 				// Validate the results.
 				expect(results.length).to.equal(1, 'Wrong number of targets matched');
 				expect(results[0].target).to.equal(targets[0], 'Wrong glob matched');
-				expect(results[0].isDirectory).to.not.equal(true, 'Should not be flagged as directory');
+				expect(results[0].targetType).to.equal(TargetType.GLOB, 'Should be flagged as glob');
 				expect(results[0].paths.length).to.equal(2, 'Wrong number of paths matched');
 			});
 		});
@@ -628,7 +628,7 @@ describe('RuleManager', () => {
 				// Validate the results.
 				expect(results.length).to.equal(1, 'Wrong number of targets matched');
 				expect(results[0].target).to.equal(targets[1], 'Wrong file matched');
-				expect(results[0].isDirectory).to.not.equal(true, 'Should not be flagged as directory');
+				expect(results[0].targetType).to.equal(TargetType.FILE, 'Should be flagged as file');
 				expect(results[0].paths.length).to.equal(1, 'Wrong number of paths matched');
 			});
 
@@ -654,10 +654,10 @@ describe('RuleManager', () => {
 				// Validate the results.
 				expect(results.length).to.equal(2, 'Wrong number of targets matched');
 				expect(results[0].target).to.equal(targets[2], 'Wrong directory matched');
-				expect(results[0].isDirectory).to.equal(true, 'Should be flagged as directory');
+				expect(results[0].targetType).to.equal(TargetType.DIRECTORY, 'Should be flagged as directory');
 				expect(results[0].paths.length).to.equal(2, 'Wrong number of paths matched');
 				expect(results[1].target).to.equal(targets[3], 'Wrong directory matched');
-				expect(results[1].isDirectory).to.equal(true, 'Should be flagged as directory');
+				expect(results[1].targetType).to.equal(TargetType.DIRECTORY, 'Should be flagged as directory');
 				expect(results[1].paths.length).to.equal(1, 'Wrong number of paths matched');
 			});
 
@@ -684,10 +684,10 @@ describe('RuleManager', () => {
 				// Validate the results.
 				expect(results.length).to.equal(2, 'Wrong number of targets matched');
 				expect(results[0].target).to.equal(targets[2], 'Wrong glob matched');
-				expect(results[0].isDirectory).to.not.equal(true, 'Should not be flagged as directory');
+				expect(results[0].targetType).to.equal(TargetType.GLOB, 'Should be flagged as glob');
 				expect(results[0].paths.length).to.equal(2, 'Wrong number of paths matched');
 				expect(results[1].target).to.equal(targets[3], 'Wrong glob matched');
-				expect(results[1].isDirectory).to.not.equal(true, 'Should not be flagged as directory');
+				expect(results[1].targetType).to.equal(TargetType.GLOB, 'Should be flagged as glob');
 				expect(results[1].paths.length).to.equal(1, 'Wrong number of paths matched');
 			});
 		});

--- a/test/lib/cpd/CpdEngine.test.ts
+++ b/test/lib/cpd/CpdEngine.test.ts
@@ -1,19 +1,19 @@
 import {expect} from 'chai';
 import {CpdEngine} from '../../../src/lib/cpd/CpdEngine'
 import * as TestOverrides from '../../test-related-lib/TestOverrides';
-import { CUSTOM_CONFIG, LANGUAGE } from '../../../src/Constants';
-import { RuleTarget } from '../../../src/types';
+import {CUSTOM_CONFIG, LANGUAGE, TargetType} from '../../../src/Constants';
+import {RuleTarget} from '../../../src/types';
 
 TestOverrides.initializeTestSetup();
 
 describe('CpdEngine', () => {
 
 	const testEngine: CpdEngine = new CpdEngine();
-    
+
 	before(async () => {
 		await testEngine.init();
 	});
-    
+
 	describe('shouldEngineRun()', () => {
 		it('should always return true if the engine was not filtered out', () => {
 			expect(testEngine.shouldEngineRun([],[],[],new Map<string,string>())).to.be.true;
@@ -24,9 +24,10 @@ describe('CpdEngine', () => {
 		it('should return the correct map based on valid cpd files and targets given', () => {
 			const targets: RuleTarget[] = [{
 				target: '',
+				targetType: TargetType.GLOB,
 				paths: ['file.cls','file.trigger','file.page','file.py','file.component']
 			}];
-		
+
 			let langPathMap: Map<LANGUAGE, string[]> = new Map();
 			langPathMap.set(LANGUAGE.APEX, ['file.cls','file.trigger']);
 			langPathMap.set(LANGUAGE.VISUALFORCE, ['file.page','file.component']);
@@ -36,16 +37,17 @@ describe('CpdEngine', () => {
 		it('should compare extensions case-insensitively', () => {
 			const targets: RuleTarget[] = [{
 				target: '',
+				targetType: TargetType.GLOB,
 				paths: ['file.Cls','file.tRIGGER']
 			}];
-		
+
 			let langPathMap: Map<LANGUAGE, string[]> = new Map();
 			langPathMap.set(LANGUAGE.APEX, ['file.Cls','file.tRIGGER']);
 			expect((testEngine as any).sortPaths(targets)).to.eql(langPathMap);
 		});
 	});
 
-	
+
 	describe('isEngineRequested()', () => {
 		const emptyEngineOptions = new Map<string, string>();
 
@@ -90,5 +92,5 @@ describe('CpdEngine', () => {
 		});
 	});
 
-    
+
 });

--- a/test/lib/eslint/BaseEslintEngine.test.ts
+++ b/test/lib/eslint/BaseEslintEngine.test.ts
@@ -115,8 +115,7 @@ describe('Tests for BaseEslintEngine', () => {
 			});
 
 			it('should use target as current working directory if target is a directory', async () => {
-				const isDir = true;
-				const target = DataGenerator.getDummyTarget(isDir);
+				const target = DataGenerator.getDummyTarget();
 
 				const StaticDependenciesMock = mockStaticDependencies(target, getDummyESLint());
 
@@ -154,7 +153,7 @@ describe('Tests for BaseEslintEngine', () => {
 				const results = await engine.run(
 					[DataGenerator.getDummyRuleGroup()],
 					[], // no rules
-					[DataGenerator.getDummyTarget(true)],
+					[DataGenerator.getDummyTarget()],
 					emptyEngineOptions
 				);
 
@@ -426,7 +425,8 @@ async function createAbstractEngine(target: RuleTarget, StaticDependenciesMock: 
 	Mockito.when(MockStrategy.filterUnsupportedPaths(target.paths)).thenReturn(target.paths);
 	Mockito.when(MockStrategy.getLanguages()).thenReturn(['language']);
 	Mockito.when(MockStrategy.processRuleViolation()).thenReturn((filename: string, ruleViolation: RuleViolation)=> {
-		//do nothing
+		// Simply return true.
+		return true;
 	});
 
 	const engine = await createDummyEngine(Mockito.instance(MockStrategy), Mockito.instance(StaticDependenciesMock));

--- a/test/lib/eslint/EslintTestDataGenerator.ts
+++ b/test/lib/eslint/EslintTestDataGenerator.ts
@@ -1,4 +1,5 @@
 import { Rule, RuleGroup, RuleTarget, ESRule } from '../../../src/types';
+import { TargetType } from '../../../src/Constants';
 import {ESLint, Linter} from 'eslint';
 
 const engineName = 'TestHarnessEngine'; // TODO: crude code. revisit
@@ -22,10 +23,10 @@ export function getDummyRule(myEngineName = engineName): Rule {
 	}
 }
 
-export function getDummyTarget(isDir = true): RuleTarget {
+export function getDummyTarget(targetType = TargetType.DIRECTORY): RuleTarget {
 	return {
 		target: "/some/target",
-		isDirectory: isDir,
+		targetType,
 		paths: ['/some/target/path1', '/some/target/path2']
 	}
 }

--- a/test/lib/retire-js/RetireJsEngine.test.ts
+++ b/test/lib/retire-js/RetireJsEngine.test.ts
@@ -1,10 +1,10 @@
 import 'reflect-metadata';
 import {Rule, RuleResult, RuleTarget} from '../../../src/types';
-import path = require('path');
 import {expect} from 'chai';
 import {RetireJsEngine, RetireJsInvocation} from '../../../src/lib/retire-js/RetireJsEngine'
 import * as TestOverrides from '../../test-related-lib/TestOverrides';
-import { CUSTOM_CONFIG } from '../../../src/Constants';
+import {CUSTOM_CONFIG, TargetType} from '../../../src/Constants';
+import path = require('path');
 
 
 TestOverrides.initializeTestSetup();
@@ -37,6 +37,7 @@ describe('RetireJsEngine', () => {
 			];
 			const globTarget: RuleTarget = {
 				target: path.join('.', 'test', 'code-fixtures', 'projects', 'dep-test-app', '**', 'jquery*.js'),
+				targetType: TargetType.GLOB,
 				paths: globPaths
 			};
 
@@ -47,7 +48,7 @@ describe('RetireJsEngine', () => {
 			];
 			const dirTarget: RuleTarget = {
 				target: path.join('.', 'test', 'code-fixtures', 'projects', 'dep-test-app', 'folder-c'),
-				isDirectory: true,
+				targetType: TargetType.DIRECTORY,
 				paths: dirPaths
 			};
 
@@ -57,6 +58,7 @@ describe('RetireJsEngine', () => {
 			];
 			const fileTarget: RuleTarget = {
 				target: path.join('.', 'test', 'code-fixtures', 'projects', 'dep-test-app', 'folder-d', 'OrangeChicken.js'),
+				targetType: TargetType.FILE,
 				paths: filePaths
 			};
 
@@ -70,7 +72,7 @@ describe('RetireJsEngine', () => {
 			];
 			const resourceTarget: RuleTarget = {
 				target: path.join('.', 'test', 'code-fixtures', 'projects', 'dep-test-app', 'folder-e'),
-				isDirectory: true,
+				targetType: TargetType.DIRECTORY,
 				paths: resourcePaths
 			};
 
@@ -82,7 +84,7 @@ describe('RetireJsEngine', () => {
 			];
 			const implicitResourceTarget: RuleTarget = {
 				target: path.join('test', 'code-fixtures', 'projects', 'dep-test-app', 'folder-g'),
-				isDirectory: true,
+				targetType: TargetType.DIRECTORY,
 				paths: implicitResourcePaths
 			};
 
@@ -148,6 +150,7 @@ describe('RetireJsEngine', () => {
 			];
 			const flatZipTarget: RuleTarget = {
 				target: path.join('test', 'code-fixtures', 'projects', 'dep-test-app', 'folder-f', 'ZipFile*'),
+				targetType: TargetType.GLOB,
 				paths: flatZipPaths
 			};
 
@@ -158,6 +161,7 @@ describe('RetireJsEngine', () => {
 			];
 			const verticalZipTarget: RuleTarget = {
 				target: path.join('test', 'code-fixtures', 'projects', 'dep-test-app', 'folder-h', '*.zip'),
+				targetType: TargetType.GLOB,
 				paths: verticalZipPaths
 			};
 
@@ -169,6 +173,7 @@ describe('RetireJsEngine', () => {
 			];
 			const imgTarget: RuleTarget = {
 				target: path.join('test', 'code-fixtures', 'project', 'dep-test-app', 'folder-f', 'ImageFile*'),
+				targetType: TargetType.GLOB,
 				paths: imgPaths
 			};
 


### PR DESCRIPTION
This PR does the following:
- Replaces the `isDirectory` property on the `RuleTarget` type with a `TargetType` enum whose values are `FILE`, `DIRECTORY`, and `GLOB`.
- Discards ESLint ignore file warnings unless they correspond to a directly-targeted file, thereby preserving ESLint's default behavior.