### PR TITLE
NEW (GraphEngine): @W-13569674@: Create PerformNullCheckOnSoqlVariables rule, fix instance variable resolution

### DIFF
--- a/sfge/src/main/java/com/salesforce/config/UserFacingMessages.java
+++ b/sfge/src/main/java/com/salesforce/config/UserFacingMessages.java
@@ -19,7 +19,9 @@ public final class UserFacingMessages {
         public static final String AVOID_DATABASE_OPERATION_IN_LOOP =
                 "Detects database operations inside loops, which can cause degraded performance.";
         public static final String SHARING_RULE =
-                "Identifies a database operation executed outside of a \"with sharing\" policy. Warns when DML or SOQL operations inherit sharing rules implicitly instead of explicitly";
+                "Identifies a database operation executed outside of a \"with sharing\" policy. Warns when DML or SOQL operations inherit sharing rules implicitly instead of explicitly.";
+        public static final String PERFORM_NULL_CHECK_ON_SOQL_VARIABLE =
+                "Identifies SOQL queries with variables in WHERE clauses that lack null checks.";
     }
 
     public static final class RuleViolationTemplates {
@@ -154,5 +156,11 @@ public final class UserFacingMessages {
          */
         public static final String WARNING_TEMPLATE =
                 "Database operation executed in a class that implicitly inherits a sharing policy from %s %s. Explicitly assign a sharing policy instead.";
+    }
+
+    public static final class PerformNullCheckOnSoqlVariablesTemplates {
+        /** String param: name of variable */
+        public static final String MESSAGE_TEMPLATE =
+                "Null check is missing for variable %s used in SOQL query.";
     }
 }

--- a/sfge/src/main/java/com/salesforce/graph/ops/MethodUtil.java
+++ b/sfge/src/main/java/com/salesforce/graph/ops/MethodUtil.java
@@ -518,7 +518,15 @@ public final class MethodUtil {
                 apexValue = SystemSchema.getInstance();
             } else {
                 // Symbolic method call such as c.myMethod()
-                apexValue = symbols.getApexValue(symbolicName).orElse(null);
+
+                // if this is a variable, resolve to the class instance's variable if it contains a
+                // "this." e.g. this.varName
+                if ((vertex instanceof VariableExpressionVertex)
+                        && ((VariableExpressionVertex) vertex).isThisReference()) {
+                    apexValue = symbols.getApexValueFromInstanceScope(symbolicName).orElse(null);
+                } else {
+                    apexValue = symbols.getApexValue(symbolicName).orElse(null);
+                }
             }
         }
 

--- a/sfge/src/main/java/com/salesforce/graph/ops/expander/ApexPathExpander.java
+++ b/sfge/src/main/java/com/salesforce/graph/ops/expander/ApexPathExpander.java
@@ -545,7 +545,7 @@ class ApexPathExpander
             // allowing the caller to know which predicate is interested in
             // which vertex without the need to call
             // #test a second time
-            if (predicate.test(predicateVertex)) {
+            if (predicate.test(predicateVertex, symbolProviderVisitor.getSymbolProvider())) {
                 predicate.accept(
                         new VertexPredicateVisitor() {
                             @Override

--- a/sfge/src/main/java/com/salesforce/graph/symbols/AbstractDefaultNoOpScope.java
+++ b/sfge/src/main/java/com/salesforce/graph/symbols/AbstractDefaultNoOpScope.java
@@ -40,6 +40,11 @@ public abstract class AbstractDefaultNoOpScope implements MutableSymbolProvider 
     }
 
     @Override
+    public Optional<ApexValue<?>> getApexValueFromInstanceScope(String key) {
+        return Optional.empty();
+    }
+
+    @Override
     public Optional<ApexValue<?>> getReturnedValue(InvocableVertex vertex) {
         return Optional.empty();
     }

--- a/sfge/src/main/java/com/salesforce/graph/symbols/CloningSymbolProvider.java
+++ b/sfge/src/main/java/com/salesforce/graph/symbols/CloningSymbolProvider.java
@@ -59,6 +59,11 @@ public final class CloningSymbolProvider implements SymbolProvider {
     }
 
     @Override
+    public Optional<ApexValue<?>> getApexValueFromInstanceScope(String key) {
+        return delegate.getApexValueFromInstanceScope(key).map(a -> a.deepClone());
+    }
+
+    @Override
     public ChainedVertex getValueAtTimeOfInvocation(InvocableVertex vertex, ChainedVertex value) {
         // Vertices are singletons
         return delegate.getValueAtTimeOfInvocation(vertex, value);

--- a/sfge/src/main/java/com/salesforce/graph/symbols/DefaultSymbolProviderVertexVisitor.java
+++ b/sfge/src/main/java/com/salesforce/graph/symbols/DefaultSymbolProviderVertexVisitor.java
@@ -154,6 +154,14 @@ public class DefaultSymbolProviderVertexVisitor
     }
 
     @Override
+    public Optional<ApexValue<?>> getApexValueFromInstanceScope(String key) {
+        // implementation of #getApexValueFromInstance should correctly walk up stack of scopes
+        // with #getClosestClassInstanceScope to find the relevant class instance, so here we can
+        // just call #getApexValueFromInstance on the first scope on the stack
+        return scopeStack.peek().getMutableSymbolProvider().getApexValueFromInstanceScope(key);
+    }
+
+    @Override
     public Optional<ApexValue<?>> getReturnedValue(InvocableVertex vertex) {
         return scopeStack.peek().getMutableSymbolProvider().getReturnedValue(vertex);
     }

--- a/sfge/src/main/java/com/salesforce/graph/symbols/JSONDeserializeFactory.java
+++ b/sfge/src/main/java/com/salesforce/graph/symbols/JSONDeserializeFactory.java
@@ -170,7 +170,7 @@ public final class JSONDeserializeFactory {
     /** Indicates that a path contains {@link MethodCallExpressionVertex} */
     private static final class MethodCallExpressionPredicate implements VertexPredicate {
         @Override
-        public boolean test(BaseSFVertex vertex) {
+        public boolean test(BaseSFVertex vertex, SymbolProvider provider) {
             return vertex instanceof MethodCallExpressionVertex;
         }
 

--- a/sfge/src/main/java/com/salesforce/graph/symbols/SymbolProvider.java
+++ b/sfge/src/main/java/com/salesforce/graph/symbols/SymbolProvider.java
@@ -51,6 +51,12 @@ public interface SymbolProvider {
     Optional<ApexValue<?>> getApexValue(String key);
 
     /**
+     * Get the ApexValue represented by {@code key} in the <b>class instance scope</b> at this
+     * moment. Resolving it to the most specific value.
+     */
+    Optional<ApexValue<?>> getApexValueFromInstanceScope(String key);
+
+    /**
      * Get the resolved value at the time the method was invoked. This is used to resolve what was
      * invoked during object constructors
      */

--- a/sfge/src/main/java/com/salesforce/graph/vertex/VertexPredicate.java
+++ b/sfge/src/main/java/com/salesforce/graph/vertex/VertexPredicate.java
@@ -1,10 +1,16 @@
 package com.salesforce.graph.vertex;
 
+import com.salesforce.graph.symbols.SymbolProvider;
 import com.salesforce.graph.visitor.VertexPredicateVisitor;
 
 public interface VertexPredicate {
-    /** Return true if the implementer is interested in this vertex. */
-    boolean test(BaseSFVertex vertex);
+    /**
+     * Return true if the implementer is interested in this vertex.<br>
+     * <br>
+     * WARNING: the {@link SymbolProvider} parameter is experimental and may be removed in future
+     * releases. It should be used sparingly, for performance reasons.
+     */
+    boolean test(BaseSFVertex vertex, SymbolProvider provider);
 
     /** Dispatch to a {@link VertexPredicateVisitor} */
     void accept(VertexPredicateVisitor visitor);

--- a/sfge/src/main/java/com/salesforce/rules/ApexFlsViolationRule.java
+++ b/sfge/src/main/java/com/salesforce/rules/ApexFlsViolationRule.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableSet;
 import com.salesforce.exception.UnexpectedException;
 import com.salesforce.graph.ApexPath;
 import com.salesforce.graph.source.ApexPathSource.Type;
+import com.salesforce.graph.symbols.SymbolProvider;
 import com.salesforce.graph.vertex.BaseSFVertex;
 import com.salesforce.rules.fls.apex.operations.FlsViolationInfo;
 import java.util.*;
@@ -113,7 +114,7 @@ public final class ApexFlsViolationRule extends AbstractPathTraversalRule {
     }
 
     @Override
-    public boolean test(BaseSFVertex vertex) {
+    public boolean test(BaseSFVertex vertex, SymbolProvider provider) {
         // Return true when any rule handler is interested in this vertex
         return ruleHandlers.stream().anyMatch(ruleHandler -> ruleHandler.test(vertex));
     }

--- a/sfge/src/main/java/com/salesforce/rules/AvoidDatabaseOperationInLoop.java
+++ b/sfge/src/main/java/com/salesforce/rules/AvoidDatabaseOperationInLoop.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import com.salesforce.config.UserFacingMessages;
 import com.salesforce.graph.ApexPath;
 import com.salesforce.graph.source.ApexPathSource;
+import com.salesforce.graph.symbols.SymbolProvider;
 import com.salesforce.graph.vertex.BaseSFVertex;
 import com.salesforce.rules.avoiddatabaseoperationinloop.AvoidDatabaseOperationInLoopHandler;
 import java.util.ArrayList;
@@ -26,7 +27,7 @@ public final class AvoidDatabaseOperationInLoop extends AbstractPathTraversalRul
 
     /** check if a certain vertex is of interest to this rule */
     @Override
-    public boolean test(BaseSFVertex vertex) {
+    public boolean test(BaseSFVertex vertex, SymbolProvider provider) {
         return ruleHandler.test(vertex);
     }
 

--- a/sfge/src/main/java/com/salesforce/rules/AvoidMultipleMassSchemaLookups.java
+++ b/sfge/src/main/java/com/salesforce/rules/AvoidMultipleMassSchemaLookups.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import com.salesforce.config.UserFacingMessages;
 import com.salesforce.graph.ApexPath;
 import com.salesforce.graph.source.ApexPathSource;
+import com.salesforce.graph.symbols.SymbolProvider;
 import com.salesforce.graph.vertex.BaseSFVertex;
 import com.salesforce.rules.multiplemassschemalookup.MultipleMassSchemaLookupRuleHandler;
 import java.util.ArrayList;
@@ -26,7 +27,7 @@ public class AvoidMultipleMassSchemaLookups extends AbstractPathTraversalRule {
     }
 
     @Override
-    public boolean test(BaseSFVertex vertex) {
+    public boolean test(BaseSFVertex vertex, SymbolProvider provider) {
         return ruleHandler.test(vertex);
     }
 

--- a/sfge/src/main/java/com/salesforce/rules/PerformNullCheckOnSoqlVariables.java
+++ b/sfge/src/main/java/com/salesforce/rules/PerformNullCheckOnSoqlVariables.java
@@ -1,0 +1,142 @@
+package com.salesforce.rules;
+
+import com.google.common.collect.ImmutableSet;
+import com.salesforce.config.UserFacingMessages;
+import com.salesforce.exception.ProgrammingException;
+import com.salesforce.exception.UnexpectedException;
+import com.salesforce.graph.ApexPath;
+import com.salesforce.graph.source.ApexPathSource;
+import com.salesforce.graph.symbols.ScopeUtil;
+import com.salesforce.graph.symbols.SymbolProvider;
+import com.salesforce.graph.symbols.apex.ApexValue;
+import com.salesforce.graph.symbols.apex.Constraint;
+import com.salesforce.graph.vertex.BaseSFVertex;
+import com.salesforce.graph.vertex.SFVertex;
+import com.salesforce.graph.vertex.SoqlExpressionVertex;
+import com.salesforce.graph.vertex.VariableExpressionVertex;
+import java.util.*;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+
+public final class PerformNullCheckOnSoqlVariables extends AbstractPathTraversalRule {
+
+    private static final ImmutableSet<ApexPathSource.Type> SOURCE_TYPES =
+            ImmutableSet.copyOf(ApexPathSource.Type.values());
+
+    private static final String URL =
+            "https://forcedotcom.github.io/sfdx-scanner/en/v3.x/salesforce-graph-engine/rules/#PerformNullCheckOnSoqlVariables";
+
+    // don't instantiate
+    private PerformNullCheckOnSoqlVariables() {}
+
+    @Override
+    public ImmutableSet<ApexPathSource.Type> getSourceTypes() {
+        return SOURCE_TYPES;
+    }
+
+    @Override
+    protected int getSeverity() {
+        return SEVERITY.MODERATE.code;
+    }
+
+    @Override
+    protected String getDescription() {
+        return UserFacingMessages.RuleDescriptions.PERFORM_NULL_CHECK_ON_SOQL_VARIABLE;
+    }
+
+    @Override
+    protected String getCategory() {
+        return CATEGORY.PERFORMANCE.name;
+    }
+
+    @Override
+    protected String getUrl() {
+        return URL;
+    }
+
+    public static PerformNullCheckOnSoqlVariables getInstance() {
+        return LazyHolder.INSTANCE;
+    }
+
+    @Override
+    protected boolean isEnabled() {
+        return true;
+    }
+
+    /**
+     * Tests a vertex using a symbol provider to check if it violates this rule.
+     *
+     * @param vertex the vertex to check for this rule
+     * @param symbols a {@link SymbolProvider} that can provide symbols for the given vertex
+     * @return true if, according to the symbol provider, the vertex is equal to null, constrained
+     *     to be null, or has an indeterminate value
+     */
+    @Override
+    public boolean test(BaseSFVertex vertex, SymbolProvider symbols) {
+
+        // We only check for SOQL expressions with variables as grandchildren.
+        // No need to check for MethodCallExpressionVertex because the only relevant method is
+        // Database.queryWithBinds, which already does null checks for the keys and
+        // values in its bind variables.
+        if (!(vertex instanceof VariableExpressionVertex)
+                || !(vertex.getParent().getParent() instanceof SoqlExpressionVertex)) {
+            return false;
+        }
+
+        VariableExpressionVertex variableExpressionVertex = (VariableExpressionVertex) vertex;
+
+        // try and find the value of this vertex
+        Optional<ApexValue<?>> variableValueOpt =
+                ScopeUtil.resolveToApexValue(symbols, variableExpressionVertex);
+        if (variableValueOpt.isPresent()) {
+            ApexValue<?> variableValue = variableValueOpt.get();
+
+            if (variableValue.hasNegativeConstraint(Constraint.Null)) {
+                // negative constraint means the value is guaranteed NOT to be null,
+                // so this deserves no violation
+                return false;
+            } else if (variableValue.isNull() || variableValue.isIndeterminant()) {
+                // if the variable is null (is actually null or has positive null constraint) OR the
+                // value is indeterminant, this deserves a violation
+                return true;
+            }
+
+        } else {
+            throw new UnexpectedException(
+                    "PerformNullCheckOnSoqlVariables couldn't find an apex value associated with variable vertex "
+                            + vertex);
+        }
+        return false;
+    }
+
+    @Override
+    protected List<RuleThrowable> _run(
+            GraphTraversalSource g, ApexPath path, BaseSFVertex sinkVertex) {
+        if (!(sinkVertex instanceof VariableExpressionVertex)) {
+            throw new ProgrammingException(
+                    "PerformNullCheckOnSoqlVariables rule can only be applied to VariableExpressionVertex sink vertex. Provided sink vertex="
+                            + sinkVertex);
+        }
+
+        VariableExpressionVertex vertex = (VariableExpressionVertex) sinkVertex;
+        final SFVertex sourceVertex = path.getMethodVertex().orElse(null);
+
+        // Note: this rule runs differently. The test(BaseSFVertex, SymbolProvider) method
+        // above only accepts vertices that are confirmed to be violations. So, this run method just
+        // needs to actually create and return the violation.
+        return Collections.singletonList(
+                new Violation.PathBasedRuleViolation(
+                        String.format(
+                                UserFacingMessages.PerformNullCheckOnSoqlVariablesTemplates
+                                        .MESSAGE_TEMPLATE,
+                                vertex.getFullName()),
+                        sourceVertex,
+                        sinkVertex));
+    }
+
+    // lazy holder
+    private static final class LazyHolder {
+        // postpone initialization until after first use
+        private static final PerformNullCheckOnSoqlVariables INSTANCE =
+                new PerformNullCheckOnSoqlVariables();
+    }
+}

--- a/sfge/src/main/java/com/salesforce/rules/UseWithSharingOnDatabaseOperation.java
+++ b/sfge/src/main/java/com/salesforce/rules/UseWithSharingOnDatabaseOperation.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import com.salesforce.config.UserFacingMessages;
 import com.salesforce.graph.ApexPath;
 import com.salesforce.graph.source.ApexPathSource;
+import com.salesforce.graph.symbols.SymbolProvider;
 import com.salesforce.graph.vertex.BaseSFVertex;
 import com.salesforce.rules.usewithsharingondatabaseoperation.UseWithSharingOnDatabaseOperationHandler;
 import java.util.ArrayList;
@@ -25,7 +26,7 @@ public final class UseWithSharingOnDatabaseOperation extends AbstractPathTravers
     }
 
     @Override
-    public boolean test(BaseSFVertex vertex) {
+    public boolean test(BaseSFVertex vertex, SymbolProvider provider) {
         return ruleHandler.test(vertex);
     }
 

--- a/sfge/src/test/java/com/salesforce/cli/CliArgParserTest.java
+++ b/sfge/src/test/java/com/salesforce/cli/CliArgParserTest.java
@@ -56,7 +56,7 @@ public class CliArgParserTest {
         // As we add new DFA and non-DFA rules, the numbers in these tests
         // will increase.
         "pathless, 1",
-        "dfa, 6"
+        "dfa, 7"
     })
     @ParameterizedTest(name = "{displayName}: {0} rules")
     public void catalogFlowReturnsExpectedRules(String arg, int ruleCount) {

--- a/sfge/src/test/java/com/salesforce/graph/ops/ApexPathUtilTest.java
+++ b/sfge/src/test/java/com/salesforce/graph/ops/ApexPathUtilTest.java
@@ -70,7 +70,7 @@ public class ApexPathUtilTest {
         VertexPredicate predicate =
                 new AbstractVisitingVertexPredicate() {
                     @Override
-                    public boolean test(BaseSFVertex vertex) {
+                    public boolean test(BaseSFVertex vertex, SymbolProvider provider) {
                         return vertex instanceof MethodCallExpressionVertex;
                     }
                 };

--- a/sfge/src/test/java/com/salesforce/graph/ops/directive/EngineDirectiveTest.java
+++ b/sfge/src/test/java/com/salesforce/graph/ops/directive/EngineDirectiveTest.java
@@ -13,6 +13,7 @@ import com.salesforce.collections.CollectionUtil;
 import com.salesforce.graph.Schema;
 import com.salesforce.graph.ops.expander.ApexPathExpanderConfig;
 import com.salesforce.graph.symbols.ContextProviders;
+import com.salesforce.graph.symbols.SymbolProvider;
 import com.salesforce.graph.vertex.AbstractVisitingVertexPredicate;
 import com.salesforce.graph.vertex.BaseSFVertex;
 import com.salesforce.graph.vertex.DmlStatementVertex;
@@ -501,7 +502,7 @@ public class EngineDirectiveTest {
         VertexPredicate predicate =
                 new AbstractVisitingVertexPredicate() {
                     @Override
-                    public boolean test(BaseSFVertex vertex) {
+                    public boolean test(BaseSFVertex vertex, SymbolProvider symbols) {
                         if (vertex instanceof MethodCallExpressionVertex) {
                             MethodCallExpressionVertex methodCallExpression =
                                     (MethodCallExpressionVertex) vertex;
@@ -562,7 +563,7 @@ public class EngineDirectiveTest {
         VertexPredicate predicate =
                 new AbstractVisitingVertexPredicate() {
                     @Override
-                    public boolean test(BaseSFVertex vertex) {
+                    public boolean test(BaseSFVertex vertex, SymbolProvider symbols) {
                         if (vertex instanceof MethodCallExpressionVertex) {
                             MethodCallExpressionVertex methodCallExpression =
                                     (MethodCallExpressionVertex) vertex;
@@ -612,7 +613,7 @@ public class EngineDirectiveTest {
         VertexPredicate predicate =
                 new AbstractVisitingVertexPredicate() {
                     @Override
-                    public boolean test(BaseSFVertex vertex) {
+                    public boolean test(BaseSFVertex vertex, SymbolProvider symbols) {
                         if (vertex instanceof MethodCallExpressionVertex) {
                             MethodCallExpressionVertex methodCallExpression =
                                     (MethodCallExpressionVertex) vertex;

--- a/sfge/src/test/java/com/salesforce/graph/ops/expander/NullApexValueConstrainerTest.java
+++ b/sfge/src/test/java/com/salesforce/graph/ops/expander/NullApexValueConstrainerTest.java
@@ -9,6 +9,7 @@ import com.salesforce.exception.UnexpectedException;
 import com.salesforce.graph.ApexPath;
 import com.salesforce.graph.ApexPathVertexMetaInfo;
 import com.salesforce.graph.ops.ApexPathUtil;
+import com.salesforce.graph.symbols.SymbolProvider;
 import com.salesforce.graph.symbols.apex.ApexStringValue;
 import com.salesforce.graph.symbols.apex.Constraint;
 import com.salesforce.graph.vertex.AbstractVisitingVertexPredicate;
@@ -94,7 +95,7 @@ public class NullApexValueConstrainerTest {
         VertexPredicate predicate =
                 new AbstractVisitingVertexPredicate() {
                     @Override
-                    public boolean test(BaseSFVertex vertex) {
+                    public boolean test(BaseSFVertex vertex, SymbolProvider provider) {
                         return vertex instanceof StandardConditionVertex;
                     }
                 };
@@ -183,7 +184,7 @@ public class NullApexValueConstrainerTest {
         VertexPredicate predicate =
                 new AbstractVisitingVertexPredicate() {
                     @Override
-                    public boolean test(BaseSFVertex vertex) {
+                    public boolean test(BaseSFVertex vertex, SymbolProvider provider) {
                         return vertex instanceof StandardConditionVertex;
                     }
                 };

--- a/sfge/src/test/java/com/salesforce/rules/RuleRunnerTest.java
+++ b/sfge/src/test/java/com/salesforce/rules/RuleRunnerTest.java
@@ -18,6 +18,7 @@ import com.salesforce.graph.cache.VertexCache;
 import com.salesforce.graph.cache.VertexCacheProvider;
 import com.salesforce.graph.cache.VertexCacheTestProvider;
 import com.salesforce.graph.source.ApexPathSource;
+import com.salesforce.graph.symbols.SymbolProvider;
 import com.salesforce.graph.vertex.BaseSFVertex;
 import com.salesforce.graph.vertex.MethodVertex;
 import com.salesforce.graph.vertex.ReturnStatementVertex;
@@ -259,12 +260,13 @@ public class RuleRunnerTest {
         }
 
         @Override
-        public boolean test(BaseSFVertex vertex) {
+        public boolean test(BaseSFVertex vertex, SymbolProvider provider) {
             // The test should show interest in the return statement for any method defined in the
             // "MyClass" class.
             return vertex instanceof ReturnStatementVertex
                     && vertex.getParentClass().get().getDefiningType().startsWith("MyClass");
         }
+
 
         public static PathTraversalTestRule getInstance() {
             return LazyHolder.INSTANCE;

--- a/sfge/src/test/java/com/salesforce/rules/RuleUtilTest.java
+++ b/sfge/src/test/java/com/salesforce/rules/RuleUtilTest.java
@@ -28,7 +28,7 @@ public class RuleUtilTest {
         try {
             List<AbstractRule> allRules = RuleUtil.getEnabledRules();
             MatcherAssert.assertThat(
-                    "Wrong number of rules returned. Did you add any?", allRules, hasSize(7));
+                    "Wrong number of rules returned. Did you add any?", allRules, hasSize(8));
             assertTrue(allRules.contains(ApexFlsViolationRule.getInstance()));
         } catch (Exception ex) {
             fail("Unexpected " + ex.getClass().getSimpleName() + ": " + ex.getMessage());

--- a/sfge/src/test/java/com/salesforce/rules/fls/apex/VariableResolutionTest.java
+++ b/sfge/src/test/java/com/salesforce/rules/fls/apex/VariableResolutionTest.java
@@ -1,0 +1,223 @@
+package com.salesforce.rules.fls.apex;
+
+import com.salesforce.rules.AbstractPathBasedRule;
+import com.salesforce.rules.ApexFlsViolationRule;
+import com.salesforce.rules.fls.apex.operations.FlsConstants;
+import com.salesforce.testutils.BaseFlsTest;
+import org.junit.jupiter.api.Test;
+
+public class VariableResolutionTest extends BaseFlsTest {
+
+    private final AbstractPathBasedRule rule = ApexFlsViolationRule.getInstance();
+
+    /**
+     * It's a violation to create an account with a Phone field after checking if the Name field is
+     * createable. This tests that this.fieldName correctly resolves to the instance variable value,
+     * "Name".
+     */
+    @Test
+    public void testUnsafeInsertionBecauseOfInstanceVar() {
+        // spotless:off
+        String sourceCode =
+            "public class MyClass {\n" +
+                "public String fieldName = 'Name';\n" +
+                "void foo() {\n" +
+                "   String fieldName = 'Phone';\n" +
+                "   boolean safe = Account.SObjectType.getDescribe().fields.getMap()" +
+                "                   .get(this.fieldName).getDescribe().isCreateable();\n" +
+                "   Account a = new Account(Phone = '867-5309');\n" +
+                "   if (safe) {\n" +
+                "       insert a;\n" +
+                "   }" +
+                "}\n" +
+            "}\n";
+        // spotless:on
+
+        assertViolations(
+                rule,
+                sourceCode,
+                expect(8, FlsConstants.FlsValidationType.INSERT, "Account").withField("Phone"));
+    }
+
+    /**
+     * It's not a violation to create an account with a Name field after checking if the Name field
+     * is createable. This tests that the reference to this.fieldName correctly resolves to the
+     * instance variable value, "Name".
+     */
+    @Test
+    public void testSafeInsertionBecauseOfInstanceVar() {
+        // spotless:off
+        String sourceCode =
+            "public class MyClass {\n" +
+                "public String fieldName = 'Name';\n" +
+                "void foo() {\n" +
+                "   String fieldName = 'Phone';\n" +
+                "   boolean safe = Account.SObjectType.getDescribe().fields.getMap()" +
+                "                   .get(this.fieldName).getDescribe().isCreateable();\n" +
+                "   Account a = new Account(Name = 'Jenny');\n" +
+                "   if (safe){\n" +
+                "       insert a;\n" +
+                "   }" +
+                "}\n" +
+            "}\n";
+        // spotless:on
+
+        assertNoViolation(rule, sourceCode);
+    }
+
+    /**
+     * It's not a violation to create an account with a Phone field after checking if the Phone
+     * field is createable. This tests that the reference to fieldName correctly resolves to the
+     * scoped variable value, "Phone".
+     */
+    @Test
+    public void testSafeInsertionBecauseOfScopeVar() {
+        // spotless:off
+        String sourceCode =
+            "public class MyClass {\n" +
+                "public String fieldName = 'Name';\n" +
+                "void foo() {\n" +
+                "   String fieldName = 'Phone';\n" +
+                "   boolean safe = Account.SObjectType.getDescribe().fields.getMap()" +
+                "                   .get(fieldName).getDescribe().isCreateable();\n" +
+                "   Account a = new Account(Phone = '867-5309');\n" +
+                "   if (safe) {\n" +
+                "       insert a;\n" +
+                "   }" +
+                "}\n" +
+            "}\n";
+        // spotless:on
+
+        assertNoViolation(rule, sourceCode);
+    }
+
+    /**
+     * It's a violation to create an account with a Name field after checking the Phone field is
+     * createable. This tests that the reference to fieldName correctly resolves to the scoped
+     * variable value, "Phone".
+     */
+    @Test
+    public void testUnsafeInsertionBecauseOfScopeVar() {
+        // spotless:off
+        String sourceCode =
+            "public class MyClass {\n" +
+                "public String fieldName = 'Name';\n" +
+                "void foo() {\n" +
+                "   String fieldName = 'Phone';\n" +
+                "   boolean safe = Account.SObjectType.getDescribe().fields.getMap()" +
+                "                   .get(fieldName).getDescribe().isCreateable();\n" +
+                "   Account a = new Account(Name = 'Jenny');\n" +
+                "   if (safe){\n" +
+                "       insert a;\n" +
+                "   }" +
+                "}\n" +
+            "}\n";
+        // spotless:on
+
+        assertViolations(
+                rule,
+                sourceCode,
+                expect(8, FlsConstants.FlsValidationType.INSERT, "Account").withField("Name"));
+    }
+
+    /**
+     * It's not a violation to create an account with a Name field after checking if the field Name
+     * is createable. This tests that the reference to this.fieldName correctly resolves to the
+     * instance variable value, "Name".
+     */
+    @Test
+    public void testInheritance_this() {
+        // spotless:off
+        String[] sourceCode = {
+          "public class GrandParent {\n" +
+              "public String fieldName = 'Phone';\n" +
+          "}",
+          "public class Parent extends GrandParent {\n" +
+              "public String fieldName = 'Phone';\n" +
+          "}",
+          "public class MyClass extends Parent {\n" +
+              "public String fieldName = 'Name';\n" +
+              "void foo() {\n" +
+              "   String fieldName = 'Phone';\n" +
+              "   boolean safe = Account.SObjectType.getDescribe().fields.getMap()" +
+              "                   .get(this.fieldName).getDescribe().isCreateable();\n" +
+              "   Account a = new Account(Name = 'Jenny');\n" +
+              "   if (safe) {\n" +
+              "       insert a;\n" +
+              "   }\n" +
+              "}\n" +
+          "}",
+        };
+        // spotless:on
+
+        assertNoViolation(rule, sourceCode);
+    }
+
+    /**
+     * It's not a violation to create an account with a Name field after checking if the field Name
+     * is createable. This tests that the reference to this.fieldName correctly resolves to the
+     * instance variable value, "Name" (which comes from the parent).
+     */
+    @Test
+    public void testInheritance_thisFromParent() {
+        // spotless:off
+        String[] sourceCode = {
+            "public class GrandParent {\n" +
+                "public String fieldName = 'Phone';\n" +
+            "}",
+            "public class Parent extends GrandParent {\n" +
+                "public String fieldName = 'Name';\n" +
+            "}",
+            "public class MyClass extends Parent {\n" +
+                "void foo() {\n" +
+                "   String fieldName = 'Phone';\n" +
+                "   boolean safe = Account.SObjectType.getDescribe().fields.getMap()" +
+                "                   .get(this.fieldName).getDescribe().isCreateable();\n" +
+                "   Account a = new Account(Name = 'Jenny');\n" +
+                "   if (safe) {\n" +
+                "       insert a;\n" +
+                "   }\n" +
+                "}\n" +
+            "}",
+        };
+        // spotless:on
+
+        assertNoViolation(rule, sourceCode);
+    }
+
+    /**
+     * It's a violation to create an account with a Name field after checking if the field Phone is
+     * createable. This tests that the reference to super.fieldName correctly resolves to the
+     * instance variable's value (which is from a parent class).
+     */
+    @Test
+    public void testInheritance_super() {
+        // spotless:off
+        String[] sourceCode = {
+            "public class GrandParent {\n" +
+                "public String fieldName = 'Phone';\n" +
+                "}",
+            "public class Parent extends GrandParent {\n" +
+                "public String fieldName = 'Phone';\n" +
+                "}",
+            "public class MyClass extends Parent {\n" +
+                "public String fieldName = 'Name';\n" +
+                "void foo() {\n" +
+                "   String fieldName = 'Phone';\n" +
+                "   boolean safe = Account.SObjectType.getDescribe().fields.getMap()" +
+                "                   .get(super.fieldName).getDescribe().isCreateable();\n" +
+                "   Account a = new Account(Name = 'Jenny');\n" +
+                "   if (safe) {\n" +
+                "       insert a;\n" +
+                "   }\n" +
+                "}\n" +
+            "}",
+        };
+        // spotless:on
+
+        assertViolations(
+                rule,
+                sourceCode,
+                expect(8, FlsConstants.FlsValidationType.INSERT, "Account").withField("Name"));
+    }
+}

--- a/sfge/src/test/java/com/salesforce/rules/performnullcheckonsoqlvariables/PerformNullCheckOnSoqlVariablesTest.java
+++ b/sfge/src/test/java/com/salesforce/rules/performnullcheckonsoqlvariables/PerformNullCheckOnSoqlVariablesTest.java
@@ -1,0 +1,348 @@
+package com.salesforce.rules.performnullcheckonsoqlvariables;
+
+import com.salesforce.rules.PerformNullCheckOnSoqlVariables;
+import com.salesforce.testutils.BasePathBasedRuleTest;
+import com.salesforce.testutils.ViolationWrapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class PerformNullCheckOnSoqlVariablesTest extends BasePathBasedRuleTest {
+
+    private static final String MY_CLASS = "MyClass";
+
+    protected static final PerformNullCheckOnSoqlVariables RULE =
+            PerformNullCheckOnSoqlVariables.getInstance();
+
+    protected ViolationWrapper.SoqlNullViolationBuilder expect(int line, String varname) {
+        return new ViolationWrapper.SoqlNullViolationBuilder(line, varname);
+    }
+
+    @Test
+    public void testBasicNullString() {
+        // spotless:off
+        String sourceCode =
+            "public class " + MY_CLASS + " {\n" +
+            "   void foo() {\n" +
+            "       String nullString = null;\n" +
+            "       Account a = [SELECT Name FROM Account WHERE Name =: nullString LIMIT 1];\n" +
+            "   }\n" +
+            "}\n";
+        //  spotless:on
+
+        assertViolations(RULE, sourceCode, expect(4, "nullString"));
+    }
+
+    /**
+     * Since the entrypoint takes a parameter, this should be a violation due to indeterminate
+     * value.
+     */
+    @Test
+    public void testIndeterminateParameter() {
+        // spotless:off
+        String sourceCode =
+            "public class " + MY_CLASS + " {\n" +
+            "   void foo(String parameterName) {\n" +
+            "       Account a = [SELECT Name FROM Account WHERE Name =: parameterName LIMIT 1];\n" +
+            "   }\n" +
+            "}\n";
+        //  spotless:on
+
+        assertViolations(RULE, sourceCode, expect(3, "parameterName"));
+    }
+
+    @ValueSource(
+            strings = {
+                "nullInstanceVariable",
+                "this.nullInstanceVariable",
+                "emptyString",
+                "methodParameterVariable",
+                "methodScopeAccount.Name",
+                "accountWithNullName.Name",
+            })
+    @ParameterizedTest(name = "{displayName}: {0}")
+    public void testNullCheckOk(String varName) {
+        // spotless:off
+        String sourceCode =
+            "public class " + MY_CLASS + " {\n" +
+                "   String nullInstanceVariable = null;\n" +
+                "   String emptyString = '';\n" +
+                "   Account accountWithNullName = new Account(name = null);\n" +
+                "   void foo(String methodParameterVariable) {\n" +
+                "       Account methodScopeAccount = [SELECT Name FROM Account WHERE Name = 'Jane' LIMIT 1];\n" +
+                "       if (" + varName + " != null) {\n" +
+                "           Account a = [SELECT Name FROM Account WHERE Name =: " + varName + " LIMIT 1];\n" +
+                "       }\n" +
+                "   }\n" +
+                "}\n";
+        //  spotless:on
+
+        assertNoViolation(RULE, sourceCode);
+    }
+
+    @ValueSource(
+            strings = {
+                "nullInstanceVariable",
+                "this.nullInstanceVariable",
+                "emptyString",
+                "methodParameterVariable",
+                "methodScopeAccount.Name",
+                "accountWithNullName.Name",
+            })
+    @ParameterizedTest(name = "{displayName}: {0}")
+    public void testNullCheckElseOk(String varName) {
+        // spotless:off
+        String sourceCode =
+            "public class " + MY_CLASS + " {\n" +
+                "   String nullInstanceVariable = null;\n" +
+                "   String emptyString = '';\n" +
+                "   Account accountWithNullName = new Account(name = null);\n" +
+                "   void foo(String methodParameterVariable) {\n" +
+                "       Account methodScopeAccount = [SELECT Name FROM Account WHERE Name = 'Jane' LIMIT 1];\n" +
+                "       if (" + varName + " == null) {\n" +
+                "           return;\n" +
+                "       } else {\n" +
+                "           Account a = [SELECT Name FROM Account WHERE Name =: " + varName + " LIMIT 1];\n" +
+                "       }\n" +
+                "   }\n" +
+                "}\n";
+        //  spotless:on
+
+        assertNoViolation(RULE, sourceCode);
+    }
+
+    @ValueSource(
+            strings = {
+                "nullInstanceVariable",
+                "this.nullInstanceVariable",
+                "emptyString",
+                "methodParameterVariable",
+                "methodScopeAccount.Name",
+                "accountWithNullName.Name",
+            })
+    @ParameterizedTest(name = "{displayName}: {0}")
+    public void testReturnIfNullOk(String varName) {
+        // spotless:off
+        String sourceCode =
+            "public class " + MY_CLASS + " {\n" +
+                "   String nullInstanceVariable = null;\n" +
+                "   String emptyString = '';\n" +
+                "   Account accountWithNullName = new Account(name = null);\n" +
+                "   void foo(String methodParameterVariable) {\n" +
+                "       Account methodScopeAccount = [SELECT Name FROM Account WHERE Name = 'Jane' LIMIT 1];\n" +
+                "       if (" + varName + " == null) {\n" +
+                "           return;\n" +
+                "       }\n" +
+                "       Account a = [SELECT Name FROM Account WHERE Name =: " + varName + " LIMIT 1];\n" +
+                "   }\n" +
+                "}\n";
+        //  spotless:on
+
+        assertNoViolation(RULE, sourceCode);
+    }
+
+    @ValueSource(
+            strings = {
+                "nullInstanceVariable",
+                "this.nullInstanceVariable",
+                "methodParameterVariable",
+                "methodScopeAccount.Name",
+                "accountWithNullName.Name",
+            })
+    @ParameterizedTest(name = "{displayName}: {0}")
+    public void testNoNullCheck(String varName) {
+        // spotless:off
+        String sourceCode =
+            "public class " + MY_CLASS + " {\n" +
+                "   String nullInstanceVariable = null;\n" +
+                "   Account accountWithNullName = new Account(name = null);\n" +
+                "   void foo(String methodParameterVariable) {\n" +
+                "       Account methodScopeAccount = [SELECT Name FROM Account WHERE Name = 'Jane' LIMIT 1];\n" +
+                "       Account a = [SELECT Name FROM Account WHERE Name =: " + varName + " LIMIT 1];\n" +
+                "   }\n" +
+                "}\n";
+        //  spotless:on
+
+        assertViolations(RULE, sourceCode, expect(6, varName.replace("this.", "")));
+    }
+
+    /**
+     * These should all be violations. Though they are indeterminate, they are definitely null
+     * within the if statement.
+     */
+    @ValueSource(
+            strings = {
+                "methodParameterVariable",
+                "methodScopeAccount.Name",
+                "classScopeAccount.Name"
+            })
+    @ParameterizedTest(name = "{displayName}: {0}")
+    public void testPositiveNullConstrainedIndeterminate(String varName) {
+        // spotless:off
+        String sourceCode =
+            "public class " + MY_CLASS + " {\n" +
+                "   Account classScopeAccount = [SELECT Name FROM Account WHERE Name = '' LIMIT 1];\n" +
+                "   void foo(String methodParameterVariable) {\n" +
+                "       Account methodScopeAccount = [SELECT Name FROM Account WHERE Name = 'Jane' LIMIT 1];\n" +
+                "       if (" + varName + " == null) {\n" +
+                "           Account a = [SELECT Name FROM Account WHERE Name =: " + varName + " LIMIT 1];\n" +
+                "       }\n" +
+                "   }\n" +
+                "}\n";
+        //  spotless:on
+
+        assertViolations(RULE, sourceCode, expect(6, varName));
+    }
+
+    /**
+     * Even though this code runs a SOQL query only when emptyString is null, emptyString is never
+     * actually null since it is explicitly defined as an empty string. Therefore, there are no
+     * paths where the soql expression runs, and there are no violations.
+     *
+     * <p>Note: an empty string is not equal to null in Apex.
+     */
+    @Test
+    public void testNullVariableInsideSoqlStatementThatNeverRuns() {
+        // spotless:off
+        String sourceCode =
+            "public class " + MY_CLASS + " {\n" +
+                "   void foo() {\n" +
+                "       String emptyString = '';\n" +
+                "       if (emptyString == null) {\n" +
+                "           Account a = [SELECT Name, BillingState FROM Account WHERE Name =: emptyString LIMIT 1];\n" +
+                "       }\n" +
+                "   }\n" +
+                "}\n";
+        //  spotless:on
+
+        assertNoViolation(RULE, sourceCode);
+    }
+
+    /**
+     * Tests correctly resolving a scope variable when a scope and instance variable have the same
+     * name. Note: there is no need to test referencing static methods via "this.varName" because
+     * static methods cannot reference static properties via "this." in Apex.
+     */
+    @Test
+    public void testScopeAndInstanceVarSameName_resolveToScopeVar() {
+        // spotless:off
+        String sourceCode =
+            "public class " + MY_CLASS + " {\n" +
+            "   String nullString = 'ACTUALLY THERE IS TEXT!';\n" +
+            "   void foo() {\n" +
+            "       String nullString = null;\n" +
+            "       Account a = [SELECT Name FROM Account WHERE Name =: nullString LIMIT 1];\n" +
+            "   }\n" +
+            "}\n";
+        // spotless:on
+
+        assertViolations(RULE, sourceCode, expect(5, "nullString"));
+    }
+
+    @Test
+    public void testScopeAndInstanceVarSameName_resolveToInstanceVar() {
+        // spotless:off
+        String sourceCode =
+            "public class " + MY_CLASS + " {\n" +
+            "   String nullString = 'ACTUALLY THERE IS TEXT!';\n" +
+            "   void foo() {\n" +
+            "       String nullString = null;\n" +
+            "       Account a = [SELECT Name FROM Account WHERE Name =: this.nullString LIMIT 1];\n" +
+            "   }\n" +
+            "}\n";
+        // spotless:on
+
+        assertNoViolation(RULE, sourceCode);
+    }
+
+    @Test
+    public void testReassignVariable() {
+        // spotless:off
+        String sourceCode =
+            "public class " + MY_CLASS + " {\n" +
+                "   void foo(String parameterName) {\n" +
+                "       parameterName = null;\n" +
+                "       Account a = [SELECT Name FROM Account WHERE Name =: parameterName LIMIT 1];\n" +
+                "   }\n" +
+                "}\n";
+        // spotless:on
+
+        assertViolations(RULE, sourceCode, expect(4, "parameterName"));
+    }
+
+    /**
+     * Test null variables in the LIMIT and OFFSET clauses. // TODO: consider moving to {@link
+     * com.salesforce.rules.ApexNullPointerExceptionRule}. Technically, these throw a Null Pointer
+     * Exception in Apex.
+     *
+     * <p>NOTE: this will break when W-13876363 is fixed. This is acceptable and should not prevent
+     * us from fixing that bug. Afterwards, this rule might need to be updated. Currently, all
+     * VariableExpression children of a BindExpression (contained in a SoqlExpressionVertex) are
+     * checked for null values, including those in the LIMIT/OFFSET clauses. This rule may need to
+     * be updated to parse the SOQL statement and check only the variables contained in the WHERE
+     * clause.
+     */
+    @ValueSource(strings = {"LIMIT", "OFFSET"})
+    @ParameterizedTest(name = "{displayName}: {0}")
+    public void testNullVariableInLimitAndOffset(String command) {
+        // spotless:off
+        String sourceCode =
+            "public class " + MY_CLASS + " {\n" +
+            "   void foo() {\n" +
+            "       Integer i;\n" +
+            "       Account[] accs = [SELECT Name FROM Account " + command + " :i];\n" +
+            "   }\n" +
+            "}\n";
+        // spotless:on
+
+        assertViolations(RULE, sourceCode, expect(4, "i"));
+    }
+
+    /**
+     * Both cases of the if statement lead to the use of a non-null-checked variable in the soql
+     * expression. Though two paths lead to the same sink, only one violation should be thrown.
+     */
+    @Test
+    public void testMultiplePathsSameSink_twoBadPaths() {
+        // spotless:off
+        String sourceCode =
+            "public class MyClass {\n" +
+                "public void doOperation(Integer i) {\n" +
+                "   Account b = [SELECT Name FROM Account LIMIT :i];\n" +
+                "}\n" +
+                "public void foo(Integer i, Boolean maybe) {\n" +
+                "   if (maybe) {\n" +
+                "       doOperation(i);\n" +
+                "   } else {\n" +
+                "       doOperation(i);\n" +
+                "   }\n" +
+                "}\n" +
+            "}";
+        // spotless:on
+        assertViolations(RULE, sourceCode, expect(3, "i"));
+    }
+
+    /**
+     * Only one path leads to the use of a non-null-checked variable in the soql expression, even
+     * though both do the SOQL query. We'd expect one violation.
+     */
+    @Test
+    public void testMultiplePathsSameVertex_oneBadPath() {
+        // spotless:off
+        String sourceCode =
+            "public class MyClass {\n" +
+                "public void doOperation(Integer i) {\n" +
+                "   Account b = [SELECT Name FROM Account LIMIT :i];\n" +
+                "}\n" +
+                "public void foo(Integer i, Boolean maybe) {\n" +
+                "   if (i == null) {\n" +
+                "       doOperation(i);\n" +
+                "   } else {\n" +
+                "       doOperation(i);\n" +
+                "   }\n" +
+                "}\n" +
+            "}";
+        // spotless:on
+        assertViolations(RULE, sourceCode, expect(3, "i"));
+    }
+}

--- a/sfge/src/test/java/com/salesforce/testutils/ViolationWrapper.java
+++ b/sfge/src/test/java/com/salesforce/testutils/ViolationWrapper.java
@@ -320,6 +320,22 @@ public class ViolationWrapper {
         }
     }
 
+    public static class SoqlNullViolationBuilder extends ViolationBuilder {
+        private final String variableName;
+
+        public SoqlNullViolationBuilder(int sinkLine, String varname) {
+            super(sinkLine);
+            this.variableName = varname;
+        }
+
+        @Override
+        public String getMessage() {
+            return String.format(
+                    UserFacingMessages.PerformNullCheckOnSoqlVariablesTemplates.MESSAGE_TEMPLATE,
+                    this.variableName);
+        }
+    }
+
     public static class MessageBuilder {
         private final int line;
         private final String violationMsg;


### PR DESCRIPTION
Notable changes:
- Adds PerformNullCheckOnSoqlVariable and appropriate automated testing. 
- Adds `onAcceptVertex` method to `PathExpansionObserver` that is called when a `AbstractPathTraversalRule` accepts a vertex AND the a `PathExpansionObserver` has been registered with `ApexPathExpanderConfig.Builder#withObservedPredicate(VertexPredicate, PathExpansionObserver)`. 

QA Notes:
- Fixes a bug where `this.whateverVariable` would not correctly resolve using `ScopeUtil.resolveToApexValue`. See `sfge/src/test/java/com/salesforce/rules/fls/apex/VariableResolutionTest.java` and b86489c.