### PR TITLE
FIX (GraphEngine): @W-13869734@: Fix crash on explicit access level specified in Database.query method

### DIFF
--- a/sfge/src/main/java/com/salesforce/graph/symbols/apex/ApexSoqlValueFactory.java
+++ b/sfge/src/main/java/com/salesforce/graph/symbols/apex/ApexSoqlValueFactory.java
@@ -17,7 +17,7 @@ public final class ApexSoqlValueFactory {
                 if (QUERY.equalsIgnoreCase(methodName)
                         && chainedNames.size() == 1
                         && DATABASE.equalsIgnoreCase(chainedNames.get(0))) {
-                    if (vertex.getParameters().size() != 1) {
+                    if (vertex.getParameters().isEmpty() || vertex.getParameters().size() > 2) {
                         throw new UnexpectedException(vertex);
                     }
                     // Do not resolve this parameter, it will be resolved in #setConcreteType

--- a/sfge/src/main/java/com/salesforce/rules/fls/apex/operations/ValidationConverter.java
+++ b/sfge/src/main/java/com/salesforce/rules/fls/apex/operations/ValidationConverter.java
@@ -34,9 +34,20 @@ import org.apache.logging.log4j.Logger;
 public class ValidationConverter {
     private static final Logger LOGGER = LogManager.getLogger(ValidationConverter.class);
     private final FlsValidationType validationType;
+    private final boolean userModeOverride;
 
     public ValidationConverter(FlsValidationType validationType) {
+        this(validationType, false);
+    }
+
+    /**
+     * @param validationType the {@link FlsValidationType} to check for
+     * @param isUserModeOverride indicates whether the operation is accompanied by a User Mode
+     *     access level
+     */
+    public ValidationConverter(FlsValidationType validationType, boolean isUserModeOverride) {
         this.validationType = validationType;
+        this.userModeOverride = isUserModeOverride;
     }
 
     /** Converts SoqlExpressions to Validation representations */
@@ -50,7 +61,7 @@ public class ValidationConverter {
         return holder.getValidationReps();
     }
 
-    /** Converts given apexvalue to Validation Representations */
+    /** Converts given apexValue to Validation Representations. */
     public Set<FlsValidationRepresentation> convertToExpectedValidations(ApexValue<?> apexValue) {
         final ValidationHolder holder =
                 this.getHolder(apexValue, validationType.getProcessFields());
@@ -213,6 +224,7 @@ public class ValidationConverter {
         return apexValue;
     }
 
+    /** check if validation is necessary. if so, add it to holder. */
     private void convertSoqlQueryInfo(
             ValidationHolder holder,
             ProcessFields defaultProcessFields,
@@ -241,6 +253,15 @@ public class ValidationConverter {
                 if (LOGGER.isInfoEnabled()) {
                     LOGGER.info(
                             "A query that has \"WITH USER_MODE\" clause is inherently protected",
+                            queryInfo);
+                }
+                continue;
+            }
+
+            if (this.userModeOverride) {
+                if (LOGGER.isInfoEnabled()) {
+                    LOGGER.info(
+                            "A method in the Database class with \"USER_MODE\" accessLevel is inherently protected",
                             queryInfo);
                 }
                 continue;

--- a/sfge/src/test/java/com/salesforce/rules/usewithsharingondatabaseoperation/BaseUseWithSharingOnDatabaseOperationTest.java
+++ b/sfge/src/test/java/com/salesforce/rules/usewithsharingondatabaseoperation/BaseUseWithSharingOnDatabaseOperationTest.java
@@ -43,7 +43,7 @@ public abstract class BaseUseWithSharingOnDatabaseOperationTest extends BasePath
      * com.salesforce.graph.vertex.SoqlExpressionVertex}
      */
     public static final String[] SOQL_STATEMENTS = {
-        "Account b = [SELECT Id, NumberOfEmployees FROM account WHERE NumberOfEmployees = 3 LIMIT 1]",
+        "Account b = [SELECT Name, NumberOfEmployees FROM account WHERE NumberOfEmployees = 3 LIMIT 1]",
     };
 
     /**
@@ -66,15 +66,16 @@ public abstract class BaseUseWithSharingOnDatabaseOperationTest extends BasePath
         "Database.getAsyncLocator(Database.deleteAsync(List.of(a), false))",
         "Database.getAsyncSaveResult(Database.insert(a))",
         "Database.getDeleted('account__c', Datetime.now().addHours(-1), Datetime.now())",
-        "Database.getQueryLocator('SELECT Id, NumberOfEmployees FROM account WHERE NumberOfEmployees = 3 LIMIT 1')",
-        "Database.getQueryLocatorWithBinds('SELECT Id, NumberOfEmployees FROM account WHERE NumberOfEmployees = 3 LIMIT 1', new Map<String, Object>{'name' => 'KENSINGTON'})",
+        "Database.getQueryLocator('SELECT Name, NumberOfEmployees FROM account WHERE NumberOfEmployees = 3 LIMIT 1')",
+        "Database.getQueryLocatorWithBinds('SELECT Name, NumberOfEmployees FROM account WHERE NumberOfEmployees = :i LIMIT 1', new Map<String, Object>{'i' => 3})",
         "Database.getUpdated('account__c', Datetime.now().addHours(-1), Datetime.now())",
         "Database.insert(a)",
         "Database.insertAsync(a, nothing())",
         "Database.insertImmediate(a)",
         "Database.merge(a, new Account(name = 'Benjamin'))",
-        "Database.query('SELECT Id, NumberOfEmployees, Name FROM Account WHERE NumberOfEmployees = 100 LIMIT 1')",
-        "Database.queryWithBinds('SELECT ID, NumberOfEmployees, Name FROM Account WHERE NumberOfEmployees = 100', new Map<String, Object>{'Name' => 'WOLVES'})",
+        "Database.query('SELECT NumberOfEmployees, Name FROM Account WHERE NumberOfEmployees = 100 LIMIT 1')",
+        "Database.query('SELECT NumberOfEmployees, Name FROM Account WHERE NumberOfEmployees = 100 LIMIT 1', System.AccessLevel.USER_MODE)",
+        "Database.queryWithBinds('SELECT NumberOfEmployees, Name FROM Account WHERE NumberOfEmployees = :i', new Map<String, Object>{'i' => 100})",
         "Database.rollback(Database.setSavepoint())",
         "Database.undelete(a, false)",
         "Database.update(a, false)",

--- a/sfge/src/test/java/com/salesforce/rules/usewithsharingondatabaseoperation/SharingPolicySubclassesTest.java
+++ b/sfge/src/test/java/com/salesforce/rules/usewithsharingondatabaseoperation/SharingPolicySubclassesTest.java
@@ -36,7 +36,7 @@ public class SharingPolicySubclassesTest extends BaseUseWithSharingOnDatabaseOpe
 
     // PARENT - NO DECLARATION
 
-    @MethodSource("provideAllDatabaseOperations")
+    @MethodSource("provideSelectDatabaseOperations")
     @ParameterizedTest(name = "{displayName}: {0}")
     public void testNoDeclarationParentWithSharingSubclass(String operation) {
         String sourceCode = String.format(SUBCLASS_SOURCE, "", "with sharing", operation);
@@ -44,7 +44,7 @@ public class SharingPolicySubclassesTest extends BaseUseWithSharingOnDatabaseOpe
         assertNoViolation(RULE, sourceCode);
     }
 
-    @MethodSource("provideAllDatabaseOperations")
+    @MethodSource("provideSelectDatabaseOperations")
     @ParameterizedTest(name = "{displayName}: {0}")
     public void testNoDeclarationParentWithoutSharingSubclass(String operation) {
         String sourceCode = String.format(SUBCLASS_SOURCE, "", "without sharing", operation);
@@ -52,7 +52,7 @@ public class SharingPolicySubclassesTest extends BaseUseWithSharingOnDatabaseOpe
         assertViolations(RULE, sourceCode, expect(SINK_LINE));
     }
 
-    @MethodSource("provideAllDatabaseOperations")
+    @MethodSource("provideSelectDatabaseOperations")
     @ParameterizedTest(name = "{displayName}: {0}")
     public void testNoDeclarationParentInheritedSharingSubclass(String operation) {
         String sourceCode = String.format(SUBCLASS_SOURCE, "", "inherited sharing", operation);
@@ -60,7 +60,7 @@ public class SharingPolicySubclassesTest extends BaseUseWithSharingOnDatabaseOpe
         assertViolations(RULE, sourceCode, expect(SINK_LINE));
     }
 
-    @MethodSource("provideAllDatabaseOperations")
+    @MethodSource("provideSelectDatabaseOperations")
     @ParameterizedTest(name = "{displayName}: {0}")
     public void testNoDeclarationParentNoDeclarationSubclass(String operation) {
         String sourceCode = String.format(SUBCLASS_SOURCE, "", "", operation);
@@ -70,7 +70,7 @@ public class SharingPolicySubclassesTest extends BaseUseWithSharingOnDatabaseOpe
 
     // PARENT - WITH SHARING
 
-    @MethodSource("provideAllDatabaseOperations")
+    @MethodSource("provideSelectDatabaseOperations")
     @ParameterizedTest(name = "{displayName}: {0}")
     public void testWithSharingParentNoDeclarationSubclass(String operation) {
         String sourceCode = String.format(SUBCLASS_SOURCE, "with sharing", "", operation);
@@ -81,7 +81,7 @@ public class SharingPolicySubclassesTest extends BaseUseWithSharingOnDatabaseOpe
                 expectWarning(SINK_LINE, SharingPolicyUtil.InheritanceType.CALLING, MY_CLASS));
     }
 
-    @MethodSource("provideAllDatabaseOperations")
+    @MethodSource("provideSelectDatabaseOperations")
     @ParameterizedTest(name = "{displayName}: {0}")
     public void testWithSharingParentWithSharingSubclass(String operation) {
         String sourceCode =
@@ -90,7 +90,7 @@ public class SharingPolicySubclassesTest extends BaseUseWithSharingOnDatabaseOpe
         assertNoViolation(RULE, sourceCode);
     }
 
-    @MethodSource("provideAllDatabaseOperations")
+    @MethodSource("provideSelectDatabaseOperations")
     @ParameterizedTest(name = "{displayName}: {0}")
     public void testWithSharingParentInheritedSharingSubclass(String operation) {
         String sourceCode =
@@ -99,7 +99,7 @@ public class SharingPolicySubclassesTest extends BaseUseWithSharingOnDatabaseOpe
         assertNoViolation(RULE, sourceCode);
     }
 
-    @MethodSource("provideAllDatabaseOperations")
+    @MethodSource("provideSelectDatabaseOperations")
     @ParameterizedTest(name = "{displayName}: {0}")
     public void testWithSharingParentWithoutSharingSubclass(String operation) {
         String sourceCode =
@@ -110,7 +110,7 @@ public class SharingPolicySubclassesTest extends BaseUseWithSharingOnDatabaseOpe
 
     // PARENT - WITHOUT SHARING
 
-    @MethodSource("provideAllDatabaseOperations")
+    @MethodSource("provideSelectDatabaseOperations")
     @ParameterizedTest(name = "{displayName}: {0}")
     public void testWithoutSharingParentWithoutSharingSubclass(String operation) {
         String sourceCode =
@@ -119,7 +119,7 @@ public class SharingPolicySubclassesTest extends BaseUseWithSharingOnDatabaseOpe
         assertViolations(RULE, sourceCode, expect(SINK_LINE));
     }
 
-    @MethodSource("provideAllDatabaseOperations")
+    @MethodSource("provideSelectDatabaseOperations")
     @ParameterizedTest(name = "{displayName}: {0}")
     public void testWithoutSharingParentWithSharingSubclass(String operation) {
         String sourceCode =
@@ -128,7 +128,7 @@ public class SharingPolicySubclassesTest extends BaseUseWithSharingOnDatabaseOpe
         assertNoViolation(RULE, sourceCode);
     }
 
-    @MethodSource("provideAllDatabaseOperations")
+    @MethodSource("provideSelectDatabaseOperations")
     @ParameterizedTest(name = "{displayName}: {0}")
     public void testWithoutSharingParentInheritedSharingSubclass(String operation) {
         String sourceCode =
@@ -137,7 +137,7 @@ public class SharingPolicySubclassesTest extends BaseUseWithSharingOnDatabaseOpe
         assertViolations(RULE, sourceCode, expect(SINK_LINE));
     }
 
-    @MethodSource("provideAllDatabaseOperations")
+    @MethodSource("provideSelectDatabaseOperations")
     @ParameterizedTest(name = "{displayName}: {0}")
     public void testWithoutSharingParentNoDeclarationSubclass(String operation) {
         String sourceCode = String.format(SUBCLASS_SOURCE, "without sharing", "", operation);
@@ -147,7 +147,7 @@ public class SharingPolicySubclassesTest extends BaseUseWithSharingOnDatabaseOpe
 
     // PARENT - INHERITED SHARING
 
-    @MethodSource("provideAllDatabaseOperations")
+    @MethodSource("provideSelectDatabaseOperations")
     @ParameterizedTest(name = "{displayName}: {0}")
     public void testInheritedSharingParentWithoutSharingSubclass(String operation) {
         String sourceCode =
@@ -156,7 +156,7 @@ public class SharingPolicySubclassesTest extends BaseUseWithSharingOnDatabaseOpe
         assertViolations(RULE, sourceCode, expect(SINK_LINE));
     }
 
-    @MethodSource("provideAllDatabaseOperations")
+    @MethodSource("provideSelectDatabaseOperations")
     @ParameterizedTest(name = "{displayName}: {0}")
     public void testInheritedSharingParentWithSharingSubclass(String operation) {
         String sourceCode =
@@ -165,7 +165,7 @@ public class SharingPolicySubclassesTest extends BaseUseWithSharingOnDatabaseOpe
         assertNoViolation(RULE, sourceCode);
     }
 
-    @MethodSource("provideAllDatabaseOperations")
+    @MethodSource("provideSelectDatabaseOperations")
     @ParameterizedTest(name = "{displayName}: {0}")
     public void testInheritedSharingParentInheritedSharingSubclass(String operation) {
         String sourceCode =
@@ -174,7 +174,7 @@ public class SharingPolicySubclassesTest extends BaseUseWithSharingOnDatabaseOpe
         assertNoViolation(RULE, sourceCode);
     }
 
-    @MethodSource("provideAllDatabaseOperations")
+    @MethodSource("provideSelectDatabaseOperations")
     @ParameterizedTest(name = "{displayName}: {0}")
     public void testInheritedSharingParentNoDeclarationSubclass(String operation) {
         String sourceCode = String.format(SUBCLASS_SOURCE, "inherited sharing", "", operation);


### PR DESCRIPTION
* Parses methods in `Database` class that include a `System.AccessLevel` as their last parameter.
* If `AccessLevel.USER_MODE` is specified, prevents expected validations from being created on the vertex. 
  * That way, no violations are thrown in the case that no FLS checks are performed. This is okay because the query is performed in user mode.

Notes: 
* Need to confirm in `ValidationConverter#getHolder` that `childApexValue instanceof ApexStringValue` is true IF AND ONLY IF the vertex we are inspecting is one of the `Database.whatever` methods that could contain an explicit access level. 
  * Meaning, is there any other situation in which, when calling `convertSoqlQueryInfo(ValidationHolder, ProcessFields, HashSet<SoqlQueryInfo>, boolean)`, the last boolean (representing an override that makes any SOQL operation safe to perform without FLS validations) should be `true`? 
  * Put another way, Is there any other situation in which a SOQL query's access level could be overridden by an external factor? 

Additional notes:
* Added a new tests to `UseWithSharingOnDatabaseOperation` to test the `Database.query(String, AccessLevel)` method specifically when it has an access level specified.
* Updated `SharingPolicySubclassesTest` to use a select subset of possible database operations, not all of them. The tests were taking quite a long time. Testing all operations was not necessary since the full breadth of operations is tested in `SharingPolicySimpleTest`.

Known bugs/limiting behavior:
* Only the `insert`, `merge`, `query`, `undelete`, `upsert`, and `update` methods of the `Database` class in Apex are checked for FLS violations. TODO: check all methods, like `queryWithBinds`, etc.