### PR TITLE
CHANGE (CodeAnalyzer): @W-14198199@: PMD no longer excludes SF metadata files by default.

### DIFF
--- a/src/lib/util/Config.ts
+++ b/src/lib/util/Config.ts
@@ -37,7 +37,7 @@ const DEFAULT_CONFIG: ConfigContent = {
 			name: ENGINE.PMD,
 			targetPatterns: [
 				"**/*.cls","**/*.trigger","**/*.java","**/*.page","**/*.component","**/*.xml",
-				"!**/node_modules/**","!**/*-meta.xml"
+				"!**/node_modules/**"
 			],
 			supportedLanguages: ['apex', 'vf'],
 			disabled: false

--- a/src/lib/util/VersionUpgradeManager.ts
+++ b/src/lib/util/VersionUpgradeManager.ts
@@ -38,7 +38,7 @@ upgradeScriptsByVersion.set('v2.7.0', (config: ConfigContent): Promise<void> => 
 	return Promise.resolve();
 });
 upgradeScriptsByVersion.set('v3.0.0', (config: ConfigContent): Promise<void> => {
-	// In v3.0.0, we're changing RetireJS from a supplemental engine that must be manually enabled to an enabled-byu-default
+	// In v3.0.0, we're changing RetireJS from a supplemental engine that must be manually enabled to an enabled-by-default
 	// engine. So we need to change its `disabled` config value from true to false.
 	const retireJsConfig: EngineConfigContent = config.engines.find(e => e.name === ENGINE.RETIRE_JS);
 	if (retireJsConfig) {
@@ -61,6 +61,15 @@ upgradeScriptsByVersion.set('v3.6.0', async (config: ConfigContent): Promise<voi
 		if (!config.currentVersion || semver.lt(config.currentVersion, pilotConfig.currentVersion)) {
 			config.engines = pilotConfig.engines;
 		}
+	}
+});
+upgradeScriptsByVersion.set('v3.17.0', async (config: ConfigContent): Promise<void> => {
+	// In v3.17.0, we're changing PMD's config so that it no longer excludes Salesforce metadata
+	// files by default. This will automatically apply to any newly-generated configs, but we also
+	// want to retroactively remove this exclusion for existing users.
+	const pmdConfig: EngineConfigContent = config.engines.find(e => e.name === ENGINE.PMD);
+	if (pmdConfig) {
+		pmdConfig.targetPatterns = pmdConfig.targetPatterns.filter(s => s !== '!**/*-meta.xml');
 	}
 });
 

--- a/src/lib/util/VersionUpgradeManager.ts
+++ b/src/lib/util/VersionUpgradeManager.ts
@@ -63,7 +63,7 @@ upgradeScriptsByVersion.set('v3.6.0', async (config: ConfigContent): Promise<voi
 		}
 	}
 });
-upgradeScriptsByVersion.set('v3.17.0', async (config: ConfigContent): Promise<void> => {
+upgradeScriptsByVersion.set('v3.17.0', (config: ConfigContent): Promise<void> => {
 	// In v3.17.0, we're changing PMD's config so that it no longer excludes Salesforce metadata
 	// files by default. This will automatically apply to any newly-generated configs, but we also
 	// want to retroactively remove this exclusion for existing users.
@@ -71,6 +71,7 @@ upgradeScriptsByVersion.set('v3.17.0', async (config: ConfigContent): Promise<vo
 	if (pmdConfig) {
 		pmdConfig.targetPatterns = pmdConfig.targetPatterns.filter(s => s !== '!**/*-meta.xml');
 	}
+	return Promise.resolve();
 });
 
 

--- a/test/lib/util/VersionUpgradeManager.test.ts
+++ b/test/lib/util/VersionUpgradeManager.test.ts
@@ -329,5 +329,31 @@ describe('VersionUpgradeManager', () => {
 				expect(clonedConfig.currentVersion).to.equal('v3.6.0');
 			});
 		});
+
+		describe('v3.17.0', () => {
+			// Spoof a config that:
+			// - Appears to predate v3.17.0
+			// - Has a PMD config with '!**/*-meta.xml' in its target patterns
+			// - Has a RetireJS config with '!**/*-meta.xml' in its target patterns
+			const spoofedConfig: ConfigContent = {
+				currentVersion: '3.15.0',
+				engines: [{
+					name: ENGINE.PMD,
+					targetPatterns: ['**/*.apex', '**/*.xml', '!**/*-meta.xml'],
+					disabled: false
+				}, {
+					name: ENGINE.RETIRE_JS,
+					targetPatterns: ['**/beep/*.js', '!**/*-meta.xml', '!**/boop.js'],
+					disabled: false
+				}]
+			};
+
+			const testManagerAsAny = new VersionUpgradeManager() as any;
+			it('"!**/*-meta.xml" is removed from PMD config', async () => {
+				await testManagerAsAny.upgrade(spoofedConfig, spoofedConfig.currentVersion, 'v3.17.0');
+				expect(spoofedConfig.engines[0].targetPatterns).to.not.include('!**/*-meta.xml', 'Entry should be removed from PMD config');
+				expect(spoofedConfig.engines[1].targetPatterns).to.include('!**/*-meta.xml', 'Entry should not be removed from non-PMD config');
+			});
+		})
 	});
 });


### PR DESCRIPTION
This PR does the following:
- Removes `!**/*-meta.xml` from the default target patterns for PMD's configuration.
- Adds a post-install script to remove this entry from a user's configuration the first time they run a command with v3.17.0.