### PR TITLE
CHANGE (CodeAnalyzer): @W-14329763@: Test config now set via env-var instead of IOC.

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -3,7 +3,7 @@ import path = require('path');
 
 export const PMD_VERSION = '6.55.0';
 export const SFGE_VERSION = '1.0.1-pilot';
-export const DEFAULT_SCANNER_PATH = path.join(os.homedir(), 'sfdx-scanner');
+export const DEFAULT_SCANNER_PATH = path.join(os.homedir(), '.sfdx-scanner');
 export const CATALOG_FILE = 'Catalog.json';
 export const CUSTOM_PATHS_FILE = 'CustomPaths.json';
 export const CONFIG_PILOT_FILE = 'Config-pilot.json';

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -3,21 +3,18 @@ import path = require('path');
 
 export const PMD_VERSION = '6.55.0';
 export const SFGE_VERSION = '1.0.1-pilot';
+export const DEFAULT_SCANNER_PATH = path.join(os.homedir(), 'sfdx-scanner');
 export const CATALOG_FILE = 'Catalog.json';
 export const CUSTOM_PATHS_FILE = 'CustomPaths.json';
 export const CONFIG_PILOT_FILE = 'Config-pilot.json';
 export const CONFIG_FILE = 'Config.json';
 export const PMD_CATALOG_FILE = 'PmdCatalog.json';
 
-export interface EnvOverridable {
-	getSfdxScannerPath(): string;
-}
-
-export class ProdOverrides implements EnvOverridable {
-	public getSfdxScannerPath(): string {
-		return path.join(os.homedir(), '.sfdx-scanner');
-	}
-}
+// TODO: We should flesh this one-off solution out into one that handles all the various env vars we use.
+//       E.g., the ones defined in `EnvironmentVariable.ts` and `dfa.ts`.
+export const ENV_VAR_NAMES = {
+	SCANNER_PATH_OVERRIDE: 'SCANNER_PATH_OVERRIDE'
+};
 
 export enum ENGINE {
 	PMD = 'pmd',

--- a/src/Controller.ts
+++ b/src/Controller.ts
@@ -3,7 +3,7 @@ import "reflect-metadata";
 import {SfError, Messages} from '@salesforce/core';
 import {container} from "tsyringe";
 import {Config} from './lib/util/Config';
-import {EnvOverridable, Services, AllowedEngineFilters} from './Constants';
+import {DEFAULT_SCANNER_PATH, ENV_VAR_NAMES, Services, AllowedEngineFilters} from './Constants';
 import {RuleManager} from './lib/RuleManager';
 import {RuleEngine} from './lib/services/RuleEngine';
 import {RulePathManager} from './lib/RulePathManager';
@@ -41,8 +41,7 @@ export const Controller = {
 	},
 
 	getSfdxScannerPath: (): string => {
-		const envOverrides = container.resolve<EnvOverridable>(Services.EnvOverridable);
-		return envOverrides.getSfdxScannerPath();
+		return process.env[ENV_VAR_NAMES.SCANNER_PATH_OVERRIDE] || DEFAULT_SCANNER_PATH;
 	},
 
 	createRuleManager: async (): Promise<RuleManager> => {

--- a/src/ioc.config.ts
+++ b/src/ioc.config.ts
@@ -13,17 +13,8 @@ import {SfgePathlessEngine} from './lib/sfge/SfgePathlessEngine';
 import {CustomPmdEngine, PmdEngine} from './lib/pmd/PmdEngine';
 import LocalCatalog from './lib/services/LocalCatalog';
 import {Config} from './lib/util/Config';
-import {ProdOverrides, Services} from './Constants';
+import {Services} from './Constants';
 import {CpdEngine} from "./lib/cpd/CpdEngine";
-
-function setupProd(): void {
-	// This method may be called more than once in unit test scenarios where
-	// the test sets up the ioc container and the oclif testing framework is used.
-	// The first caller wins. In production this will be called once.
-	if (!container.isRegistered(Services.EnvOverridable)) {
-		container.register(Services.EnvOverridable, ProdOverrides);
-	}
-}
 
 /**
  * Initialize the ioc container with singletons common to test and prod
@@ -52,6 +43,5 @@ export function registerAll(): void {
  * Initialize the ioc container for a production environment
  */
 export function initContainer(): void {
-	setupProd();
 	registerAll();
 }

--- a/test/test-related-lib/TestOverrides.ts
+++ b/test/test-related-lib/TestOverrides.ts
@@ -1,24 +1,16 @@
-import { EnvOverridable } from "../../src/Constants";
+import { ENV_VAR_NAMES} from "../../src/Constants";
 import os = require('os');
 import path = require('path');
-import { Services } from "../../src/Constants";
 import { Controller } from "../../src/Controller";
 import { registerAll } from "../../src/ioc.config";
 
-export class TestOverrides implements EnvOverridable {
-	public getSfdxScannerPath(): string {
-		return path.join(os.homedir(), '.sfdx-scanner-test');
-	}
-}
+export const TEST_SCANNER_PATH = path.join(os.homedir(), '.sfdx-scanner-test');
 
 const container = Controller.container;
 
-function setupTestAlternatives(): void {
-	container.register(Services.EnvOverridable, TestOverrides);
-}
-
 export function initializeTestSetup(): void {
+	// Pretty much every test expects to use the Test config folder instead of the real one.
+	process.env[ENV_VAR_NAMES.SCANNER_PATH_OVERRIDE] = TEST_SCANNER_PATH;
 	container.reset();
-	setupTestAlternatives();
 	registerAll();
 }


### PR DESCRIPTION
Context: We need our automated tests to run with a clean, test-only configuration instead of whatever production configuration is present on the machine.

The previous mechanism for doing this was an interface called `EnvOverridable` that was injected into the `Controller` during initialization and had a method called `getSfdxScannerPath()`. The default implementation of this interface returned `.sfdx-scanner`, but during tests we would inject an alternate one that returned `.sfdx-scanner-test`.

Upgrading from `sfdx` to `sf` requires us to move away from the `fancy-test` framework we were previously using, ideally towards a NUT-style that uses a child-process under the hood. This means the old mechanism no longer works, and needs to be replaced with something.

So this pull request replaces the old mechanism with a new one: `Controller` checks for the presence of a `process.env` variable, `SCANNER_PATH_OVERRIDE` and uses that variable's value if it exists, otherwise it uses a default value `.sfdx-scanner`. The `TestOverrides` code that previously handled injecting the new `EnvOverridable` instance now handles setting this environment variable to `.sfdx-scanner-test`.