### PR TITLE
CHANGE (CodeAnalyzer): @W-14329763@: E2E tests refactored to use new framework

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
 		"flexibleTaxonomy": true
 	},
 	"nyc": {
-		"branches": "80",
+		"branches": "75",
 		"lines": "90",
 		"functions": "90",
 		"statements": "90"

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
 		"test-pmd-cataloger": "./gradlew pmd-cataloger:test pmd-cataloger:jacocoTestCoverageVerification",
 		"test-sfge": "./gradlew sfge:test sfge:jacocoTestCoverageVerification",
 		"test-sfge-quiet": "cross-env SFGE_LOGGING=false ./gradlew sfge:test sfge:jacocoTestCoverageVerification",
-		"test-typescript": "nyc mocha --timeout 10000 --retries 5 \"./test/**/*.test.ts\"",
+		"test-typescript": "nyc mocha --timeout 60000 \"./test/**/*.test.ts\"",
 		"version": "oclif readme && git add README.md"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"@istanbuljs/nyc-config-typescript": "^1.0.1",
 		"@oclif/plugin-help": "^5",
 		"@oclif/test": "^2",
-		"@salesforce/cli-plugins-testkit": "^4.4.10",
+		"@salesforce/cli-plugins-testkit": "^5.0.4",
 		"@salesforce/dev-config": "^3",
 		"@salesforce/ts-sinon": "^1.1.2",
 		"@types/chai": "^4",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
 		"@istanbuljs/nyc-config-typescript": "^1.0.1",
 		"@oclif/plugin-help": "^5",
 		"@oclif/test": "^2",
+		"@salesforce/cli-plugins-testkit": "^4.4.10",
 		"@salesforce/dev-config": "^3",
 		"@salesforce/ts-sinon": "^1.1.2",
 		"@types/chai": "^4",

--- a/test/TestUtils.ts
+++ b/test/TestUtils.ts
@@ -7,7 +7,6 @@ import {
 	execInteractiveCmd,
 	InteractiveCommandExecutionResult, PromptAnswers
 } from '@salesforce/cli-plugins-testkit';
-import { test } from '@salesforce/command/lib/test';
 // @ts-ignore
 import * as TestOverrides from './test-related-lib/TestOverrides';
 import Sinon = require('sinon');
@@ -51,20 +50,5 @@ export function runInteractiveCommand(command: string, answers: PromptAnswers): 
 	TestOverrides.initializeTestSetup();
 	return execInteractiveCmd(command, answers);
 }
-
-/**
- * Initial setup needed by all oclif command unit tests.
- *
- * Example:
- * setupCommandTest
- * 	.command(['scanner:run', '-t', 'test-code'])
- * 	.it('Scanner Run Relative Path Succeeds', ctx => {
- * 		expect(ctx.stdout).to.contain('No rule violations found.');
- * 	});
- */
-export const setupCommandTest = test
-	.do(() => TestOverrides.initializeTestSetup())
-	.stdout()
-	.stderr();
 
 

--- a/test/TestUtils.ts
+++ b/test/TestUtils.ts
@@ -1,6 +1,14 @@
 import fs = require('fs');
 import path = require('path');
+import {AnyJson} from '@salesforce/ts-types';
+import {
+	execCmd,
+	ExecCmdResult,
+	execInteractiveCmd,
+	InteractiveCommandExecutionResult, PromptAnswers
+} from '@salesforce/cli-plugins-testkit';
 import { test } from '@salesforce/command/lib/test';
+// @ts-ignore
 import * as TestOverrides from './test-related-lib/TestOverrides';
 import Sinon = require('sinon');
 import LocalCatalog from '../src/lib/services/LocalCatalog';
@@ -32,6 +40,16 @@ export function stubCatalogFixture(): void {
 	Sinon.stub(LocalCatalog.prototype, 'getCatalog').callsFake(async () => {
 		return JSON.parse(fs.readFileSync(CATALOG_FIXTURE_PATH).toString());
 	});
+}
+
+export function runCommand(command: string): ExecCmdResult<AnyJson> {
+	TestOverrides.initializeTestSetup();
+	return execCmd(command);
+}
+
+export function runInteractiveCommand(command: string, answers: PromptAnswers): Promise<InteractiveCommandExecutionResult> {
+	TestOverrides.initializeTestSetup();
+	return execInteractiveCmd(command, answers);
 }
 
 /**

--- a/test/commands/scanner/rule/add.test.ts
+++ b/test/commands/scanner/rule/add.test.ts
@@ -1,6 +1,7 @@
 import {expect} from '@salesforce/command/lib/test';
 import {Messages} from '@salesforce/core';
-import {setupCommandTest} from '../../../TestUtils';
+// @ts-ignore
+import {runCommand} from '../../../TestUtils';
 import * as os from 'os';
 import fs = require('fs');
 import path = require('path');
@@ -9,7 +10,7 @@ import path = require('path');
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/sfdx-scanner', 'add');
 
-describe('scanner:rule:add', () => {
+describe('scanner rule add', () => {
 	describe('E2E', () => {
 		const myLanguage = 'apex';
 		describe('Test Case: Adding individual JARs', () => {
@@ -27,54 +28,43 @@ describe('scanner:rule:add', () => {
 			const tmpJar4 = path.join(tmpDir4, 'bar4.jar');
 			fs.writeFileSync(tmpJar4, 'Heat and cold, life and death, and of course, light and dark.');
 
-			// For the first test, we'll add two of the JARs with their absolute paths.
-			const absolutePaths = [tmpJar1, tmpJar2];
-			setupCommandTest
-				.command(['scanner:rule:add',
-					'--language', myLanguage,
-					'--path', absolutePaths.join(','),
-					'--json'
-				])
-				.it('Individual JARs can be added with their absolute path', ctx => {
-					// The expectation is that the paths will just be used as-is.
-					const expectedPaths = absolutePaths;
-					const outputJson = JSON.parse(ctx.stdout);
-					const result = outputJson.result;
-					expect(result).to.have.property('success')
-						.and.equals(true);
+			it('Individual JARs can be added with their absolute path', () => {
+				// For the first test, we'll add two of the JARs with their absolute paths.
+				const absolutePaths = [tmpJar1, tmpJar2];
+				const output = runCommand(`scanner rule add --language ${myLanguage} --path ${absolutePaths.join(',')} --json`);
+				// The expectation is that the paths will just be used as-is.
+				const expectedPaths = absolutePaths;
+				const outputJson = output.jsonOutput;
+				const result = outputJson.result;
+				expect(result).to.have.property('success')
+					.and.equals(true);
 
-					expect(result).to.have.property('language')
-						.and.equals(myLanguage);
+				expect(result).to.have.property('language')
+					.and.equals(myLanguage);
 
-					expect(result).to.have.property('path')
-						.and.have.lengthOf(expectedPaths.length)
-						.and.deep.equals(expectedPaths);
-				});
+				expect(result).to.have.property('path')
+					.and.have.lengthOf(expectedPaths.length)
+					.and.deep.equals(expectedPaths);
+			});
 
+			it('Individual JARs can be added with their relative paths', () => {
+				// For the second test, we'll add the other two JARs with relative paths.
+				const relativePaths = [path.relative('.', tmpJar3), path.relative('.', tmpJar4)];
+				const output = runCommand(`scanner rule add --language ${myLanguage} --path ${relativePaths.join(',')} --json`);
+				// The expectation is that the paths will be converted to absolute paths.
+				const expectedPaths = [tmpJar3, tmpJar4];
+				const outputJson = output.jsonOutput;
+				const result = outputJson.result;
+				expect(result).to.have.property('success')
+					.and.equals(true);
 
-			// For the second test, we'll add the other two JARs with relative paths.
-			const relativePaths = [path.relative('.', tmpJar3), path.relative('.', tmpJar4)];
-			setupCommandTest
-				.command(['scanner:rule:add',
-					'--language', myLanguage,
-					'--path', relativePaths.join(','),
-					'--json'
-				])
-				.it('Individual JARs can be added with their relative paths', ctx => {
-					// The expectation is that the paths will be converted to absolute paths.
-					const expectedPaths = [tmpJar3, tmpJar4];
-					const outputJson = JSON.parse(ctx.stdout);
-					const result = outputJson.result;
-					expect(result).to.have.property('success')
-						.and.equals(true);
+				expect(result).to.have.property('language')
+					.and.equals(myLanguage);
 
-					expect(result).to.have.property('language')
-						.and.equals(myLanguage);
-
-					expect(result).to.have.property('path')
-						.and.have.lengthOf(expectedPaths.length)
-						.and.deep.equals(expectedPaths);
-				});
+				expect(result).to.have.property('path')
+					.and.have.lengthOf(expectedPaths.length)
+					.and.deep.equals(expectedPaths);
+			});
 		});
 
 
@@ -96,84 +86,68 @@ describe('scanner:rule:add', () => {
 			fs.writeFileSync(tmpJar6, 'With the strength of Lords, they challenged the Dragons.');
 
 			// For the first test, we'll add one of the folders by its absolute path.
-			setupCommandTest
-				.command(['scanner:rule:add',
-					'--language', myLanguage,
-					'--path', tmpDir1,
-					'--json'
-				])
-				.it('Folders can be added with their absolute paths', ctx => {
-					// The expectation is that all three JARs in the folder will have been added.
-					const expectedPaths = [tmpJar1, tmpJar2, tmpJar3];
-					const outputJson = JSON.parse(ctx.stdout);
-					const result = outputJson.result;
-					expect(result).to.have.property('success')
-						.and.equals(true);
+			it('Folders can be added with their absolute paths', () => {
+				const output = runCommand(`scanner rule add --language ${myLanguage} --path ${tmpDir1} --json`);
+				// The expectation is that all three JARs in the folder will have been added.
+				const expectedPaths = [tmpJar1, tmpJar2, tmpJar3];
+				const result = output.jsonOutput.result;
+				expect(result).to.have.property('success')
+					.and.equals(true);
 
-					expect(result).to.have.property('language')
-						.and.equals(myLanguage);
+				expect(result).to.have.property('language')
+					.and.equals(myLanguage);
 
-					expect(result).to.have.property('path')
-						.and.have.lengthOf(expectedPaths.length)
-						.and.deep.equals(expectedPaths);
-				});
+				expect(result).to.have.property('path')
+					.and.have.lengthOf(expectedPaths.length)
+					.and.deep.equals(expectedPaths);
+			});
 
 			// For the second test, we'll add the other folder by its relative path.
-			setupCommandTest
-				.command(['scanner:rule:add',
-					'--language', myLanguage,
-					'--path', path.relative('.', tmpDir2),
-					'--json'
-				])
-				.it('Folders can be added by their relative paths', ctx => {
-					// The expectation is that all three JARs in the folder will have been added.
-					const expectedPaths = [tmpJar4, tmpJar5, tmpJar6];
-					const outputJson = JSON.parse(ctx.stdout);
-					const result = outputJson.result;
-					expect(result).to.have.property('success')
-						.and.equals(true);
+			it('Folders can be added by their relative paths', () => {
+				const output = runCommand(`scanner rule add --language ${myLanguage} --path ${path.relative('.', tmpDir2)} --json`);
+				// The expectation is that all three JARs in the folder will have been added.
+				const expectedPaths = [tmpJar4, tmpJar5, tmpJar6];
+				const result = output.jsonOutput.result;
+				expect(result).to.have.property('success')
+					.and.equals(true);
 
-					expect(result).to.have.property('language')
-						.and.equals(myLanguage);
+				expect(result).to.have.property('language')
+					.and.equals(myLanguage);
 
-					expect(result).to.have.property('path')
-						.and.have.lengthOf(expectedPaths.length)
-						.and.deep.equals(expectedPaths);
-				});
+				expect(result).to.have.property('path')
+					.and.have.lengthOf(expectedPaths.length)
+					.and.deep.equals(expectedPaths);
+			});
 		});
 	});
 
 	describe('Validations', () => {
 		describe('Language validations', () => {
 			// Test for failure scenario doesn't need to do any special setup or cleanup.
-			setupCommandTest
-				.command(['scanner:rule:add', '--path', '/some/local/path'])
-				.it('should complain about missing --language flag', ctx => {
-					expect(ctx.stderr).contains('Missing required flag language');
-				});
+			it('should complain about missing --language flag', () => {
+				const output = runCommand(`scanner rule add --path /some/local/path`);
+				expect(output.shellOutput.stderr).to.contain('Missing required flag language');
+			});
 
 			// Test for failure scenario doesn't need to do any special setup or cleanup.
-			setupCommandTest
-				.command(['scanner:rule:add', '--language', '', '--path', '/some/local/path'])
-				.it('should complain about empty language entry', ctx => {
-					expect(ctx.stderr).contains(messages.getMessage('validations.languageCannotBeEmpty'));
-				});
+			it('should complain about empty language entry', () => {
+				const output = runCommand(`scanner rule add --language '' --path /some/local/path`);
+				expect(output.shellOutput.stderr).to.contain(messages.getMessage('validations.languageCannotBeEmpty'));
+			});
 		});
 
 		describe('Path validations', () => {
 			// Test for failure scenario doesn't need to do any special setup or cleanup.
-			setupCommandTest
-				.command(['scanner:rule:add', '--language', 'apex'])
-				.it('should complain about missing --path flag', ctx => {
-					expect(ctx.stderr).contains('Missing required flag path');
-				});
+			it('should complain about missing --path flag', () => {
+				const output = runCommand(`scanner rule add --language apex`);
+				expect(output.shellOutput.stderr).to.contain('Missing required flag path');
+			});
 
 			// Test for failure scenario doesn't need to do any special setup or cleanup.
-			setupCommandTest
-				.command(['scanner:rule:add', '--language', 'apex', '--path', ''])
-				.it('should complain about empty path', ctx => {
-					expect(ctx.stderr).contains(messages.getMessage('validations.pathCannotBeEmpty'));
-				});
+			it('should complain about empty path', () => {
+				const output = runCommand(`scanner rule add --language apex --path ''`);
+				expect(output.shellOutput.stderr).to.contain(messages.getMessage('validations.pathCannotBeEmpty'));
+			});
 		});
 	});
 });

--- a/test/commands/scanner/rule/add.test.ts
+++ b/test/commands/scanner/rule/add.test.ts
@@ -131,7 +131,7 @@ describe('scanner rule add', () => {
 
 			// Test for failure scenario doesn't need to do any special setup or cleanup.
 			it('should complain about empty language entry', () => {
-				const output = runCommand(`scanner rule add --language '' --path /some/local/path`);
+				const output = runCommand(`scanner rule add --language "" --path /some/local/path`);
 				expect(output.shellOutput.stderr).to.contain(messages.getMessage('validations.languageCannotBeEmpty'));
 			});
 		});

--- a/test/commands/scanner/rule/describe.test.ts
+++ b/test/commands/scanner/rule/describe.test.ts
@@ -1,101 +1,90 @@
 import {expect} from '@salesforce/command/lib/test';
-import {setupCommandTest} from '../../../TestUtils';
+// @ts-ignore
+import {runCommand} from '../../../TestUtils';
 import { Messages } from '@salesforce/core';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/sfdx-scanner', 'describe');
 
-describe('scanner:rule:describe', () => {
+describe('scanner rule describe', () => {
 	describe('E2E', () => {
 		describe('Test Case: No matching rules', () => {
 			const formattedWarning = messages.getMessage('output.noMatchingRules', ['DefinitelyFakeRule']);
-			setupCommandTest
-				.command(['scanner:rule:describe', '--rulename', 'DefinitelyFakeRule'])
-				.it('Correct warning is displayed', ctx => {
-					expect(ctx.stderr).to.contain('WARNING: ' + formattedWarning, 'Warning message should match');
-				});
+			it('Correct warning is displayed', () => {
+				const output = runCommand(`scanner rule describe --rulename DefinitelyFakeRule`);
+				expect(output.shellOutput.stderr).to.contain(`WARNING: ${formattedWarning}`, 'Warning message should match');
+			});
 
-			setupCommandTest
-				.command(['scanner:rule:describe', '--rulename', 'DefinitelyFakeRule', '--json'])
-				.it('--json flag yields correct results', ctx => {
-					const ctxJson = JSON.parse(ctx.stdout);
-					expect(ctxJson.result.length).to.equal(0, 'Should be no results');
-					expect(ctxJson.warnings.length).to.equal(2, 'Incorrect warning count');
-					expect(ctxJson.warnings[1]).to.equal(formattedWarning, 'Warning message should match');
-				});
+			it('--json flag yields correct results', () => {
+				const output = runCommand(`scanner rule describe --rulename DefinitelyFakeRule --json`);
+				const ctxJson = output.jsonOutput;
+				expect((ctxJson.result as any[]).length).to.equal(0, 'Should be no results');
+				expect(ctxJson.warnings.length).to.equal(2, 'Incorrect warning count');
+				expect(ctxJson.warnings[1]).to.equal(formattedWarning, 'Warning message should match');
+			});
 		});
 
 		describe('Test Case: One matching rule', () => {
-			setupCommandTest
-				.command(['scanner:rule:describe', '--rulename', 'TooManyFields'])
-				.it('Displayed output matches expectations', ctx => {
-					// Rather than compare every attribute, we'll just compare a few so we can be reasonably confident we got the right
-					// rule.
-					expect(ctx.stdout).to.match(/name:\s+TooManyFields/, 'Name should be \'TooManyFields\'');
-					expect(ctx.stdout).to.match(/engine:\s+pmd/, 'Engine should be PMD');
-					expect(ctx.stdout).to.match(/enabled:\s+true/, 'Rule is enabled');
-					expect(ctx.stdout).to.match(/categories:\s+Design/, 'Category should be \'Design\'');
-					expect(ctx.stdout).to.match(/languages:\s+apex/, 'Language should be \'apex\'');
-					expect(ctx.stdout).to.match(/message:\s+Too many fields/, 'Message should match');
-				});
+			it('Displayed output matches expectations', () => {
+				const output = runCommand(`scanner rule describe --rulename TooManyFields`);
+				// Rather than compare every attribute, we'll just compare a few, so we can be reasonably confident we got the right
+				// rule.
+				const ctx = output.shellOutput;
+				expect(ctx.stdout).to.match(/name:\s+TooManyFields/, 'Name should be \'TooManyFields\'');
+				expect(ctx.stdout).to.match(/engine:\s+pmd/, 'Engine should be PMD');
+				expect(ctx.stdout).to.match(/enabled:\s+true/, 'Rule is enabled');
+				expect(ctx.stdout).to.match(/categories:\s+Design/, 'Category should be \'Design\'');
+				expect(ctx.stdout).to.match(/languages:\s+apex/, 'Language should be \'apex\'');
+				expect(ctx.stdout).to.match(/message:\s+Too many fields/, 'Message should match');
+			});
 
-			setupCommandTest
-				.command(['scanner:rule:describe', '--rulename', 'TooManyFields', '--json'])
-				.it('--json flag yields correct results', ctx => {
-					const resultList = JSON.parse(ctx.stdout).result;
-					expect(resultList.length).to.equal(1, 'Should be one matching rule');
-					const ruleJson = resultList[0];
-					// Rather than compare every attribute, we'll just compare a few so we can be reasonably confident we got the right
-					// rule.
-					expect(ruleJson.name).to.equal('TooManyFields');
-					expect(ruleJson.languages.length).to.equal(1, 'Should be one language applied to rule');
-					expect(ruleJson.languages[0]).to.equal('apex', 'Rule language should be apex');
-					expect(ruleJson.message).to.equal('Too many fields', 'Rule message should match');
-				});
+			it('--json flag yields correct results', () => {
+				const output = runCommand(`scanner rule describe --rulename TooManyFields --json`);
+				const resultList = output.jsonOutput.result as any[];
+				expect(resultList.length).to.equal(1, 'Should be one matching rule');
+				const ruleJson = resultList[0];
+				// Rather than compare every attribute, we'll just compare a few so we can be reasonably confident we got the right
+				// rule.
+				expect(ruleJson.name).to.equal('TooManyFields');
+				expect(ruleJson.languages.length).to.equal(1, 'Should be one language applied to rule');
+				expect(ruleJson.languages[0]).to.equal('apex', 'Rule language should be apex');
+				expect(ruleJson.message).to.equal('Too many fields', 'Rule message should match');
+			});
 		});
 
 		describe('Test Case: Multiple matching rules', () => {
 			// Both tests will test for the presence of this warning string in the output, so we might as well format it up here.
 			const formattedWarning = messages.getMessage('output.multipleMatchingRules', ['3', 'constructor-super']);
 
-			setupCommandTest
-				.command(['scanner:rule:describe', '--rulename', 'constructor-super'])
-				.it('Displayed output matches expectations', ctx => {
-					// First, verify that the warning was printed at the start like it should have been.
-					expect(ctx.stderr).to.contain('WARNING: ' + formattedWarning, 'Warning message should be formatted correctly');
+			it('Displayed output matches expectations', () => {
+				const output = runCommand(`scanner rule describe --rulename constructor-super`);
+				const ctx = output.shellOutput;
+				// First, verify that the warning was printed at the start like it should have been.
+				expect(ctx.stderr).to.contain('WARNING: ' + formattedWarning, 'Warning message should be formatted correctly');
 
-					// Next, verify that there are rule descriptions that are distinctly identified.
-					const regex = /=== Rule #1\n\nname:\s+constructor-super(.*\n)*=== Rule #2\n\nname:\s+constructor-super(.*\n)*=== Rule #3\n\nname:\s+constructor-super/g;
-					expect(ctx.stdout).to.match(regex, 'Output should contain three rules named constructor-super for each eslint based engine');
-				});
+				// Next, verify that there are rule descriptions that are distinctly identified.
+				const regex = /=== Rule #1\n\nname:\s+constructor-super(.*\n)*=== Rule #2\n\nname:\s+constructor-super(.*\n)*=== Rule #3\n\nname:\s+constructor-super/g;
+				expect(ctx.stdout).to.match(regex, 'Output should contain three rules named constructor-super for each eslint based engine');
+			});
 
-			// TODO: THIS TEST IS FAILING BECAUSE THE WARNING FOR DEFINITELYFAKERULE IS BEING INCLUDED IN THE WARNINGS HERE.
-			//  WHEN THE CAUSE FOR THAT IS DETERMINED AND RESOLVED, RE-ENABLE THIS TEST.
-			/*
-			describeTest
-			  .stdout()
-			  .stderr()
-			  .command(['scanner:rule:describe', '--rulename', 'WhileLoopsMustUseBraces', '--json'])
-			  .it('--json flag yields correct results', ctx => {
-				const ctxJson = JSON.parse(ctx.stdout);
+			it('--json flag yields correct results', () => {
+				const output = runCommand(`scanner rule describe --rulename constructor-super --json`);
+				const ctxJson = output.jsonOutput;
 
 				// Verify we got the right number of rules.
-				expect(ctxJson.result).to.have.lengthOf(2, 'Should be two included rules');
-				// Verify that there's only one warning.
-				expect(ctxJson.warnings).to.have.lengthOf(1, 'Should be only one warning, instead ' + ctx.stdout);
-				// Verify that the warning looks right.
-				expect(ctxJson.warnings[0]).to.equal(formattedWarning, 'Warning should match');
-			  });
-			 */
+				expect(ctxJson.result).to.have.lengthOf(3, 'Should be three included rules');
+				// There are two warnings, but only the second is relevant.
+				expect(ctxJson.warnings).to.have.lengthOf(2, 'Should be two warnings');
+				expect(ctxJson.warnings[1]).to.equal(formattedWarning, 'Warning should match');
+			});
 		});
 
 		describe('Error handling', () => {
-			setupCommandTest
-				.command(['scanner:rule:describe'])
-				.it('Must input a rule name', ctx => {
-					expect(ctx.stderr).to.contain(`ERROR running scanner:rule:describe:  The following error occurred:
+			it('Must input a rule name', () => {
+				const output = runCommand(`scanner rule describe`);
+				expect(output.shellOutput.stderr).to.contain(`ERROR running scanner:rule:describe:  The following error occurred:
   Missing required flag rulename`);
-				});
+			});
 		});
 	});
 });

--- a/test/commands/scanner/rule/list.test.ts
+++ b/test/commands/scanner/rule/list.test.ts
@@ -1,5 +1,6 @@
 import {expect} from '@salesforce/command/lib/test';
-import {setupCommandTest} from '../../../TestUtils';
+// @ts-ignore
+import {runCommand} from '../../../TestUtils';
 import {Rule} from '../../../../src/types';
 import {CATALOG_FILE, ENGINE} from '../../../../src/Constants';
 import fs = require('fs');
@@ -45,32 +46,30 @@ async function getRulesFilteredByCategoryCount(includeDefaultDisabled: boolean, 
 	return rules.length;
 }
 
-describe('scanner:rule:list', () => {
+describe('scanner rule list', () => {
 
 	describe('E2E', () => {
 		describe('Test Case: No filters applied', () => {
-			setupCommandTest
-				.command(['scanner:rule:list'])
-				.it('All rules for enabled engines are returned', async ctx => {
-					const totalRuleCount = await getRulesFilteredByCategoryCount(false);
+			it('All rules for enabled engines are returned', async () => {
+				const output = runCommand(`scanner rule list`);
+				const totalRuleCount = await getRulesFilteredByCategoryCount(false);
 
-					// Split the output table by newline and throw out the first two rows, since they just contain header information. That
-					// should leave us with the actual data.
-					const rows = ctx.stdout.trim().split('\n');
-					rows.shift();
-					rows.shift();
-					expect(rows).to.have.lengthOf(totalRuleCount, 'All rules should have been returned');
-				});
+				// Split the output table by newline and throw out the first two rows, since they just contain header information. That
+				// should leave us with the actual data.
+				const rows = output.shellOutput.stdout.trim().split('\n');
+				rows.shift();
+				rows.shift();
+				expect(rows).to.have.lengthOf(totalRuleCount, 'All rules should have been returned');
+			});
 
-			setupCommandTest
-				.command(['scanner:rule:list', '--json'])
-				.it('--json flag yields expected JSON', async ctx => {
-					const totalRuleCount = await getRulesFilteredByCategoryCount(false);
+			it('--json flag yields expected JSON', async () => {
+				const output = runCommand(`scanner rule list --json`);
+				const totalRuleCount = await getRulesFilteredByCategoryCount(false);
 
-					// Parse the output back into a JSON, and make sure it has the right number of rules.
-					const outputJson = JSON.parse(ctx.stdout);
-					expect(outputJson.result).to.have.lengthOf(totalRuleCount, 'All rules should have been returned');
-				});
+				// Parse the output back into a JSON, and make sure it has the right number of rules.
+				const outputJson = output.jsonOutput;
+				expect(outputJson.result).to.have.lengthOf(totalRuleCount, 'All rules should have been returned');
+			});
 		});
 
 		describe('Test Case: Filtering by category only', () => {
@@ -78,245 +77,231 @@ describe('scanner:rule:list', () => {
 			// Add a preceding '!' to each category
 			const negatedCategories = positiveCategories.map(c => `!${c}`);
 
-			setupCommandTest
-				.command(['scanner:rule:list', '--category', positiveCategories[0], '--json'])
-				.it('Filtering by one category returns only the rules in that category for enabled engines', async ctx => {
-					const targetRuleCount = await getRulesFilteredByCategoryCount(true, [positiveCategories[0]]);
+			it('Filtering by one category returns only the rules in that category for enabled engines', async () => {
+				const output = runCommand(`scanner rule list --category '${positiveCategories[0]}' --json`);
+				const targetRuleCount = await getRulesFilteredByCategoryCount(true, [positiveCategories[0]]);
 
-					// Parse the output back into a JSON, and make sure it has the right number of rules.
-					const outputJson = JSON.parse(ctx.stdout);
-					expect(outputJson.result).to.have.lengthOf(targetRuleCount, 'All rules in the specified category should have been returned');
+				// Parse the output back into a JSON, and make sure it has the right number of rules.
+				const outputJson = output.jsonOutput;
+				expect(outputJson.result).to.have.lengthOf(targetRuleCount, 'All rules in the specified category should have been returned');
 
-					// Make sure that each rule overlaps with the expected categories
-					outputJson.result.forEach((rule: Rule) => {
-						expect(rule.categories).to.contain(positiveCategories[0], `Rule ${rule.name} was included despite being in the wrong category`);
-					});
+				// Make sure that each rule overlaps with the expected categories
+				(outputJson.result as any[]).forEach((rule: Rule) => {
+					expect(rule.categories).to.contain(positiveCategories[0], `Rule ${rule.name} was included despite being in the wrong category`);
 				});
+			})
 
-			setupCommandTest
-				.command(['scanner:rule:list', '--category', positiveCategories.join(','), '--json'])
-				.it('Filtering by multiple categories returns any rule in either category', async ctx => {
-					const targetRuleCount = await getRulesFilteredByCategoryCount(true, positiveCategories);
+			it('Filtering by multiple categories returns any rule in either category', async () => {
+				const output = runCommand(`scanner rule list --category '${positiveCategories.join(',')}' --json`);
+				const targetRuleCount = await getRulesFilteredByCategoryCount(true, positiveCategories);
 
-					// Parse the output back into a JSON, and make sure it has the right number of rules.
-					const outputJson = JSON.parse(ctx.stdout);
-					expect(outputJson.result).to.have.lengthOf(targetRuleCount, 'All rules in either category should be returned');
+				// Parse the output back into a JSON, and make sure it has the right number of rules.
+				const outputJson = output.jsonOutput;
+				expect(outputJson.result).to.have.lengthOf(targetRuleCount, 'All rules in either category should be returned');
 
-					// Make sure that each rule overlaps with the expected categories
-					outputJson.result.forEach((rule: Rule) => {
-						expect(rule).to.satisfy((rule) => {
-								return listContentsOverlap(rule.categories, positiveCategories)
-							},
-							`Rule ${rule.name} was included despite being in the wrong category`
-						);
-					});
+				// Make sure that each rule overlaps with the expected categories
+				(outputJson.result as any[]).forEach((rule: Rule) => {
+					expect(rule).to.satisfy((rule) => {
+							return listContentsOverlap(rule.categories, positiveCategories)
+						},
+						`Rule ${rule.name} was included despite being in the wrong category`
+					);
+				});
 			});
 
-			setupCommandTest
-				.command(['scanner:rule:list', '--category', negatedCategories[0], '--json'])
-				.it('Excluding by one category excludes all rules from that category', async ctx => {
-					const targetRuleCount = await getRulesFilteredByCategoryCount(false, [], [positiveCategories[0]]);
+			it('Excluding by one category excludes all rules from that category', async () => {
+				const output = runCommand(`scanner rule list --category '${negatedCategories[0]}' --json`);
+				const targetRuleCount = await getRulesFilteredByCategoryCount(false, [], [positiveCategories[0]]);
 
-					// Parse the output back into a JSON, and make sure it has the right number of rules.
-					const outputJson = JSON.parse(ctx.stdout);
-					expect(outputJson.result).to.have.lengthOf(targetRuleCount, 'All rules in the specified category should have been returned');
+				// Parse the output back into a JSON, and make sure it has the right number of rules.
+				const outputJson = output.jsonOutput;
+				expect(outputJson.result).to.have.lengthOf(targetRuleCount, 'All rules in the specified category should have been returned');
 
-					// Ensure that all of the returned rules have excluded the single category
-					outputJson.result.forEach((rule: Rule) => {
-						expect(rule.categories).to.not.contain(positiveCategories[0], `Rule ${rule.name} with categories ${rule.categories} was included despite being in the wrong category`);
-					});
+				// Ensure that all of the returned rules have excluded the single category
+				(outputJson.result as any[]).forEach((rule: Rule) => {
+					expect(rule.categories).to.not.contain(positiveCategories[0], `Rule ${rule.name} with categories ${rule.categories} was included despite being in the wrong category`);
 				});
+			});
 
-			setupCommandTest
-				.command(['scanner:rule:list', '--category', negatedCategories.join(','), '--json'])
-				.it('Excluding by multiple categories excludes all rules from those categories', async ctx => {
-					const targetRuleCount = await getRulesFilteredByCategoryCount(false, [], positiveCategories);
+			it('Excluding by multiple categories excludes all rules from those categories', async () => {
+				const output = runCommand(`scanner rule list --category '${negatedCategories.join(',')}' --json`);
+				const targetRuleCount = await getRulesFilteredByCategoryCount(false, [], positiveCategories);
 
-					// Parse the output back into a JSON, and make sure it has the right number of rules.
-					const outputJson = JSON.parse(ctx.stdout);
-					expect(outputJson.result).to.have.lengthOf(targetRuleCount, 'All rules in the specified category should have been returned');
+				// Parse the output back into a JSON, and make sure it has the right number of rules.
+				const outputJson = output.jsonOutput;
+				expect(outputJson.result).to.have.lengthOf(targetRuleCount, 'All rules in the specified category should have been returned');
 
-					// Ensure that all of the returned rules have excluded both categories
-					outputJson.result.forEach((rule: Rule) => {
-						expect(rule).to.satisfy((rule) => { return !positiveCategories.some(c => rule.categories.includes(c)) },
-							`Rule ${rule.name} with categories ${rule.categories} was included despite being in the wrong category`
-						);
-					});
+				// Ensure that all of the returned rules have excluded both categories
+				(outputJson.result as any[]).forEach((rule: Rule) => {
+					expect(rule).to.satisfy((rule) => { return !positiveCategories.some(c => rule.categories.includes(c)) },
+						`Rule ${rule.name} with categories ${rule.categories} was included despite being in the wrong category`
+					);
 				});
+			});
 		});
 
 		describe('Test Case: Filtering by ruleset only', () => {
 
-			setupCommandTest
-				.command(['scanner:rule:list', '--ruleset', 'Braces'])
-				.it('--ruleset option shows deprecation warning', ctx => {
-					expect(ctx.stderr).contains(messages.getMessage('rulesetDeprecation'));
+			it('--ruleset option shows deprecation warning', () => {
+				const output = runCommand(`scanner rule list --ruleset Braces`);
+				expect(output.shellOutput.stderr).contains(messages.getMessage('rulesetDeprecation'));
+			});
+
+			it('Filtering by a single ruleset returns only the rules in that ruleset', () => {
+				const output = runCommand(`scanner rule list --ruleset Braces --json`);
+				// Count how many rules in the catalog fit the criteria.
+				const targetRuleCount = getCatalogJson().rules.filter(rule => rule.rulesets.includes('Braces')).length;
+
+				// Parse the output back into a JSON, and make sure it has the right number of rules.
+				const outputJson = output.jsonOutput;
+				expect(outputJson.result).to.have.lengthOf(targetRuleCount, 'All rules in the desired ruleset should be returned');
+
+				// Make sure that only rules in the right ruleset were returned.
+				(outputJson.result as any[]).forEach((rule: Rule) => {
+					expect(rule.rulesets).to.contain('Braces', 'Only rules in the desired ruleset should have been returned');
 				});
+			});
 
-			setupCommandTest
-				.command(['scanner:rule:list', '--ruleset', 'Braces', '--json'])
-				.it('Filtering by a single ruleset returns only the rules in that ruleset', ctx => {
-					// Count how many rules in the catalog fit the criteria.
-					const targetRuleCount = getCatalogJson().rules.filter(rule => rule.rulesets.includes('Braces')).length;
+			it('Filtering by multiple rulesets returns any rule in either ruleset', () => {
+				const output = runCommand(`scanner rule list --ruleset ApexUnit,Braces --json`);
+				// Count how many rules in the catalog fit the criteria.
+				const targetRuleCount = getCatalogJson().rules.filter(rule => rule.rulesets.includes('Braces') || rule.rulesets.includes('ApexUnit')).length;
 
-					// Parse the output back into a JSON, and make sure it has the right number of rules.
-					const outputJson = JSON.parse(ctx.stdout);
-					expect(outputJson.result).to.have.lengthOf(targetRuleCount, 'All rules in the desired ruleset should be returned');
-
-					// Make sure that only rules in the right ruleset were returned.
-					outputJson.result.forEach((rule: Rule) => {
-						expect(rule.rulesets).to.contain('Braces', 'Only rules in the desired ruleset should have been returned');
-					});
+				// Parse the output back into a JSON, and make sure it has the right number of rules.
+				const outputJson = output.jsonOutput;
+				expect(outputJson.result).to.have.lengthOf(targetRuleCount, 'All rules in both sets should have been returned');
+				// Make sure that only rules in the desired sets were returned.
+				(outputJson.result as any[]).forEach((rule: Rule) => {
+					expect(rule).to.satisfy((rule) => {
+							return rule.rulesets.includes('Braces') || rule.rulesets.includes('ApexUnit')
+						},
+						`Rule ${rule.name} was included despite being in the wrong ruleset`
+					);
 				});
-
-			setupCommandTest
-				.command(['scanner:rule:list', '--ruleset', 'ApexUnit,Braces', '--json'])
-				.it('Filtering by multiple rulesets returns any rule in either ruleset', ctx => {
-					// Count how many rules in the catalog fit the criteria.
-					const targetRuleCount = getCatalogJson().rules.filter(rule => rule.rulesets.includes('Braces') || rule.rulesets.includes('ApexUnit')).length;
-
-					// Parse the output back into a JSON, and make sure it has the right number of rules.
-					const outputJson = JSON.parse(ctx.stdout);
-					expect(outputJson.result).to.have.lengthOf(targetRuleCount, 'All rules in both sets should have been returned');
-					// Make sure that only rules in the desired sets were returned.
-					outputJson.result.forEach((rule: Rule) => {
-						expect(rule).to.satisfy((rule) => {
-								return rule.rulesets.includes('Braces') || rule.rulesets.includes('ApexUnit')
-							},
-							`Rule ${rule.name} was included despite being in the wrong ruleset`
-						);
-					});
-				});
+			});
 		});
 
 		describe('Test Case: Filtering by language only', () => {
 			const filteredLanguages = ['apex', 'javascript'];
-			setupCommandTest
-				.command(['scanner:rule:list', '--language', filteredLanguages[0], '--json'])
-				.it('Filtering by a single language returns only rules applied to that language', ctx => {
-					// Count how many rules in the catalog fit the criteria.
-					const targetRuleCount = getCatalogJson().rules.filter(rule => rule.languages.includes(filteredLanguages[0])).length;
-					expect(targetRuleCount).to.be.above(0, 'Expected rule count cannot be zero. Test invalid');
 
-					// Parse the output back into a JSON and make sure it has the right number of rules.
-					const outputJson = JSON.parse(ctx.stdout);
-					// Make sure that only the right rules were returned.
-					outputJson.result.forEach((rule) => {
-						expect(rule.languages).to.contain(filteredLanguages[0], `Rule ${rule.name} was included despite targeting the wrong language`)
-					});
+			it('Filtering by a single language returns only rules applied to that language', () => {
+				const output = runCommand(`scanner rule list --language ${filteredLanguages[0]} --json`);
+				// Count how many rules in the catalog fit the criteria.
+				const targetRuleCount = getCatalogJson().rules.filter(rule => rule.languages.includes(filteredLanguages[0])).length;
+				expect(targetRuleCount).to.be.above(0, 'Expected rule count cannot be zero. Test invalid');
+
+				// Parse the output back into a JSON and make sure it has the right number of rules.
+				const outputJson = output.jsonOutput;
+				// Make sure that only the right rules were returned.
+				(outputJson.result as any[]).forEach((rule) => {
+					expect(rule.languages).to.contain(filteredLanguages[0], `Rule ${rule.name} was included despite targeting the wrong language`)
 				});
+			});
 
-			setupCommandTest
-				.command(['scanner:rule:list', '--language', filteredLanguages.join(','), '--json'])
-				.it('Filtering by multiple languages returns any rule for either language', async ctx => {
-					// Count how many rules in the catalog fit the criteria.
-					const enabledEngines = (await Controller.getEnabledEngines()).map(e => e.getName());
-					const filterFunction: (Rule) => boolean =
-						(r: Rule) => listContentsOverlap(r.languages, filteredLanguages) && enabledEngines.includes(r.engine);
-					const targetRuleCount = getCatalogJson().rules.filter(filterFunction).length;
-					expect(targetRuleCount).to.be.above(0, 'Expected rule count cannot be zero. Test invalid');
+			it('Filtering by multiple languages returns any rule for either language', async () => {
+				const output = runCommand(`scanner rule list --language ${filteredLanguages.join(',')} --json`);
+				// Count how many rules in the catalog fit the criteria.
+				const enabledEngines = (await Controller.getEnabledEngines()).map(e => e.getName());
+				const filterFunction: (Rule) => boolean =
+					(r: Rule) => listContentsOverlap(r.languages, filteredLanguages) && enabledEngines.includes(r.engine);
+				const targetRuleCount = getCatalogJson().rules.filter(filterFunction).length;
+				expect(targetRuleCount).to.be.above(0, 'Expected rule count cannot be zero. Test invalid');
 
-					// Parse the output back into a JSON and make sure it has the right number of rules.
-					const outputJson = JSON.parse(ctx.stdout);
-					expect(outputJson.result).to.have.lengthOf(targetRuleCount, 'All rules of the desired languages should be returned');
-					// Make sure that only the right rules were returned.
-					outputJson.result.forEach((rule: Rule) => {
-						expect(rule).to.satisfy((rule) => {
-								return listContentsOverlap(rule.languages, filteredLanguages)
-							},
-							`Rule ${rule.name} was included despite targeting neither desired language`
-						);
-					});
+				// Parse the output back into a JSON and make sure it has the right number of rules.
+				const outputJson = output.jsonOutput;
+				expect(outputJson.result).to.have.lengthOf(targetRuleCount, 'All rules of the desired languages should be returned');
+				// Make sure that only the right rules were returned.
+				(outputJson.result as any[]).forEach((rule: Rule) => {
+					expect(rule).to.satisfy((rule) => {
+							return listContentsOverlap(rule.languages, filteredLanguages)
+						},
+						`Rule ${rule.name} was included despite targeting neither desired language`
+					);
 				});
+			});
 		});
 
 		describe('Test Case: Filtering by engine only', () => {
-			setupCommandTest
-				.command(['scanner:rule:list', '--engine', ENGINE.PMD, '--json'])
-				.it('Filtering by a single engine returns only rules applied to that engine', ctx => {
-					// Count how many rules in the catalog fit the criteria.
-					const targetRuleCount = getCatalogJson().rules.filter(rule => rule.engine.includes(ENGINE.PMD)).length;
+			it('Filtering by a single engine returns only rules applied to that engine', () => {
+				const output = runCommand(`scanner rule list --engine ${ENGINE.PMD} --json`);
+				// Count how many rules in the catalog fit the criteria.
+				const targetRuleCount = getCatalogJson().rules.filter(rule => rule.engine.includes(ENGINE.PMD)).length;
 
-					// Parse the output back into a JSON and make sure it has the right number of rules.
-					const outputJson = JSON.parse(ctx.stdout);
-					expect(outputJson.result).to.have.lengthOf(targetRuleCount, 'All rules of the desired engine should be returned');
-					// Make sure that only the right rules were returned.
-					outputJson.result.forEach((rule) => {
-						expect(rule.engine).to.equal(ENGINE.PMD, `Rule ${rule.name} was included despite targeting the wrong engine`)
-					});
+				// Parse the output back into a JSON and make sure it has the right number of rules.
+				const outputJson = output.jsonOutput;
+				expect(outputJson.result).to.have.lengthOf(targetRuleCount, 'All rules of the desired engine should be returned');
+				// Make sure that only the right rules were returned.
+				(outputJson.result as any[]).forEach((rule) => {
+					expect(rule.engine).to.equal(ENGINE.PMD, `Rule ${rule.name} was included despite targeting the wrong engine`)
 				});
+			});
 
-			setupCommandTest
-				.command(['scanner:rule:list', '--engine', ENGINE.ESLINT_LWC, '--json'])
-				.it('Filtering by a disabled engine returns rules', ctx => {
-					// Count how many rules in the catalog fit the criteria.
-					const targetRuleCount = getCatalogJson().rules.filter(rule => rule.engine.includes(ENGINE.ESLINT_LWC)).length;
+			it('Filtering by a disabled engine returns rules', () => {
+				const output = runCommand(`scanner rule list --engine ${ENGINE.ESLINT_LWC} --json`);
+				// Count how many rules in the catalog fit the criteria.
+				const targetRuleCount = getCatalogJson().rules.filter(rule => rule.engine.includes(ENGINE.ESLINT_LWC)).length;
 
-					// Parse the output back into a JSON and make sure it has the right number of rules.
-					const outputJson = JSON.parse(ctx.stdout);
-					expect(outputJson.result).to.have.lengthOf(targetRuleCount, 'All rules of the desired engine should be returned');
-					// Make sure that only the right rules were returned.
-					outputJson.result.forEach((rule) => {
-						expect(rule.engine).to.equal(ENGINE.ESLINT_LWC, `Rule ${rule.name} was included despite targeting the wrong engine`)
-					});
+				// Parse the output back into a JSON and make sure it has the right number of rules.
+				const outputJson = output.jsonOutput;
+				expect(outputJson.result).to.have.lengthOf(targetRuleCount, 'All rules of the desired engine should be returned');
+				// Make sure that only the right rules were returned.
+				(outputJson.result as any[]).forEach((rule) => {
+					expect(rule.engine).to.equal(ENGINE.ESLINT_LWC, `Rule ${rule.name} was included despite targeting the wrong engine`)
 				});
+			});
 
-			const engines: string[] = [ENGINE.PMD, ENGINE.ESLINT_LWC];
-			setupCommandTest
-				.command(['scanner:rule:list', '--engine', engines.join(','), '--json'])
-				.it('Filtering by multiple engines returns any rule for either engine', ctx => {
-					// Count how many rules in the catalog fit the criteria.
-					const targetRuleCount = getCatalogJson().rules.filter(rule => (engines.indexOf(rule.engine) >= 0)).length;
+			it('Filtering by multiple engines returns any rule for either engine', () => {
+				const engines: string[] = [ENGINE.PMD, ENGINE.ESLINT_LWC];
+				const output = runCommand(`scanner rule list --engine ${engines.join(',')} --json`);
+				// Count how many rules in the catalog fit the criteria.
+				const targetRuleCount = getCatalogJson().rules.filter(rule => (engines.indexOf(rule.engine) >= 0)).length;
 
-					// Parse the output back into a JSON and make sure it has the right number of rules.
-					const outputJson = JSON.parse(ctx.stdout);
-					expect(outputJson.result).to.have.lengthOf(targetRuleCount, 'All rules of the desired engines should be returned');
-					// Make sure that only the right rules were returned.
-					outputJson.result.forEach((rule: Rule) => {
-						expect(rule).to.satisfy((rule) => {
-								return (engines.indexOf(rule.engine) >= 0)
-							},
-							`Rule ${rule.name} was included despite targeting neither desired engine`
-						);
-					});
+				// Parse the output back into a JSON and make sure it has the right number of rules.
+				const outputJson = output.jsonOutput;
+				expect(outputJson.result).to.have.lengthOf(targetRuleCount, 'All rules of the desired engines should be returned');
+				// Make sure that only the right rules were returned.
+				(outputJson.result as any[]).forEach((rule: Rule) => {
+					expect(rule).to.satisfy((rule) => {
+							return (engines.indexOf(rule.engine) >= 0)
+						},
+						`Rule ${rule.name} was included despite targeting neither desired engine`
+					);
 				});
+			});
 		});
 
 		describe('Test Case: Applying multiple filter types', () => {
-			setupCommandTest
-				.command(['scanner:rule:list', '--category', 'Best Practices', '--language', 'apex', '--json'])
-				.it('Filtering on multiple columns only returns rows that satisfy BOTH filters', ctx => {
-					// Count how many rules in the catalog fit all criteria.
-					const targetRuleCount = getCatalogJson().rules.filter(rule => rule.categories.includes('Best Practices') && rule.languages.includes('apex')).length;
+			it('Filtering on multiple columns only returns rows that satisfy BOTH filters', () => {
+				const output = runCommand(`scanner rule list --category 'Best Practices' --language apex --json`);
+				// Count how many rules in the catalog fit all criteria.
+				const targetRuleCount = getCatalogJson().rules.filter(rule => rule.categories.includes('Best Practices') && rule.languages.includes('apex')).length;
 
-					// Parse the output back into a JSON and make sure it has the right number of rules.
-					const outputJson = JSON.parse(ctx.stdout);
-					expect(outputJson.result).to.have.lengthOf(targetRuleCount, 'All rules matching criteria should have been returned');
+				// Parse the output back into a JSON and make sure it has the right number of rules.
+				const outputJson = output.jsonOutput;
+				expect(outputJson.result).to.have.lengthOf(targetRuleCount, 'All rules matching criteria should have been returned');
 
-					// Make sure that only the right rules were returned.
-					outputJson.result.forEach((rule: Rule) => {
-						expect(rule.languages).to.contain('apex', `Rule ${rule.name} was included despite targeting the wrong language`);
-						expect(rule.categories).to.contain('Best Practices', `Rule ${rule.name} was included despite being in the wrong category`);
-					});
+				// Make sure that only the right rules were returned.
+				(outputJson.result as any[]).forEach((rule: Rule) => {
+					expect(rule.languages).to.contain('apex', `Rule ${rule.name} was included despite targeting the wrong language`);
+					expect(rule.categories).to.contain('Best Practices', `Rule ${rule.name} was included despite being in the wrong category`);
 				});
+			});
 		});
 
 		describe('Edge Case: No rules match criteria', () => {
-			setupCommandTest
-				.command(['scanner:rule:list', '--category', 'Beebleborp'])
-				.it('Without --json flag, an empty table is printed', ctx => {
-					// Split the result by newline, and make sure there are two rows.
-					const rows = ctx.stdout.trim().split('\n');
-					expect(rows).to.have.lengthOf(2, 'Only the header rows should have been printed');
-				});
+			it('Without --json flag, an empty table is printed', () => {
+				const output = runCommand(`scanner rule list --category Beebleborp`);
+				// Split the result by newline, and make sure there are two rows.
+				const rows = output.shellOutput.stdout.trim().split('\n');
+				expect(rows).to.have.lengthOf(2, 'Only the header rows should have been printed');
+			})
 
-			setupCommandTest
-				.command(['scanner:rule:list', '--category', 'Beebleborp', '--json'])
-				.it('With the --json flag, the results are empty', ctx => {
-					// Parse the results back into a JSON and make sure it has an empty list.
-					const outputJson = JSON.parse(ctx.stdout);
-					expect(outputJson.result).to.have.lengthOf(0, 'No results should be included');
-				});
+			it('With the --json flag, the results are empty', () => {
+				const output = runCommand(`scanner rule list --category Beebleborp --json`);
+				// Parse the results back into a JSON and make sure it has an empty list.
+				const outputJson = output.jsonOutput;
+				expect(outputJson.result).to.have.lengthOf(0, 'No results should be included');
+			});
 		});
 	});
 });

--- a/test/commands/scanner/rule/list.test.ts
+++ b/test/commands/scanner/rule/list.test.ts
@@ -78,7 +78,7 @@ describe('scanner rule list', () => {
 			const negatedCategories = positiveCategories.map(c => `!${c}`);
 
 			it('Filtering by one category returns only the rules in that category for enabled engines', async () => {
-				const output = runCommand(`scanner rule list --category '${positiveCategories[0]}' --json`);
+				const output = runCommand(`scanner rule list --category "${positiveCategories[0]}" --json`);
 				const targetRuleCount = await getRulesFilteredByCategoryCount(true, [positiveCategories[0]]);
 
 				// Parse the output back into a JSON, and make sure it has the right number of rules.
@@ -92,7 +92,7 @@ describe('scanner rule list', () => {
 			})
 
 			it('Filtering by multiple categories returns any rule in either category', async () => {
-				const output = runCommand(`scanner rule list --category '${positiveCategories.join(',')}' --json`);
+				const output = runCommand(`scanner rule list --category "${positiveCategories.join(',')}" --json`);
 				const targetRuleCount = await getRulesFilteredByCategoryCount(true, positiveCategories);
 
 				// Parse the output back into a JSON, and make sure it has the right number of rules.
@@ -110,7 +110,7 @@ describe('scanner rule list', () => {
 			});
 
 			it('Excluding by one category excludes all rules from that category', async () => {
-				const output = runCommand(`scanner rule list --category '${negatedCategories[0]}' --json`);
+				const output = runCommand(`scanner rule list --category "${negatedCategories[0]}" --json`);
 				const targetRuleCount = await getRulesFilteredByCategoryCount(false, [], [positiveCategories[0]]);
 
 				// Parse the output back into a JSON, and make sure it has the right number of rules.
@@ -124,7 +124,7 @@ describe('scanner rule list', () => {
 			});
 
 			it('Excluding by multiple categories excludes all rules from those categories', async () => {
-				const output = runCommand(`scanner rule list --category '${negatedCategories.join(',')}' --json`);
+				const output = runCommand(`scanner rule list --category "${negatedCategories.join(',')}" --json`);
 				const targetRuleCount = await getRulesFilteredByCategoryCount(false, [], positiveCategories);
 
 				// Parse the output back into a JSON, and make sure it has the right number of rules.
@@ -272,7 +272,7 @@ describe('scanner rule list', () => {
 
 		describe('Test Case: Applying multiple filter types', () => {
 			it('Filtering on multiple columns only returns rows that satisfy BOTH filters', () => {
-				const output = runCommand(`scanner rule list --category 'Best Practices' --language apex --json`);
+				const output = runCommand(`scanner rule list --category "Best Practices" --language apex --json`);
 				// Count how many rules in the catalog fit all criteria.
 				const targetRuleCount = getCatalogJson().rules.filter(rule => rule.categories.includes('Best Practices') && rule.languages.includes('apex')).length;
 

--- a/test/commands/scanner/rule/remove.test.ts
+++ b/test/commands/scanner/rule/remove.test.ts
@@ -1,8 +1,11 @@
 import {expect} from '@salesforce/command/lib/test';
-import {setupCommandTest} from '../../../TestUtils';
+import {Interaction} from '@salesforce/cli-plugins-testkit';
+// @ts-ignore
+import {runCommand, runInteractiveCommand} from '../../../TestUtils';
 import {Messages} from '@salesforce/core';
 import {Controller} from '../../../../src/Controller';
 import { CUSTOM_PATHS_FILE } from '../../../../src/Constants';
+import * as TestOverrides from './../../../test-related-lib/TestOverrides';
 import fs = require('fs');
 import path = require('path');
 
@@ -12,16 +15,6 @@ const messages = Messages.loadMessages('@salesforce/sfdx-scanner', 'remove');
 function getSfdxScannerPath(): string {
 	return Controller.getSfdxScannerPath();
 }
-
-/**
- * scanner:rule:remove typically prompts the user to confirm that they actually
- * want to remove the rules in question.
- * For these tests, this constant will indicate a number of milliseconds that
- * we should wait before simulating a user's response to that prompt.
- * It's important to wait, because if we send the input too early, it will be
- * missed by the test, which will eventually just time out and fail.
- */
-const waitTime = 5000;
 
 // NOTE: The relative paths are relative to the root of the project instead of to the location of this file,
 // because the root is the working directory during test evaluation.
@@ -37,154 +30,108 @@ const customPathDescriptor = {
 	}
 };
 
-const removeTest = setupCommandTest
-	.do(() => {
+describe('scanner rule remove', () => {
+	beforeEach(() => {
+		TestOverrides.initializeTestSetup();
 		writePopulatedCustomPathFile();
-	})
-	.finally(() => {
+	});
+
+	afterEach(() => {
 		// Clean up after ourselves.
 		writeEmptyCustomPathFile();
 	});
 
-describe('scanner:rule:remove', () => {
 	describe('E2E', () => {
-		describe('Dry-Run (omitting --path parameter)', () => {
-			removeTest
-				.command(['scanner:rule:remove'])
-				.it('When custom rules are registered, all paths are returned', ctx => {
-					const expectedRuleSummary = [pathToApexJar1, pathToApexJar2, pathToApexJar3]
-						.map(p => messages.getMessage('output.dryRunRuleTemplate', [p]))
-						.join('\n');
-					expect(ctx.stdout).to.contain(messages.getMessage('output.dryRunOutput', [3, expectedRuleSummary]), 'All paths should be logged');
+		describe('Interactivity', () => {
+			it('Omitting --path outputs list of removeable paths', () => {
+				const output = runCommand(`scanner rule remove`);
+				const expectedRuleSummary = [pathToApexJar1, pathToApexJar2, pathToApexJar3]
+					.map(p => messages.getMessage('output.dryRunRuleTemplate', [p]))
+					.join('\n');
+				expect(output.shellOutput.stdout).to.contain(messages.getMessage('output.dryRunOutput', [3, expectedRuleSummary]), 'All paths should be logged');
+			});
+
+			// TODO: THIS TEST CANNOT BE ENABLED UNTIL WE SWITCH FROM `SfdxCommand` TO `SfCommand`!
+			xit('By default, rule removal must be confirmed', async () => {
+				const output = await runInteractiveCommand(`scanner rule remove --path ${pathToApexJar1}`, {
+					'These rules will be unregistered': Interaction.Yes
 				});
-		});
-
-		describe('Rule Removal', () => {
-			describe('Test Case: Removing a single PMD JAR', () => {
-				removeTest
-					// We'll wait a few seconds then send in a 'y', to simulate the user confirming the request.
-					.stdin('y\n', waitTime)
-					.timeout(10000)
-					.command(['scanner:rule:remove',
-						'--path', pathToApexJar1
-					])
-					.it('The specified JAR is deleted.', ctx => {
-						expect(ctx.stdout).to.contain(
-							messages.getMessage('output.resultSummary', [pathToApexJar1]),
-							'Console should report deletion.'
-						);
-						const updatedCustomPathJson = getCustomPathFileContent();
-						expect(updatedCustomPathJson).to.deep.equal({
-							'pmd': {
-								'apex': [pathToApexJar2, pathToApexJar3]
-							}
-						}, `Deletion should have been persisted ${JSON.stringify(updatedCustomPathJson)}`);
-					});
+				expect(output.stdout).to.contain(
+					messages.getMessage('output.resultSummary', [pathToApexJar1]),
+					'Console should report deletion.'
+				);
+				const updatedCustomPathJson = getCustomPathFileContent();
+				expect(updatedCustomPathJson).to.deep.equal({
+					'pmd': {
+						'apex': [pathToApexJar2, pathToApexJar3]
+					}
+				}, `Deletion should have been persisted ${JSON.stringify(updatedCustomPathJson)}`);
 			});
 
-			describe('Test Case: Removing multiple PMD JARs', () => {
-				removeTest
-					// We'll wait a few seconds then send in a 'y', to simulate the user confirming the request.
-					.stdin('y\n', waitTime)
-					.timeout(10000)
-					.command(['scanner:rule:remove',
-						'--path', [pathToApexJar1, pathToApexJar2].join(',')
-					])
-					.it('The specified JARs are deleted', ctx => {
-						expect(ctx.stdout).to.contain(
-							messages.getMessage('output.resultSummary', [[pathToApexJar1, pathToApexJar2].join(', ')]),
-							'Console should report deletion'
-						);
-						const updatedCustomPathJson = getCustomPathFileContent();
-						expect(updatedCustomPathJson).to.deep.equal({
-							'pmd': {
-								'apex': [pathToApexJar3]
-							}
-						}, 'Deletion should have been persisted');
-					});
-			});
-
-			describe('Test Case: Removing an entire folder of PMD JARs', () => {
-				removeTest
-					// We'll wait a few seconds then send in a 'y', to simulate the user confirming the request.
-					.stdin('y\n', waitTime)
-					.timeout(10000)
-					.command(['scanner:rule:remove',
-						'--path', parentFolderForJars
-					])
-					.it('All JARs in the target folder are deleted', ctx => {
-						expect(ctx.stdout).to.contain(
-							messages.getMessage('output.resultSummary', [[pathToApexJar1, pathToApexJar2, pathToApexJar3].join(', ')]),
-							'Console should report deletion'
-						);
-						const updatedCustomPathJson = getCustomPathFileContent();
-						expect(updatedCustomPathJson).to.deep.equal({
-							'pmd': {
-								'apex': []
-							}
-						}, 'Deletion should have been persisted');
-					});
-			});
-
-			describe('Edge Case: Provided path is not registered as a custom rule', () => {
-				removeTest
-					// We'll wait a few seconds then send in a 'y', to simulate the user confirming the request.
-					.stdin('y\n', waitTime)
-					.timeout(10000)
-					.command(['scanner:rule:remove',
-						'--path', pathToApexJar4
-					])
-					.it('All JARs in the target folder are deleted', ctx => {
-						expect(ctx.stderr).to.contain(messages.getMessage('errors.noMatchingPaths'), 'Should throw expected error');
-					});
+			// TODO: THIS TEST CANNOT BE ENABLED UNTIL WE SWITCH FROM `SfdxCommand` TO `SfCommand`!
+			xit('Rule removal can be safely aborted', async () => {
+				const output = await runInteractiveCommand(`scanner rule remove --path ${pathToApexJar1}`, {
+					'These rules will be unregistered': Interaction.No
+				});
+				expect(output.stdout).to.contain(messages.getMessage('output.aborted'), 'Transaction should have been aborted');
+				const updatedCustomPathJson = getCustomPathFileContent();
+				expect(updatedCustomPathJson).to.deep.equal(customPathDescriptor, 'Custom paths should not have changed');
 			});
 		});
 
-		describe('User prompt', () => {
-			describe('Test Case: User chooses to abort transaction instead of confirming', () => {
-				removeTest
-					// We'll wait a few seconds and then send in a 'n', to simulate the user aborting the request.
-					.stdin('n\n', waitTime)
-					.timeout(10000)
-					.command(['scanner:rule:remove',
-						'--path', pathToApexJar1
-					])
-					.it('Request is successfully cancelled', ctx => {
-						expect(ctx.stdout).to.contain(messages.getMessage('output.aborted'), 'Transaction should have been aborted');
-						const updatedCustomPathJson = getCustomPathFileContent();
-						expect(updatedCustomPathJson).to.deep.equal(customPathDescriptor, 'Custom paths should not have changed');
-					});
+		describe('Functionality', () => {
+			it('Successfully removes a single JAR', () => {
+				const output = runCommand(`scanner rule remove --path ${pathToApexJar1} --force`);
+				expect(output.shellOutput.stdout).to.contain(
+					messages.getMessage('output.resultSummary', [pathToApexJar1]),
+					'Console should report deletion.'
+				);
+				const updatedCustomPathJson = getCustomPathFileContent();
+				expect(updatedCustomPathJson).to.deep.equal({
+					'pmd': {
+						'apex': [pathToApexJar2, pathToApexJar3]
+					}
+				}, `Deletion should have been persisted ${JSON.stringify(updatedCustomPathJson)}`);
 			});
 
-			describe('Test Case: User uses --force flag to skip confirmation prompt', () => {
-				removeTest
-					.command(['scanner:rule:remove',
-						'--path', pathToApexJar1,
-						'--force'
-					])
-					.it('--force flag bypasses need for confirmation', ctx => {
-						expect(ctx.stdout).to.contain(
-							messages.getMessage('output.resultSummary', [pathToApexJar1]),
-							'Console should report deletion.'
-						);
-						const updatedCustomPathJson = getCustomPathFileContent();
-						expect(updatedCustomPathJson).to.deep.equal({
-							'pmd': {
-								'apex': [pathToApexJar2, pathToApexJar3]
-							}
-						}, 'Deletion should have been persisted');
-					});
+			it('Successfully removes multiple JARs at once', () => {
+				const output = runCommand(`scanner rule remove --path ${pathToApexJar1},${pathToApexJar2} --force`);
+				expect(output.shellOutput.stdout).to.contain(
+					messages.getMessage('output.resultSummary', [[pathToApexJar1, pathToApexJar2].join(', ')]),
+					'Console should report deletion'
+				);
+				const updatedCustomPathJson = getCustomPathFileContent();
+				expect(updatedCustomPathJson).to.deep.equal({
+					'pmd': {
+						'apex': [pathToApexJar3]
+					}
+				}, 'Deletion should have been persisted');
+			});
+
+			it('Successfully removes a whole folder', () => {
+				const output = runCommand(`scanner rule remove --path ${parentFolderForJars} --force`);
+				expect(output.shellOutput.stdout).to.contain(
+					messages.getMessage('output.resultSummary', [[pathToApexJar1, pathToApexJar2, pathToApexJar3].join(', ')]),
+					'Console should report deletion'
+				);
+				const updatedCustomPathJson = getCustomPathFileContent();
+				expect(updatedCustomPathJson).to.deep.equal({
+					'pmd': {
+						'apex': []
+					}
+				}, 'Deletion should have been persisted');
+			});
+
+			it('Throws error when requested path is not already registered', () => {
+				const output = runCommand(`scanner rule remove --path ${pathToApexJar4}`);
+				expect(output.shellOutput.stderr).to.contain(messages.getMessage('errors.noMatchingPaths'), 'Should throw expected error');
 			});
 		});
 
 		describe('Validations', () => {
-			describe('Path validations', () => {
-				// Test for failure scenario doesn't need to do any special setup or cleanup.
-				removeTest
-					.command(['scanner:rule:remove', '--path', ''])
-					.it('should complain about empty path', ctx => {
-						expect(ctx.stderr).contains(messages.getMessage('validations.pathCannotBeEmpty'));
-					});
+			it('Complains about empty --path', () => {
+				const output = runCommand(`scanner rule remove --path ''`);
+				expect(output.shellOutput.stderr).to.contain(messages.getMessage('validations.pathCannotBeEmpty'));
 			});
 		});
 	});

--- a/test/commands/scanner/run.custom.test.ts
+++ b/test/commands/scanner/run.custom.test.ts
@@ -1,5 +1,6 @@
 import { Messages } from "@salesforce/core";
-import { setupCommandTest } from "../../TestUtils";
+// @ts-ignore
+import { runCommand } from "../../TestUtils";
 import path = require('path');
 import { expect } from "@oclif/test";
 import {ENGINE} from '../../../src/Constants';
@@ -14,92 +15,57 @@ describe('scanner:run with custom config E2E', () => {
 	const customPmdConfig =  path.join('.', 'test', 'code-fixtures', 'config', 'pmd_custom_config.xml');
 	const customEslintConfig = path.join('test', 'code-fixtures', 'config', 'custom_eslint_config.json');
 
+	it('Can use custom PMD config to detect violations', () => {
+		const targetPath = path.join('.', 'test', 'code-fixtures', 'projects', 'app', 'force-app', 'main', 'default', 'pages', 'testSELECT2.page');
+		const output = runCommand(`scanner run --target ${targetPath} --pmdconfig ${customPmdConfig} --format json`);
+		const stdout = output.shellOutput.stdout;
+		expect(stdout).to.not.be.empty;
 
-	describe('Custom PMD config', () => {
+		// Verify that the expected warning is displayed.
+		const expectedMessage = eventMessages.getMessage('info.customPmdHeadsUp', [normalize(customPmdConfig)]);
+		expect(stdout).to.contain(expectedMessage);
 
-		
-		setupCommandTest
-		.command(['scanner:run', 
-			'--target', path.join('.', 'test', 'code-fixtures', 'projects', 'app', 'force-app', 'main', 'default', 'pages', 'testSELECT2.page'),
-			'--pmdconfig', customPmdConfig,
-			'--format', 'json'])
-		.it('should use custom pmd config to detect violations', (ctx) => {
-			const stdout = ctx.stdout;
-			const jsonOutput = stdout.slice(stdout.indexOf('['), stdout.lastIndexOf(']') + 1);
-			expect(jsonOutput).to.be.not.empty;
-			const output = JSON.parse(jsonOutput);
-
-			//verify rule violations
-			expect(output.length).to.equal(1);
-			expect(output[0].engine).to.equal(ENGINE.PMD_CUSTOM.valueOf());
-			expect(output[0].violations.length).to.equal(1);
-			
-		});
-
-		setupCommandTest
-		.command(['scanner:run', 
-			'--target', path.join('.', 'test', 'code-fixtures', 'projects', 'app', 'force-app', 'main', 'default', 'pages', 'testSELECT2.page'),
-			'--pmdconfig', customPmdConfig])
-		.it('should display warning that we are about to run PMD with custom config', (ctx) => {
-			const stdout = ctx.stdout;			
-			const expectedMessage = eventMessages.getMessage('info.customPmdHeadsUp', [normalize(customPmdConfig)]);
-
-			expect(stdout).contains(expectedMessage);
-		});
-
+		// Verify that the contents are correct.
+		const jsonOutput = stdout.slice(stdout.indexOf('['), stdout.lastIndexOf(']') + 1);
+		expect(jsonOutput).to.not.be.empty;
+		const parsedJson = JSON.parse(jsonOutput);
+		expect(parsedJson).to.have.lengthOf(1);
+		expect(parsedJson[0].engine).to.equal(ENGINE.PMD_CUSTOM.valueOf());
+		expect(parsedJson[0].violations).to.have.lengthOf(1);
 	});
 
-	describe('Custom Eslint config', () => {
+	it('Can use custom ESLint config to detect violations', () => {
+		const targetPath = path.join('.', 'test', 'code-fixtures', 'projects', 'ts', 'src', 'simpleYetWrong.ts');
+		const output = runCommand(`scanner run --target ${targetPath} --eslintconfig ${customEslintConfig} --format json`);
+		const stdout = output.shellOutput.stdout;
+		expect(stdout).to.not.be.empty;
 
-		setupCommandTest
-		.command(['scanner:run',
-			'--target', path.join('.', 'test', 'code-fixtures', 'projects', 'ts', 'src', 'simpleYetWrong.ts'),
-			'--eslintconfig', customEslintConfig,
-			'--format', 'json'])
-		.it('should use custom eslint config to detect violations', ctx => {
-			const stdout = ctx.stdout;
-			const jsonOutput = stdout.slice(stdout.indexOf('['), stdout.lastIndexOf(']') + 1);
-			expect(jsonOutput).to.be.not.empty;
-			const output = JSON.parse(jsonOutput);
+		// Verify that the expected warning is displayed.
+		const expectedMessage = eventMessages.getMessage('info.customEslintHeadsUp', [normalize(customEslintConfig)]);
+		expect(stdout).to.contain(expectedMessage);
 
-			//verify rule violations
-			expect(output.length).to.equal(1);
-			expect(output[0].engine).to.equal(ENGINE.ESLINT_CUSTOM.valueOf());
-			expect(output[0].violations.length).to.equal(1);
-		});
-
-
-		setupCommandTest
-		.command(['scanner:run',
-			'--target', path.join('.', 'test', 'code-fixtures', 'projects', 'ts', 'src', 'simpleYetWrong.ts'),
-			'--eslintconfig', customEslintConfig])
-		.it('should display warning that we are about to run Eslint with custom config', (ctx) => {
-			const stdout = ctx.stdout;			
-			const expectedMessage = eventMessages.getMessage('info.customEslintHeadsUp', [normalize(customEslintConfig)]);
-							
-			expect(stdout).contains(expectedMessage);
-		});
+		// Verify that the contents are correct.
+		const jsonOutput = stdout.slice(stdout.indexOf('['), stdout.lastIndexOf(']') + 1);
+		expect(jsonOutput).to.not.be.empty;
+		const parsedJson = JSON.parse(jsonOutput);
+		expect(parsedJson).to.have.lengthOf(1);
+		expect(parsedJson[0].engine).to.equal(ENGINE.ESLINT_CUSTOM.valueOf());
+		expect(parsedJson[0].violations.length).to.equal(1);
 	});
 
-	describe('Engine exclusivity with custom config', () => {
+	it('Default engine and custom variant are mutually exclusive', () => {
+		const targetPath = path.join('.', 'test', 'code-fixtures', 'projects', 'app', 'force-app');
+		const output = runCommand(`scanner run --target ${targetPath} --pmdconfig ${customPmdConfig} --format json`);
+		const stdout = output.shellOutput.stdout;
+		const jsonOutput = stdout.slice(stdout.indexOf('['), stdout.lastIndexOf(']') + 1);
+		expect(jsonOutput).to.not.be.empty;
 
-		setupCommandTest
-		.command(['scanner:run',
-			'--target', path.join('.', 'test', 'code-fixtures', 'projects', 'app', 'force-app'),
-			'--pmdconfig', customPmdConfig,
-			'--format', 'json'])
-		.it('should not run default PMD engine when custom config provided, but can run default Eslint engines', ctx => {
-			const stdout = ctx.stdout;
-			const jsonOutput = stdout.slice(stdout.indexOf('['), stdout.lastIndexOf(']') + 1);
-			expect(jsonOutput).to.be.not.empty;
+		const parsedOutput = JSON.parse(jsonOutput);
 
-			const output = JSON.parse(jsonOutput);
-
-			const onlyCustomPmdAndDefaultEslint = output.filter(violation => {
-				return (violation.engine === ENGINE.PMD_CUSTOM.valueOf() || violation.engine === ENGINE.ESLINT.valueOf());
-			});
-
-			expect(output.length).equals(onlyCustomPmdAndDefaultEslint.length, 'Rule violations should include violations from custom PMD and default Eslint');
+		const onlyCustomPmdAndDefaultEslint = parsedOutput.filter(violation => {
+			return (violation.engine === ENGINE.PMD_CUSTOM.valueOf() || violation.engine === ENGINE.ESLINT.valueOf());
 		});
+
+		expect(parsedOutput.length).to.equal(onlyCustomPmdAndDefaultEslint.length, 'Violations should be only from Custom PMD and Default ESLint');
 	});
 });

--- a/test/commands/scanner/run.dfa.test.ts
+++ b/test/commands/scanner/run.dfa.test.ts
@@ -1,5 +1,6 @@
 import {expect} from '@salesforce/command/lib/test';
-import {setupCommandTest} from '../../TestUtils';
+// @ts-ignore
+import {runCommand} from '../../TestUtils';
 import {Messages} from '@salesforce/core';
 import * as path from 'path';
 import Dfa from '../../../src/commands/scanner/run/dfa';
@@ -26,6 +27,7 @@ const startGraphBuildMessage = sfgeMessages.getMessage('info.sfgeStartedBuilding
 const endGraphBuildMessage = sfgeMessages.getMessage('info.sfgeFinishedBuildingGraph');
 const identifiedEntryMessage = sfgeMessages.getMessage('info.sfgePathEntryPointsIdentified', [entryPointCount]);
 const completedAnalysisMessage = sfgeMessages.getMessage('info.sfgeCompletedPathAnalysis', [pathCount, entryPointCount, violationCount]);
+const experimentalRuleName = "RemoveUnusedMethod";
 
 function isSubstr(output: string, substring: string): boolean {
 	const updatedSubstr = substring.replace('[', '\\[');
@@ -46,80 +48,63 @@ describe('scanner:run:dfa', function () {
 	this.timeout(20000); // TODO why do we get timeouts at the default of 5000?  What is so expensive here?
 
 	describe('End to end', () => {
-
-		describe('Output consistency', () => {
-			describe('run with --format json', () => {
-				setupCommandTest
-				.command(['scanner:run:dfa',
-				'--target', dfaTarget,
-				'--projectdir', projectdir,
-				'--format', 'json'
-			])
-			.it('provides only json in stdout', ctx => {
-				try {
-					JSON.parse(ctx.stdout);
-				} catch (error) {
-					expect.fail("dummy", "another dummy", "Invalid JSON output from --format json: " + ctx.stdout + ", error = " + error);
-				}
-
-				});
-			});
-		});
-
-		describe('Flags', () => {
-			describe('--with-pilot', () => {
-				setupCommandTest
-					.command(['scanner:run:dfa',
-						'--target', dfaTarget,
-						'--projectdir', projectdir,
-						'--format', 'json',
-						'--with-pilot'
-					])
-					.it('Including flag activates pilot rules', ctx => {
-						// Verify that there's a violation somewhere for an experimental rule.
-						verifyContains(ctx.stdout, "RemoveUnusedMethod");
-					});
-
-				setupCommandTest
-					.command(['scanner:run:dfa',
-						'--target', dfaTarget,
-						'--projectdir', projectdir,
-						'--format', 'json'
-					])
-					.it('Omitting flag disables pilot rules', ctx => {
-						// Verify that there's a NOT violation somewhere for an experimental rule.
-						verifyNotContains(ctx.stdout, "RemoveUnusedMethod");
-					});
-			});
-		});
-
-		describe('Progress output', () => {
+		describe('Without special flags', () => {
 			let sandbox;
 			let spy: sinon.SinonSpy;
-				before(() => {
-					sandbox = sinon.createSandbox();
-					spy = sandbox.spy(Dfa.prototype, "updateSpinner");
-				});
 
-				after(() => {
-					spy.restore();
-					sinon.restore();
-				});
+			before(() => {
+				sandbox = sinon.createSandbox();
+				spy = sandbox.spy(Dfa.prototype, "updateSpinner");
+			})
 
-			setupCommandTest
-				.command(['scanner:run:dfa',
-					'--target', dfaTarget,
-					'--projectdir', projectdir,
-					'--format', 'json'
-				])
-				.it('contains valid information when --verbose is not used', ctx => {
-					const output = ctx.stdout;
-					verifyNotContains(output, customSettingsMessage);
-					verifyNotContains(output, apexControllerMessage);
-					expect(spy.calledWith(compiledMessage, startGraphBuildMessage, endGraphBuildMessage, identifiedEntryMessage, completedAnalysisMessage));
-				});
+			after(() => {
+				spy.restore();
+				sinon.restore();
+			});
 
+			const output = runCommand(`scanner run dfa --target ${dfaTarget} --projectdir ${projectdir} --format json`);
+
+
+			it('Output is parsable JSON', () => {
+				try {
+					JSON.parse(output.shellOutput.stdout);
+				} catch (error) {
+					expect.fail(`Invalid JSON output from --format json: ${output.shellOutput.stdout}; error = ${error}`);
+				}
+			});
+
+			it('Pilot rules are not executed', () => {
+				// Verify that there's NOT a violation somewhere for an experimental rule.
+				verifyNotContains(output.shellOutput.stdout, experimentalRuleName);
+			});
+
+			it('Contains no verbose-only information', () => {
+				// The messages about loading various types of thing should only be logged when --verbose is used.
+				const stdout = output.shellOutput.stdout;
+				verifyNotContains(stdout, customSettingsMessage);
+				verifyNotContains(stdout, apexControllerMessage);
+				expect(spy.calledWith(compiledMessage, startGraphBuildMessage, endGraphBuildMessage, identifiedEntryMessage, completedAnalysisMessage));
+			});
 		});
 
+		describe('Using --with-pilot flag', () => {
+			const output = runCommand(`scanner run dfa --target ${dfaTarget} --projectdir ${projectdir} --format json --with-pilot`);
+
+			it('Executes experimental rules', () => {
+				// Verify that there's a violation somewhere in there for an experimental rule.
+				verifyContains(output.shellOutput.stdout, experimentalRuleName);
+			});
+		});
+
+		describe('Using --verbose flag', () => {
+			const output = runCommand(`scanner run dfa --target ${dfaTarget} --projectdir ${projectdir} --format json --verbose`);
+
+			it('Verbose information is logged', () => {
+				// The messages about loading various types of thing should only be logged when --verbose is used.
+				const stdout = output.shellOutput.stdout;
+				verifyContains(stdout, customSettingsMessage);
+				verifyContains(stdout, apexControllerMessage);
+			});
+		});
 	});
 });

--- a/test/commands/scanner/run.filters.test.ts
+++ b/test/commands/scanner/run.filters.test.ts
@@ -1,5 +1,6 @@
-import {expect} from '@salesforce/command/lib/test';
-import {setupCommandTest} from '../../TestUtils';
+import {expect} from 'chai';
+// @ts-ignore
+import {runCommand} from '../../TestUtils';
 import {Messages} from '@salesforce/core';
 import path = require('path');
 import * as TestUtils from '../../TestUtils';
@@ -7,20 +8,14 @@ import * as TestUtils from '../../TestUtils';
 Messages.importMessagesDirectory(__dirname);
 const exceptionMessages = Messages.loadMessages('@salesforce/sfdx-scanner', 'Exceptions');
 
-/**
- * IMPORTANT. The oclif CLI test framework requires the .it to come after the .command
- */
 describe('scanner:run tests that result in the use of RuleFilters', function () {
-	describe('--engine flag', () => {
-		setupCommandTest
-			.command(['scanner:run',
-				'--target', path.join('test', 'code-fixtures', 'lwc'),
-				'--format', 'csv',
-				'--engine', 'eslint-lwc'
-			])
-			.it('LWC Engine Successfully parses LWC code', ctx => {
+	describe('Single filter', () => {
+		describe('Positive constraints', () => {
+			it('Case: --engine eslint-lwc against clean LWC code', () => {
+				const output = runCommand(`scanner run --target ${path.join('test', 'code-fixtures', 'lwc')} --format csv --engine eslint-lwc`);
+				const stdout = output.shellOutput.stdout;
 				// If there's a summary, then it'll be separated from the CSV by an empty line. Throw it away.
-				const [csv, _] = ctx.stdout.trim().split(/\n\r?\n/);
+				const [csv, _] = stdout.trim().split(/\n\r?\n/);
 
 				// Confirm there are no violations.
 				// Since it's a CSV, the rows themselves are separated by newline characters.
@@ -28,14 +23,9 @@ describe('scanner:run tests that result in the use of RuleFilters', function () 
 				expect(csv.indexOf('\n')).to.equal(-1, "Should be no violations detected");
 			});
 
-		setupCommandTest
-			.command(['scanner:run',
-				'--target', path.join('test', 'code-fixtures', 'invalid-lwc'),
-				'--format', 'json',
-				'--engine', 'eslint-lwc'
-			])
-			.it('LWC Engine detects LWC errors', ctx => {
-				const stdout = ctx.stdout;
+			it('Case: --engine eslint-lwc against unclean LWC code', () => {
+				const output = runCommand(`scanner run --target ${path.join('test', 'code-fixtures', 'invalid-lwc')} --format json --engine eslint-lwc`);
+				const stdout = output.shellOutput.stdout;
 				const results = JSON.parse(stdout.slice(stdout.indexOf('['), stdout.lastIndexOf(']') + 1));
 				expect(results, `results does not have expected length. ${results.map(r => r.fileName).join(',')}`)
 					.to.be.an('Array').that.has.length(1);
@@ -46,179 +36,119 @@ describe('scanner:run tests that result in the use of RuleFilters', function () 
 					expect(messages).to.contain(expectedMessage);
 				}
 			});
+		});
+
+		describe('Negative constraints', () => {
+			it('Case: Negate one category', () => {
+				const category = '\'!Code Style\'';
+				const output = runCommand(`scanner run --target ${path.join('test', 'code-fixtures', 'apex')} --format json --category ${category}`);
+				const stdout = output.shellOutput.stdout;
+				const results = JSON.parse(stdout.slice(stdout.indexOf('['), stdout.lastIndexOf(']') + 1));
+
+				expect(results.length).greaterThan(0);
+				for (const result of results) {
+					for (const violation of result.violations) {
+						expect(violation.category, TestUtils.prettyPrint(violation)).to.not.equal(category);
+					}
+				}
+			});
+
+			it('Case: Negate multiple categories', () => {
+				const category = `'!Code Style,!Security'`;
+				const nonExpectedCategories: Set<string> = new Set<string>();
+				nonExpectedCategories.add('Code Style').add('Security');
+
+				const output = runCommand(`scanner run --target ${path.join('test', 'code-fixtures', 'apex')} --format json --category ${category}`);
+				const stdout = output.shellOutput.stdout;
+				const results = JSON.parse(stdout.slice(stdout.indexOf('['), stdout.lastIndexOf(']') + 1));
+				expect(results.length).greaterThan(0);
+
+				for (const result of results) {
+					for (const violation of result.violations) {
+						expect(nonExpectedCategories.has(violation.category), TestUtils.prettyPrint(violation)).to.be.false;
+					}
+				}
+			});
+
+			it('Case: Negate non-negatable filter (--ruleset)', () => {
+				const ruleset = `'!some-value'`;
+				const output = runCommand(`scanner run --target ${path.join('test', 'code-fixtures', 'apex')} --format json --ruleset ${ruleset}`);
+				expect(output.shellOutput.stderr).to.contain(exceptionMessages.getMessage('RuleFilter.PositiveOnly', ['Ruleset']), '--ruleset should not be negateable');
+			});
+		});
+
+		it('Case: Mixing positive and negative constraints', () => {
+			const category = `'!Code Style,Security'`;
+			const output = runCommand(`scanner run --target ${path.join('test', 'code-fixtures', 'apex')} --format json --category ${category}`);
+			expect(output.shellOutput.stderr).to.contain(exceptionMessages.getMessage('RuleFilter.MixedTypes', ['Category']), 'Cannot mix positive and negative constraints');
+		});
 	});
 
-	describe('--category and --engine flag', () => {
-		describe('Eslint Javascript Engine --category flag', () => {
+	describe('Multiple filters', () => {
+		const pathToDomParserController = path.join('test', 'code-fixtures', 'projects', 'app', 'force-app', 'main', 'default', 'aura', 'dom_parser', 'dom_parserController.js');
+		it('Case: --engine eslint --category problem', () => {
 			const category = 'problem';
 			const expectedViolationCount = 3;
-			setupCommandTest
-				.command(['scanner:run',
-					'--target', path.join('test', 'code-fixtures', 'projects', 'app', 'force-app', 'main', 'default', 'aura', 'dom_parser', 'dom_parserController.js'),
-					'--format', 'json',
-					'--engine', 'eslint',
-					'--category', category
-				])
-				.it('Only correct categories are returned', ctx => {
-					const stdout = ctx.stdout;
-					const output = JSON.parse(stdout.slice(stdout.indexOf('['), stdout.lastIndexOf(']') + 1));
-					expect(output.length).to.equal(1, 'Should only be violations from one file');
-					expect(output[0].engine).to.equal('eslint');
-					expect(output[0].violations, TestUtils.prettyPrint(output[0].violations)).to.be.lengthOf(expectedViolationCount);
+			const commandOutput = runCommand(`scanner run --target ${pathToDomParserController} --format json --engine eslint --category ${category}`);
+			const stdout = commandOutput.shellOutput.stdout;
+			const output = JSON.parse(stdout.slice(stdout.indexOf('['), stdout.lastIndexOf(']') + 1));
+			expect(output.length).to.equal(1, 'Should only be violations from one file');
+			expect(output[0].engine).to.equal('eslint');
+			expect(output[0].violations, TestUtils.prettyPrint(output[0].violations)).to.be.lengthOf(expectedViolationCount);
 
-					// Make sure only violations are returned for the requested category
-					for (const v of output[0].violations) {
-						expect(v.category, TestUtils.prettyPrint(v)).to.equal(category);
-					}
-				});
+			// Make sure only violations are returned for the requested category
+			for (const v of output[0].violations) {
+				expect(v.category, TestUtils.prettyPrint(v)).to.equal(category);
+			}
 		});
 
-		describe('Eslint LWC Engine --category flag', () => {
+		it('Case: --engine eslint-lwc --category suggestion', () => {
 			const category = 'suggestion';
 			const expectedViolationCount = 36;
-			setupCommandTest
-				.command(['scanner:run',
-					'--target', path.join('test', 'code-fixtures', 'projects', 'app', 'force-app', 'main', 'default', 'aura', 'dom_parser', 'dom_parserController.js'),
-					'--format', 'json',
-					'--engine', 'eslint-lwc',
-					'--category', category
-				])
-				.it('Only correct categories are returned', ctx => {
-					const stdout = ctx.stdout;
-					const output = JSON.parse(stdout.slice(stdout.indexOf('['), stdout.lastIndexOf(']') + 1));
-					expect(output.length).to.equal(1, 'Should only be violations from one file');
-					expect(output[0].engine).to.equal('eslint-lwc');
-					expect(output[0].violations, TestUtils.prettyPrint(output[0].violations)).to.be.lengthOf(expectedViolationCount);
+			const commandOutput = runCommand(`scanner run --target ${pathToDomParserController} --format json --engine eslint-lwc --category ${category}`)
+			const stdout = commandOutput.shellOutput.stdout;
+			const output = JSON.parse(stdout.slice(stdout.indexOf('['), stdout.lastIndexOf(']') + 1));
+			expect(output.length).to.equal(1, 'Should only be violations from one file');
+			expect(output[0].engine).to.equal('eslint-lwc');
+			expect(output[0].violations, TestUtils.prettyPrint(output[0].violations)).to.be.lengthOf(expectedViolationCount);
 
-					// Make sure only violations are returned for the requested category
-					for (const v of output[0].violations) {
-						expect(v.category, TestUtils.prettyPrint(v)).to.equal(category);
-					}
-				});
-
+			// Make sure only violations are returned for the requested category
+			for (const v of output[0].violations) {
+				expect(v.category, TestUtils.prettyPrint(v)).to.equal(category);
+			}
 		});
 
-		describe('Eslint Typescript Engine --category flag', () => {
+		it('Case: --engine eslint-typescript --category problem', () => {
 			const category = 'problem';
+			const target = path.join('test', 'code-fixtures', 'projects', 'ts', 'src', 'simpleYetWrong.ts');
+			const config = path.join('test', 'code-fixtures', 'projects', 'tsconfig.json');
 			const expectedViolationCount = 4;
-			setupCommandTest
-				.command(['scanner:run',
-					'--target', path.join('test', 'code-fixtures', 'projects', 'ts', 'src', 'simpleYetWrong.ts'),
-					'--tsconfig', path.join('test', 'code-fixtures', 'projects', 'tsconfig.json'),
-					'--format', 'json',
-					'--engine', 'eslint-typescript',
-					'--category', category
-				])
-				.it('Only correct categories are returned', ctx => {
-					const stdout = ctx.stdout;
-					const output = JSON.parse(stdout.slice(stdout.indexOf('['), stdout.lastIndexOf(']') + 1));
-					expect(output.length).to.equal(1, 'Should only be violations from one file');
-					expect(output[0].engine).to.equal('eslint-typescript');
-					expect(output[0].violations, TestUtils.prettyPrint(output[0].violations)).to.be.lengthOf(expectedViolationCount);
+			const commandOutput = runCommand(`scanner run --target ${target} --tsconfig ${config} --format json --engine eslint-typescript --category ${category}`);
+			const stdout = commandOutput.shellOutput.stdout;
+			const output = JSON.parse(stdout.slice(stdout.indexOf('['), stdout.lastIndexOf(']') + 1));
+			expect(output.length).to.equal(1, 'Should only be violations from one file');
+			expect(output[0].engine).to.equal('eslint-typescript');
+			expect(output[0].violations, TestUtils.prettyPrint(output[0].violations)).to.be.lengthOf(expectedViolationCount);
 
-					// Make sure only violations are returned for the requested category
-					for (const v of output[0].violations) {
-						expect(v.category, TestUtils.prettyPrint(v)).to.equal(category);
-					}
-				});
+			// Make sure only violations are returned for the requested category
+			for (const v of output[0].violations) {
+				expect(v.category, TestUtils.prettyPrint(v)).to.equal(category);
+			}
 		});
 
-		describe('PMD Engine --category flag', () => {
+		it('Case: --engine pmd --category \'Code Style\'', () => {
 			const category = 'Code Style';
-			setupCommandTest
-				.command(['scanner:run',
-					'--target', path.join('test', 'code-fixtures', 'apex'),
-					'--format', 'json',
-					'--engine', 'pmd',
-					'--category', category
-				])
-				.it('Only correct categories are returned', ctx => {
-					const stdout = ctx.stdout;
-					const output = JSON.parse(stdout.slice(stdout.indexOf('['), stdout.lastIndexOf(']') + 1));
-					expect(output.length).to.equal(1, 'Should only be violations from one file');
-					expect(output[0].engine).to.equal('pmd');
-					expect(output[0].violations, TestUtils.prettyPrint(output[0].violations)).to.be.lengthOf(2);
+			const commandOutput = runCommand(`scanner run --target ${path.join('test', 'code-fixtures', 'apex')} --format json --engine pmd --category '${category}'`);
+			const stdout = commandOutput.shellOutput.stdout;
+			const output = JSON.parse(stdout.slice(stdout.indexOf('['), stdout.lastIndexOf(']') + 1));
+			expect(output.length).to.equal(1, 'Should only be violations from one file');
+			expect(output[0].engine).to.equal('pmd');
+			expect(output[0].violations, TestUtils.prettyPrint(output[0].violations)).to.be.lengthOf(2);
 
-					// Make sure only violations are returned for the requested category
-					for (const v of output[0].violations) {
-						expect(v.category, TestUtils.prettyPrint(v)).to.equal(category);
-					}
-				});
-		});
-	});
-
-	describe('Negated --category', () => {
-		describe('Single --category', () => {
-			const category = '!Code Style';
-			setupCommandTest
-				.command(['scanner:run',
-					'--target', path.join('test', 'code-fixtures', 'apex'),
-					'--format', 'json',
-					'--category', category
-				])
-				.it('Only correct categories are returned', ctx => {
-					const stdout = ctx.stdout;
-					const output = JSON.parse(stdout.slice(stdout.indexOf('['), stdout.lastIndexOf(']') + 1));
-
-					expect(output.length).greaterThan(0);
-					for (const result of output) {
-						for (const violation of result.violations) {
-							expect(violation.category, TestUtils.prettyPrint(violation)).to.not.equal(category);
-						}
-					}
-
-				});
-		});
-
-		describe('Multiple --category', () => {
-			const category = '!Code Style,!Security';
-			const expectedCategories: Set<string> = new Set<string>();
-			expectedCategories.add('Code Style').add('Security');
-			setupCommandTest
-				.command(['scanner:run',
-					'--target', path.join('test', 'code-fixtures', 'apex'),
-					'--format', 'json',
-					'--category', category
-				])
-				.it('Only correct categories are returned', ctx => {
-					const stdout = ctx.stdout;
-					const output = JSON.parse(stdout.slice(stdout.indexOf('['), stdout.lastIndexOf(']') + 1));
-					expect(output.length).greaterThan(0);
-
-					for (const result of output) {
-						for (const violation of result.violations) {
-							expect(expectedCategories.has(violation.category), TestUtils.prettyPrint(violation)).to.be.false;
-						}
-					}
-				});
-		});
-
-		describe('Invalid --category', () => {
-			// Positive and negative categories can't be mixed
-			const category = '!Code Style,Security';
-			setupCommandTest
-				.command(['scanner:run',
-					'--target', path.join('test', 'code-fixtures', 'apex'),
-					'--format', 'json',
-					'--category', category
-				])
-				.it('Positive and Negative Combinations throws an error', ctx => {
-					expect(ctx.stderr).to.contain(exceptionMessages.getMessage('RuleFilter.MixedTypes', ['Category']));
-				});
-		});
-
-		describe('Invalid --engine', () => {
-			// Ruleset doesn't support negation
-			const ruleset = '!some-value';
-			setupCommandTest
-				.command(['scanner:run',
-					'--target', path.join('test', 'code-fixtures', 'apex'),
-					'--format', 'json',
-					'--ruleset', ruleset
-				])
-				.it('Negative filters that are not supported throws an error', ctx => {
-					expect(ctx.stderr).to.contain(exceptionMessages.getMessage('RuleFilter.PositiveOnly', ['Ruleset']));
-				});
+			// Make sure only violations are returned for the requested category
+			for (const v of output[0].violations) {
+				expect(v.category, TestUtils.prettyPrint(v)).to.equal(category);
+			}
 		});
 	});
 });

--- a/test/commands/scanner/run.filters.test.ts
+++ b/test/commands/scanner/run.filters.test.ts
@@ -54,7 +54,7 @@ describe('scanner:run tests that result in the use of RuleFilters', function () 
 			});
 
 			it('Case: Negate multiple categories', () => {
-				const category = `'!Code Style,!Security'`;
+				const category = `!Code Style,!Security`;
 				const nonExpectedCategories: Set<string> = new Set<string>();
 				nonExpectedCategories.add('Code Style').add('Security');
 
@@ -78,7 +78,7 @@ describe('scanner:run tests that result in the use of RuleFilters', function () 
 		});
 
 		it('Case: Mixing positive and negative constraints', () => {
-			const category = `'!Code Style,Security'`;
+			const category = `!Code Style,Security`;
 			const output = runCommand(`scanner run --target ${path.join('test', 'code-fixtures', 'apex')} --format json --category "${category}"`);
 			expect(output.shellOutput.stderr).to.contain(exceptionMessages.getMessage('RuleFilter.MixedTypes', ['Category']), 'Cannot mix positive and negative constraints');
 		});

--- a/test/commands/scanner/run.filters.test.ts
+++ b/test/commands/scanner/run.filters.test.ts
@@ -40,8 +40,8 @@ describe('scanner:run tests that result in the use of RuleFilters', function () 
 
 		describe('Negative constraints', () => {
 			it('Case: Negate one category', () => {
-				const category = '\'!Code Style\'';
-				const output = runCommand(`scanner run --target ${path.join('test', 'code-fixtures', 'apex')} --format json --category ${category}`);
+				const category = 'Code Style';
+				const output = runCommand(`scanner run --target ${path.join('test', 'code-fixtures', 'apex')} --format json --category "!${category}"`);
 				const stdout = output.shellOutput.stdout;
 				const results = JSON.parse(stdout.slice(stdout.indexOf('['), stdout.lastIndexOf(']') + 1));
 
@@ -58,7 +58,7 @@ describe('scanner:run tests that result in the use of RuleFilters', function () 
 				const nonExpectedCategories: Set<string> = new Set<string>();
 				nonExpectedCategories.add('Code Style').add('Security');
 
-				const output = runCommand(`scanner run --target ${path.join('test', 'code-fixtures', 'apex')} --format json --category ${category}`);
+				const output = runCommand(`scanner run --target ${path.join('test', 'code-fixtures', 'apex')} --format json --category "${category}"`);
 				const stdout = output.shellOutput.stdout;
 				const results = JSON.parse(stdout.slice(stdout.indexOf('['), stdout.lastIndexOf(']') + 1));
 				expect(results.length).greaterThan(0);
@@ -79,7 +79,7 @@ describe('scanner:run tests that result in the use of RuleFilters', function () 
 
 		it('Case: Mixing positive and negative constraints', () => {
 			const category = `'!Code Style,Security'`;
-			const output = runCommand(`scanner run --target ${path.join('test', 'code-fixtures', 'apex')} --format json --category ${category}`);
+			const output = runCommand(`scanner run --target ${path.join('test', 'code-fixtures', 'apex')} --format json --category "${category}"`);
 			expect(output.shellOutput.stderr).to.contain(exceptionMessages.getMessage('RuleFilter.MixedTypes', ['Category']), 'Cannot mix positive and negative constraints');
 		});
 	});
@@ -138,7 +138,7 @@ describe('scanner:run tests that result in the use of RuleFilters', function () 
 
 		it('Case: --engine pmd --category \'Code Style\'', () => {
 			const category = 'Code Style';
-			const commandOutput = runCommand(`scanner run --target ${path.join('test', 'code-fixtures', 'apex')} --format json --engine pmd --category '${category}'`);
+			const commandOutput = runCommand(`scanner run --target ${path.join('test', 'code-fixtures', 'apex')} --format json --engine pmd --category "${category}"`);
 			const stdout = commandOutput.shellOutput.stdout;
 			const output = JSON.parse(stdout.slice(stdout.indexOf('['), stdout.lastIndexOf(']') + 1));
 			expect(output.length).to.equal(1, 'Should only be violations from one file');

--- a/test/commands/scanner/run.severity.test.ts
+++ b/test/commands/scanner/run.severity.test.ts
@@ -1,5 +1,6 @@
 import {expect} from '@salesforce/command/lib/test';
-import {setupCommandTest} from '../../TestUtils';
+// @ts-ignore
+import {runCommand} from '../../TestUtils';
 import {Messages} from '@salesforce/core';
 import path = require('path');
 
@@ -12,133 +13,94 @@ describe('scanner:run', function () {
 	describe('E2E', () => {
 
 		describe('--severity-threshold flag', () => {
-
-			setupCommandTest
-				.command(['scanner:run',
-					'--target', path.join('test', 'code-fixtures', 'apex', 'YetAnotherTestClass.cls'),
-					'--format', 'json',
-					'--severity-threshold', '3'
-				])
-				.it('When no violations are found, no error is thrown', ctx => {
-					expect(ctx.stdout).to.contain(processorMessages.getMessage('output.noViolationsDetected', ['pmd, retire-js']));
-					expect(ctx.stderr).to.not.contain(processorMessages.getMessage('output.sevThresholdSummary', ['3']), 'Error should not be present');
+			describe('Flag functionality', () => {
+				it('When no violations are found, no error is thrown', () => {
+					const output = runCommand(`scanner run --target ${path.join('test', 'code-fixtures', 'apex', 'YetAnotherTestClass.cls')} --format json --severity-threshold 3`);
+					expect(output.shellOutput.stdout).to.contain(processorMessages.getMessage('output.noViolationsDetected', ['pmd, retire-js']));
+					expect(output.shellOutput.stderr).to.not.contain(processorMessages.getMessage('output.sevThresholdSummary', ['3']), 'Error should not be present');
 				});
 
-			setupCommandTest
-				.command(['scanner:run',
-					'--target', path.join('test', 'code-fixtures', 'apex', 'SomeTestClass.cls'),
-					'--format', 'json',
-					'--severity-threshold', '1'
-				])
-				.it('When no violations are found equal to or greater than flag value, no error is thrown', ctx => {
+				it('When no violations exceed the flag value, no error is thrown', () => {
+					const commandOutput = runCommand(`scanner run --target ${path.join('test', 'code-fixtures', 'apex', 'SomeTestClass.cls')} --format json --severity-threshold 1`);
 
-                    const output = JSON.parse(ctx.stdout);
-                    // check that test file still has severities of 3
-                    for (let i=0; i<output.length; i++) {
-                        for (let j=0; j<output[i].violations.length; j++) {
-                            expect(output[i].violations[j].normalizedSeverity).to.equal(3);
-                        }
-                    }
+					const output = JSON.parse(commandOutput.shellOutput.stdout);
+					// check that test file still has severities of 3
+					for (let i = 0; i < output.length; i++) {
+						for (let j = 0; j < output[i].violations.length; j++) {
+							expect(output[i].violations[j].normalizedSeverity).to.equal(3);
+						}
+					}
 
-                    expect(ctx.stderr).not.to.contain(processorMessages.getMessage('output.sevThresholdSummary', ['1']));
-
+					expect(commandOutput.shellOutput.stderr).not.to.contain(processorMessages.getMessage('output.sevThresholdSummary', ['1']));
 				});
 
-			setupCommandTest
-				.command(['scanner:run',
-					'--target', path.join('test', 'code-fixtures', 'apex', 'SomeTestClass.cls'),
-					'--format', 'json',
-					'--severity-threshold', '3'
-				])
-				.it('When violations are found equal to or greater than flag value, an error is thrown', ctx => {
+				it('When flag value is exceeded, an error is thrown', () => {
+					const commandOutput = runCommand(`scanner run --target ${path.join('test', 'code-fixtures', 'apex', 'SomeTestClass.cls')} --format json --severity-threshold 3`);
+					const output = JSON.parse(commandOutput.shellOutput.stdout);
+					// check that test file still has severities of 3
+					for (let i = 0; i < output.length; i++) {
+						for (let j = 0; j < output[i].violations.length; j++) {
+							expect(output[i].violations[j].normalizedSeverity).to.equal(3);
+						}
+					}
+					expect(commandOutput.shellOutput.stderr).to.contain(processorMessages.getMessage('output.sevThresholdSummary', ['3']));
+				});
+			});
 
-                    const output = JSON.parse(ctx.stdout);
-                    // check that test file still has severities of 3
-                    for (let i=0; i<output.length; i++) {
-                        for (let j=0; j<output[i].violations.length; j++) {
-                            expect(output[i].violations[j].normalizedSeverity).to.equal(3);
-                        }
-                    }
-                    expect(ctx.stderr).to.contain(processorMessages.getMessage('output.sevThresholdSummary', ['3']));
-
+			describe('Input validation', () => {
+				it('Input cannot be less than 1', () => {
+					const commandOutput = runCommand(`scanner run --target ${path.join('test', 'code-fixtures', 'apex', 'SomeTestClass.cls')} --format json --severity-threshold -1`);
+					expect(commandOutput.shellOutput.stderr).to.contain('Expected integer greater than or equal to 1 but received -1');
 				});
 
-			setupCommandTest
-                .command(['scanner:run',
-                    '--target', path.join('test', 'code-fixtures', 'apex', 'SomeTestClass.cls'),
-                    '--format', 'json',
-                    '--severity-threshold', '-1'
-                ])
-                .it('Ensure values below the min for severity-threshold cause an error', ctx => {
-                    expect(ctx.stderr).to.contain('Expected integer greater than or equal to 1 but received -1');
-                });
-
-            setupCommandTest
-                .command(['scanner:run',
-                    '--target', path.join('test', 'code-fixtures', 'apex', 'SomeTestClass.cls'),
-                    '--format', 'json',
-                    '--severity-threshold', '5'
-                ])
-                .it('Ensure values above the max for severity-threshold cause an error', ctx => {
-                    expect(ctx.stderr).to.contain('Expected integer less than or equal to 3 but received 5');
-                });
-
+				it('Input cannot be greater than 3', () => {
+					const commandOutput = runCommand(`scanner run --target ${path.join('test', 'code-fixtures', 'apex', 'SomeTestClass.cls')} --format json --severity-threshold 5`);
+					expect(commandOutput.shellOutput.stderr).to.contain('Expected integer less than or equal to 3 but received 5');
+				});
+			});
 		});
 
 		describe('--normalize-severity flag', () => {
 
-			setupCommandTest
-				.timeout(15000)
-				.command(['scanner:run',
-					'--target', path.join('test', 'code-fixtures'),
-					'--format', 'json',
-					'--normalize-severity'
-				])
-				.it('Ensure normalized severity is correct', ctx => {
-					const output = JSON.parse(ctx.stdout);
-
-					for (let i=0; i<output.length; i++) {
-                        for (let j=0; j<output[i].violations.length; j++) {
-							if (output[i].engine.includes("pmd")){
-								if (output[i].violations[j].severity == 1) {
-									expect(output[i].violations[j].normalizedSeverity).to.equal(1);
-								} else if (output[i].violations[j].severity == 2) {
-									expect(output[i].violations[j].normalizedSeverity).to.equal(2);
-								} else if (output[i].violations[j].severity == 3) {
-									expect(output[i].violations[j].normalizedSeverity).to.equal(3);
-								} else if (output[i].violations[j].severity == 4) {
-									expect(output[i].violations[j].normalizedSeverity).to.equal(3);
-								} else if (output[i].violations[j].severity == 5) {
-									expect(output[i].violations[j].normalizedSeverity).to.equal(3);
-								}
-							} else if (output[i].engine.includes("eslint")) {
-								if (output[i].violations[j].severity == 1) {
-									expect(output[i].violations[j].normalizedSeverity).to.equal(2);
-								} else if (output[i].violations[j].severity == 2) {
-									expect(output[i].violations[j].normalizedSeverity).to.equal(1);
-								}
+			it('Normalized severities are correct', () => {
+				const commandOutput = runCommand(`scanner run --target ${path.join('test', 'code-fixtures')} --format json --normalize-severity`);
+				const output = JSON.parse(commandOutput.shellOutput.stdout);
+				for (let i=0; i<output.length; i++) {
+					for (let j=0; j<output[i].violations.length; j++) {
+						if (output[i].engine.includes("pmd")){
+							if (output[i].violations[j].severity == 1) {
+								expect(output[i].violations[j].normalizedSeverity).to.equal(1);
+							} else if (output[i].violations[j].severity == 2) {
+								expect(output[i].violations[j].normalizedSeverity).to.equal(2);
+							} else if (output[i].violations[j].severity == 3) {
+								expect(output[i].violations[j].normalizedSeverity).to.equal(3);
+							} else if (output[i].violations[j].severity == 4) {
+								expect(output[i].violations[j].normalizedSeverity).to.equal(3);
+							} else if (output[i].violations[j].severity == 5) {
+								expect(output[i].violations[j].normalizedSeverity).to.equal(3);
 							}
+						} else if (output[i].engine.includes("eslint")) {
+							if (output[i].violations[j].severity == 1) {
+								expect(output[i].violations[j].normalizedSeverity).to.equal(2);
+							} else if (output[i].violations[j].severity == 2) {
+								expect(output[i].violations[j].normalizedSeverity).to.equal(1);
+							}
+						}
 
-                        }
-                    }
-				});
+					}
+				}
+			});
 
-			setupCommandTest
-				.timeout(15000)
-				.command(['scanner:run',
-					'--target', path.join('test', 'code-fixtures'),
-					'--format', 'json'
-				])
-				.it('Ensure normalized severity is not outputted when --normalize-severity not provided', ctx => {
-					const output = JSON.parse(ctx.stdout);
+			it('Omitting --normalize-severity yields non-normalized severities', () => {
+				const commandOutput = runCommand(`scanner run --target ${path.join('test', 'code-fixtures')} --format json`);
+				const output = JSON.parse(commandOutput.shellOutput.stdout);
 
-					for (let i=0; i<output.length; i++) {
-                        for (let j=0; j<output[i].violations.length; j++) {
-							expect(output[i].violations[j].normalizedSeverity).to.equal(undefined);
-                        }
-                    }
-				});
-
+				for (let i=0; i<output.length; i++) {
+					for (let j=0; j<output[i].violations.length; j++) {
+						expect(output[i].violations[j].normalizedSeverity).to.equal(undefined);
+					}
+				}
+			});
 		});
 
 	});

--- a/yarn.lock
+++ b/yarn.lock
@@ -898,6 +898,21 @@
     mv "~2"
     safe-json-stringify "~1"
 
+"@salesforce/cli-plugins-testkit@^4.4.10":
+  version "4.4.10"
+  resolved "https://registry.yarnpkg.com/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-4.4.10.tgz#d71f1688c8455acb5eb6b9553beb4d52b08ba7b6"
+  integrity sha512-qFC/U49CNostlj9AGwEODCGmmXo+lF5Uqrp0y0l1yRmgDriti8oz01/CBtgww6Fx/HTRKmo4EO6bGsSBXqZpuw==
+  dependencies:
+    "@salesforce/core" "^5.3.10"
+    "@salesforce/kit" "^3.0.13"
+    "@salesforce/ts-types" "^2.0.6"
+    "@types/shelljs" "^0.8.14"
+    debug "^4.3.1"
+    jszip "^3.10.1"
+    shelljs "^0.8.4"
+    strip-ansi "6.0.1"
+    ts-retry-promise "^0.7.1"
+
 "@salesforce/command@^5":
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/@salesforce/command/-/command-5.3.2.tgz#b91c3e81effe5720a7aa80fa62c01ebcc68ff12f"
@@ -933,6 +948,30 @@
     jsonwebtoken "9.0.0"
     ts-retry-promise "^0.7.0"
 
+"@salesforce/core@^5.3.10":
+  version "5.3.12"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-5.3.12.tgz#0ff38307b39d9abb8aedaa575ecd6d037bc8eee1"
+  integrity sha512-A2oOBiGvZRxcdUcz8oA1B0l2nQZApmBQnbUUrsH18isgb9seQLTGuV6YelY4rLZbGsfcp3rzbERMGrHas+OuXQ==
+  dependencies:
+    "@salesforce/kit" "^3.0.14"
+    "@salesforce/schemas" "^1.6.0"
+    "@salesforce/ts-types" "^2.0.8"
+    "@types/semver" "^7.5.3"
+    ajv "^8.12.0"
+    change-case "^4.1.2"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    js2xmlparser "^4.0.1"
+    jsforce "^2.0.0-beta.28"
+    jsonwebtoken "9.0.2"
+    jszip "3.10.1"
+    pino "^8.16.0"
+    pino-abstract-transport "^1.0.0"
+    pino-pretty "^10.2.3"
+    proper-lockfile "^4.1.2"
+    semver "^7.5.4"
+    ts-retry-promise "^0.7.1"
+
 "@salesforce/dev-config@^3":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@salesforce/dev-config/-/dev-config-3.1.0.tgz#8eb5b35860ff60d1c1dc3fd9329b01a28475d5b9"
@@ -962,10 +1001,23 @@
     shx "^0.3.3"
     tslib "^2.5.0"
 
+"@salesforce/kit@^3.0.13", "@salesforce/kit@^3.0.14":
+  version "3.0.15"
+  resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-3.0.15.tgz#713df3f5767f874c70a2e731c7cb5ba677989559"
+  integrity sha512-XkA8jsuLvVnyP460dAbU3pBFP2IkmmmsVxMQVifcKKbNWaIBbZBzAfj+vdaQfnvZyflLhsrFT3q2xkb0vHouPg==
+  dependencies:
+    "@salesforce/ts-types" "^2.0.9"
+    tslib "^2.6.2"
+
 "@salesforce/schemas@^1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.5.0.tgz#8bfe2cb5d7cb29d3394b3b9cfb71bb527009c82c"
   integrity sha512-EKFBURBuON7cj8XZCW+ybeSRRw7wUP1XUXZVHzFgx8KiYmSeGiRHBYbDjQOsQMho2uOLsTozMPEt2ehYnji0YA==
+
+"@salesforce/schemas@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.6.0.tgz#14505ebad2fb2d4f7b14837545d662766d293561"
+  integrity sha512-SwhDTLucj/GRbPpxlEoDZeqlX22o+G6fiebTXTu1cZKmd1oE0W2L7SlTTgJnWck8bhTeBIgQi9cpD8c2t5ISKA==
 
 "@salesforce/ts-sinon@^1.1.2":
   version "1.4.6"
@@ -982,6 +1034,13 @@
   integrity sha512-jpmekGqZ7tpHRJwf1rF0yBJ/IMC5mOrryNi4HZkKuNQn8RF97WpynmL8Om04mLTCESvCiif3y7NWfIcxtID2Gw==
   dependencies:
     tslib "^2.5.0"
+
+"@salesforce/ts-types@^2.0.6", "@salesforce/ts-types@^2.0.8", "@salesforce/ts-types@^2.0.9":
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/@salesforce/ts-types/-/ts-types-2.0.9.tgz#66bff7b41720065d6b01631b6f6a3ccca02857c5"
+  integrity sha512-boUD9jw5vQpTCPCCmK/NFTWjSuuW+lsaxOynkyNXLW+zxOc4GDjhtKc4j0vWZJQvolpafbyS8ZLFHZJvs12gYA==
+  dependencies:
+    tslib "^2.6.2"
 
 "@sigstore/bundle@^1.1.0":
   version "1.1.0"
@@ -1180,6 +1239,14 @@
   resolved "https://registry.yarnpkg.com/@types/expect/-/expect-1.20.4.tgz#8288e51737bf7e3ab5d7c77bfa695883745264e5"
   integrity sha512-Q5Vn3yjTDyCMV50TB6VRIbQNxSE4OmZR86VSbGaNpfUolm0iePBB4KdEEHmxoY5sT2+2DIvXW0rvMDP2nHZ4Mg==
 
+"@types/glob@~7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
+  integrity sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==
+  dependencies:
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
 "@types/graceful-fs@^4.1.6":
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.6.tgz#e14b2576a1c25026b7f02ede1de3b84c3a1efeae"
@@ -1223,6 +1290,11 @@
   version "4.14.191"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.191.tgz#09511e7f7cba275acd8b419ddac8da9a6a79e2fa"
   integrity sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==
+
+"@types/minimatch@*":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
+  integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
 "@types/minimatch@^3.0.3":
   version "3.0.5"
@@ -1291,10 +1363,18 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
   integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
 
-"@types/semver@^7.5.0":
+"@types/semver@^7.5.0", "@types/semver@^7.5.3":
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.4.tgz#0a41252ad431c473158b22f9bfb9a63df7541cff"
   integrity sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==
+
+"@types/shelljs@^0.8.14":
+  version "0.8.14"
+  resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.8.14.tgz#87b8817b2397ffe97b86a4d844036ee0d2a1f0ca"
+  integrity sha512-eqKaGPi60riuxI9pUVeCT02EGo94Y6HT119h7w5bXSELsis6+JqzdEy6H/w2xXl881wcN3VDnb/D0WlgSety5w==
+  dependencies:
+    "@types/glob" "~7.2.0"
+    "@types/node" "*"
 
 "@types/sinon@*":
   version "10.0.13"
@@ -1511,7 +1591,7 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
-ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4, ajv@^8.11.2:
+ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4, ajv@^8.11.2, ajv@^8.12.0:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -1758,6 +1838,11 @@ at-least-node@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
+
+atomic-sleep@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/atomic-sleep/-/atomic-sleep-1.0.0.tgz#eb85b77a601fc932cfe432c5acd364a9e2c9075b"
+  integrity sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==
 
 available-typed-arrays@^1.0.5:
   version "1.0.5"
@@ -2288,6 +2373,11 @@ color-support@^1.1.2, color-support@^1.1.3:
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
 
+colorette@^2.0.7:
+  version "2.0.20"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
+  integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
+
 colors@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
@@ -2461,7 +2551,7 @@ data-uri-to-buffer@3:
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz#594b8973938c5bc2c33046535785341abc4f3636"
   integrity sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==
 
-dateformat@^4.5.0:
+dateformat@^4.5.0, dateformat@^4.6.3:
   version "4.6.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.6.3.tgz#556fa6497e5217fedb78821424f8a1c22fa3f4b5"
   integrity sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==
@@ -2476,7 +2566,7 @@ dayjs@^1.8.16:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.7.tgz#4b296922642f70999544d1144a2c25730fce63e2"
   integrity sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==
 
-debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -3078,6 +3168,11 @@ fancy-test@^2.0.12:
     nock "^13.3.0"
     stdout-stderr "^0.1.9"
 
+fast-copy@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-3.0.1.tgz#9e89ef498b8c04c1cd76b33b8e14271658a732aa"
+  integrity sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA==
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -3110,6 +3205,16 @@ fast-levenshtein@^3.0.0:
   integrity sha512-hKKNajm46uNmTlhHSyZkmToAc56uZJwYq7yrciZjqOxnlfQwERDQJmHPUp7m1m9wx8vgOe8IaCKZ5Kv2k1DdCQ==
   dependencies:
     fastest-levenshtein "^1.0.7"
+
+fast-redact@^3.1.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-3.3.0.tgz#7c83ce3a7be4898241a46560d51de10f653f7634"
+  integrity sha512-6T5V1QK1u4oF+ATxs1lWUmlEk6P2T9HqJG3e2DnHOdVgZy2rFJBoEnrIedcTXlkAHU/zKC+7KETJ+KGGKwxgMQ==
+
+fast-safe-stringify@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
+  integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
 
 fastest-levenshtein@^1.0.7:
   version "1.0.16"
@@ -3516,7 +3621,7 @@ glob@^7.0.0, glob@^7.1.1, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^8.0.1:
+glob@^8.0.0, glob@^8.0.1:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
   integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
@@ -3587,7 +3692,7 @@ graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0,
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
-graceful-fs@^4.1.5, graceful-fs@^4.2.6:
+graceful-fs@^4.1.5, graceful-fs@^4.2.4, graceful-fs@^4.2.6:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -3678,6 +3783,14 @@ header-case@^2.0.4:
   dependencies:
     capital-case "^1.0.4"
     tslib "^2.0.3"
+
+help-me@^4.0.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/help-me/-/help-me-4.2.0.tgz#50712bfd799ff1854ae1d312c36eafcea85b0563"
+  integrity sha512-TAOnTB8Tz5Dw8penUuzHVrKNKlCIbwwbHnXraNJxPwf8LRtE2HlM84RYuezMFcwOJmoYOCWVDyJ8TQGxn9PgxA==
+  dependencies:
+    glob "^8.0.0"
+    readable-stream "^3.6.0"
 
 hosted-git-info@^2.1.4, hosted-git-info@^3.0.8, hosted-git-info@^4.0.1, hosted-git-info@^6.0.0:
   version "3.0.8"
@@ -3822,6 +3935,11 @@ ignore@^5.2.0:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
+
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==
 
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
@@ -4281,6 +4399,11 @@ jmespath@0.16.0:
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.16.0.tgz#b15b0a85dfd4d930d43e69ed605943c802785076"
   integrity sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==
 
+joycon@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/joycon/-/joycon-3.1.1.tgz#bce8596d6ae808f8b68168f5fc69280996894f03"
+  integrity sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==
+
 js-sdsl@^4.1.4:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.3.0.tgz#aeefe32a451f7af88425b11fdb5f58c90ae1d711"
@@ -4343,6 +4466,32 @@ jsforce@^2.0.0-beta.19:
     regenerator-runtime "^0.13.3"
     strip-ansi "^6.0.0"
     xml2js "^0.4.22"
+
+jsforce@^2.0.0-beta.28:
+  version "2.0.0-beta.28"
+  resolved "https://registry.yarnpkg.com/jsforce/-/jsforce-2.0.0-beta.28.tgz#5fd8d9b8e5efc798698793b147e00371f3d74e8f"
+  integrity sha512-tTmKRhr4yWNinhmurY/tiiltLFQq9RQ+gpYAt3wjFdCGjzd49/wqYQIFw4SsI3+iLjxXnc0uTgGwdAkDjxDWnA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@babel/runtime-corejs3" "^7.12.5"
+    "@types/node" "^12.19.9"
+    abort-controller "^3.0.0"
+    base64url "^3.0.1"
+    commander "^4.0.1"
+    core-js "^3.6.4"
+    csv-parse "^4.8.2"
+    csv-stringify "^5.3.4"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    fs-extra "^8.1.0"
+    https-proxy-agent "^5.0.0"
+    inquirer "^7.0.0"
+    multistream "^3.1.0"
+    node-fetch "^2.6.1"
+    open "^7.0.0"
+    regenerator-runtime "^0.13.3"
+    strip-ansi "^6.0.0"
+    xml2js "^0.5.0"
 
 json-buffer@3.0.1:
   version "3.0.1"
@@ -4427,6 +4576,32 @@ jsonwebtoken@9.0.0:
     ms "^2.1.1"
     semver "^7.3.8"
 
+jsonwebtoken@9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz#65ff91f4abef1784697d40952bb1998c504caaf3"
+  integrity sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==
+  dependencies:
+    jws "^3.2.2"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^7.5.4"
+
+jszip@3.10.1, jszip@^3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.1.tgz#34aee70eb18ea1faec2f589208a157d1feb091c2"
+  integrity sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==
+  dependencies:
+    lie "~3.3.0"
+    pako "~1.0.2"
+    readable-stream "~2.3.6"
+    setimmediate "^1.0.5"
+
 just-diff-apply@^5.2.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/just-diff-apply/-/just-diff-apply-5.5.0.tgz#771c2ca9fa69f3d2b54e7c3f5c1dfcbcc47f9f0f"
@@ -4489,6 +4664,13 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lie@~3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
+  integrity sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
+  dependencies:
+    immediate "~3.0.5"
+
 lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
@@ -4548,15 +4730,45 @@ lodash.get@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
 
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==
+
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
   integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
 
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
 
 lodash.template@^4.5.0:
   version "4.5.0"
@@ -5509,6 +5721,11 @@ oclif@^4.0.3:
     yeoman-environment "^3.15.1"
     yeoman-generator "^5.8.0"
 
+on-exit-leak-free@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz#fed195c9ebddb7d9e4c3842f93f281ac8dadd3b8"
+  integrity sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==
+
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -5738,6 +5955,11 @@ pacote@^15.2.0:
     ssri "^10.0.0"
     tar "^6.1.11"
 
+pako@~1.0.2:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
+
 param-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/param-case/-/param-case-3.0.4.tgz#7d17fe4aa12bde34d4a77d91acfb6219caad01c5"
@@ -5874,6 +6096,56 @@ pify@^4.0.1:
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
+pino-abstract-transport@^1.0.0, pino-abstract-transport@v1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pino-abstract-transport/-/pino-abstract-transport-1.1.0.tgz#083d98f966262164504afb989bccd05f665937a8"
+  integrity sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==
+  dependencies:
+    readable-stream "^4.0.0"
+    split2 "^4.0.0"
+
+pino-pretty@^10.2.3:
+  version "10.2.3"
+  resolved "https://registry.yarnpkg.com/pino-pretty/-/pino-pretty-10.2.3.tgz#db539c796a1421fd4d130734fa994f5a26027783"
+  integrity sha512-4jfIUc8TC1GPUfDyMSlW1STeORqkoxec71yhxIpLDQapUu8WOuoz2TTCoidrIssyz78LZC69whBMPIKCMbi3cw==
+  dependencies:
+    colorette "^2.0.7"
+    dateformat "^4.6.3"
+    fast-copy "^3.0.0"
+    fast-safe-stringify "^2.1.1"
+    help-me "^4.0.1"
+    joycon "^3.1.1"
+    minimist "^1.2.6"
+    on-exit-leak-free "^2.1.0"
+    pino-abstract-transport "^1.0.0"
+    pump "^3.0.0"
+    readable-stream "^4.0.0"
+    secure-json-parse "^2.4.0"
+    sonic-boom "^3.0.0"
+    strip-json-comments "^3.1.1"
+
+pino-std-serializers@^6.0.0:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz#d9a9b5f2b9a402486a5fc4db0a737570a860aab3"
+  integrity sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==
+
+pino@^8.16.0:
+  version "8.16.1"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-8.16.1.tgz#dcaf82764b1a27f24101317cdd6453e96290f1d9"
+  integrity sha512-3bKsVhBmgPjGV9pyn4fO/8RtoVDR8ssW1ev819FsRXlRNgW8gR/9Kx+gCK4UPWd4JjrRDLWpzd/pb1AyWm3MGA==
+  dependencies:
+    atomic-sleep "^1.0.0"
+    fast-redact "^3.1.1"
+    on-exit-leak-free "^2.1.0"
+    pino-abstract-transport v1.1.0
+    pino-std-serializers "^6.0.0"
+    process-warning "^2.0.0"
+    quick-format-unescaped "^4.0.3"
+    real-require "^0.2.0"
+    safe-stable-stringify "^2.3.1"
+    sonic-boom "^3.7.0"
+    thread-stream "^2.0.0"
+
 pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
@@ -5928,6 +6200,11 @@ process-on-spawn@^1.0.0:
   dependencies:
     fromentries "^1.2.0"
 
+process-warning@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/process-warning/-/process-warning-2.2.0.tgz#008ec76b579820a8e5c35d81960525ca64feb626"
+  integrity sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg==
+
 process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
@@ -5960,6 +6237,15 @@ propagate@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
   integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
+
+proper-lockfile@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/proper-lockfile/-/proper-lockfile-4.1.2.tgz#c8b9de2af6b2f1601067f98e01ac66baa223141f"
+  integrity sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==
+  dependencies:
+    graceful-fs "^4.2.4"
+    retry "^0.12.0"
+    signal-exit "^3.0.2"
 
 proxy-agent@^5.0.0:
   version "5.0.0"
@@ -6017,6 +6303,11 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+quick-format-unescaped@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz#93ef6dd8d3453cbc7970dd614fad4c5954d6b5a7"
+  integrity sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==
 
 quick-lru@^5.1.1:
   version "5.1.1"
@@ -6124,7 +6415,7 @@ readable-stream@1.1.x:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.3.5:
+readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.3.5, readable-stream@~2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
   integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
@@ -6146,7 +6437,7 @@ readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-readable-stream@^4.3.0:
+readable-stream@^4.0.0, readable-stream@^4.3.0:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-4.4.2.tgz#e6aced27ad3b9d726d8308515b9a1b98dc1b9d13"
   integrity sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==
@@ -6180,6 +6471,11 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+real-require@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/real-require/-/real-require-0.2.0.tgz#209632dea1810be2ae063a6ac084fee7e33fba78"
+  integrity sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==
 
 rechoir@^0.6.2:
   version "0.6.2"
@@ -6381,6 +6677,11 @@ safe-regex-test@^1.0.0:
     get-intrinsic "^1.1.3"
     is-regex "^1.1.4"
 
+safe-stable-stringify@^2.3.1:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz#138c84b6f6edb3db5f8ef3ef7115b8f55ccbf886"
+  integrity sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==
+
 "safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
@@ -6405,6 +6706,11 @@ scoped-regex@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/scoped-regex/-/scoped-regex-2.1.0.tgz#7b9be845d81fd9d21d1ec97c61a0b7cf86d2015f"
   integrity sha512-g3WxHrqSWCZHGHlSrF51VXFdjImhwvH8ZO/pryFH56Qi0cDsZfylQa/t0jCzVQFNbNvM00HfHjkDPEuarKDSWQ==
+
+secure-json-parse@^2.4.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/secure-json-parse/-/secure-json-parse-2.7.0.tgz#5a5f9cd6ae47df23dba3151edd06855d47e09862"
+  integrity sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==
 
 "semver@2 || 3 || 4 || 5", semver@^5.5.0:
   version "5.7.1"
@@ -6456,6 +6762,11 @@ set-blocking@^2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
 
+setimmediate@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+  integrity sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==
+
 setprototypeof@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
@@ -6485,7 +6796,7 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shelljs@^0.8.5:
+shelljs@^0.8.4, shelljs@^0.8.5:
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
   integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
@@ -6624,6 +6935,13 @@ socks@^2.3.3, socks@^2.6.2:
     ip "^2.0.0"
     smart-buffer "^4.2.0"
 
+sonic-boom@^3.0.0, sonic-boom@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-3.7.0.tgz#b4b7b8049a912986f4a92c51d4660b721b11f2f2"
+  integrity sha512-IudtNvSqA/ObjN97tfgNmOKyDOs4dNcg4cUUsHDebqsgb8wGBBwb31LIgShNO8fye0dFI52X1+tFoKKI6Rq1Gg==
+  dependencies:
+    atomic-sleep "^1.0.0"
+
 sort-keys@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-4.2.0.tgz#6b7638cee42c506fff8c1cecde7376d21315be18"
@@ -6673,6 +6991,11 @@ spdx-license-ids@^3.0.0:
   version "3.0.12"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz#69077835abe2710b65f03969898b6637b505a779"
   integrity sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==
+
+split2@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/split2/-/split2-4.2.0.tgz#c9c5920904d148bab0b9f67145f245a86aadbfa4"
+  integrity sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -6768,7 +7091,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -6900,6 +7223,13 @@ textextensions@^5.12.0, textextensions@^5.13.0:
   resolved "https://registry.yarnpkg.com/textextensions/-/textextensions-5.16.0.tgz#57dd60c305019bba321e848b1fdf0f99bfa59ec1"
   integrity sha512-7D/r3s6uPZyU//MCYrX6I14nzauDwJ5CxazouuRGNuvSCihW87ufN6VLoROLCrHg6FblLuJrT6N2BVaPVzqElw==
 
+thread-stream@^2.0.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/thread-stream/-/thread-stream-2.4.1.tgz#6d588b14f0546e59d3f306614f044bc01ce43351"
+  integrity sha512-d/Ex2iWd1whipbT681JmTINKw0ZwOUBZm7+Gjs64DHuX34mmw8vJL2bFAaNacaW72zYiTJxSHi5abUuOi5nsfg==
+  dependencies:
+    real-require "^0.2.0"
+
 through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
@@ -6997,6 +7327,11 @@ ts-retry-promise@^0.7.0:
   resolved "https://registry.yarnpkg.com/ts-retry-promise/-/ts-retry-promise-0.7.0.tgz#08f2dcbbf5d2981495841cb63389a268324e8147"
   integrity sha512-x6yWZXC4BfXy4UyMweOFvbS1yJ/Y5biSz/mEPiILtJZLrqD3ZxIpzVOGGgifHHdaSe3WxzFRtsRbychI6zofOg==
 
+ts-retry-promise@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/ts-retry-promise/-/ts-retry-promise-0.7.1.tgz#176d6eee6415f07b6c7c286d3657355e284a6906"
+  integrity sha512-NhHOCZ2AQORvH42hOPO5UZxShlcuiRtm7P2jIq2L2RY3PBxw2mLnUsEdHrIslVBFya1v5aZmrR55lWkzo13LrQ==
+
 tsconfig-paths@^3.14.1:
   version "3.14.2"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz#6e32f1f79412decd261f92d633a9dc1cfa99f088"
@@ -7017,7 +7352,7 @@ tslib@^2, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.4.1, tslib@^2.5.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
-tslib@^2.1.0:
+tslib@^2.1.0, tslib@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
@@ -7541,7 +7876,7 @@ xml-js@^1.6.11:
   dependencies:
     sax "^1.2.4"
 
-xml2js@0.5.0:
+xml2js@0.5.0, xml2js@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.5.0.tgz#d9440631fbb2ed800203fad106f2724f62c493b7"
   integrity sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -898,15 +898,15 @@
     mv "~2"
     safe-json-stringify "~1"
 
-"@salesforce/cli-plugins-testkit@^4.4.10":
-  version "4.4.10"
-  resolved "https://registry.yarnpkg.com/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-4.4.10.tgz#d71f1688c8455acb5eb6b9553beb4d52b08ba7b6"
-  integrity sha512-qFC/U49CNostlj9AGwEODCGmmXo+lF5Uqrp0y0l1yRmgDriti8oz01/CBtgww6Fx/HTRKmo4EO6bGsSBXqZpuw==
+"@salesforce/cli-plugins-testkit@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-5.0.4.tgz#523c459f43822d7b24bff5117aeda7f77ed5e26c"
+  integrity sha512-8pquViVBCd5sF6nBXgLgwymEBE6pSAS376R9qq7rxuV+PSFCC5bnzQaKm2ugY+s5vXKNcV6WcmBHNCQnGv+M7Q==
   dependencies:
-    "@salesforce/core" "^5.3.10"
-    "@salesforce/kit" "^3.0.13"
+    "@salesforce/core" "^5.3.20"
+    "@salesforce/kit" "^3.0.15"
     "@salesforce/ts-types" "^2.0.6"
-    "@types/shelljs" "^0.8.14"
+    "@types/shelljs" "^0.8.15"
     debug "^4.3.1"
     jszip "^3.10.1"
     shelljs "^0.8.4"
@@ -948,15 +948,15 @@
     jsonwebtoken "9.0.0"
     ts-retry-promise "^0.7.0"
 
-"@salesforce/core@^5.3.10":
-  version "5.3.12"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-5.3.12.tgz#0ff38307b39d9abb8aedaa575ecd6d037bc8eee1"
-  integrity sha512-A2oOBiGvZRxcdUcz8oA1B0l2nQZApmBQnbUUrsH18isgb9seQLTGuV6YelY4rLZbGsfcp3rzbERMGrHas+OuXQ==
+"@salesforce/core@^5.3.20":
+  version "5.3.20"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-5.3.20.tgz#4e934d4551bb70423cb1c4115615bc41cffca41e"
+  integrity sha512-y+O6O2c8OYFDrAy2qsG+pAcNxoyL14nmBXcBRRcYA7Huj8ikK+aLJK84PuVAYdQz+hNwImQF+69IWtDkpK4Irg==
   dependencies:
-    "@salesforce/kit" "^3.0.14"
-    "@salesforce/schemas" "^1.6.0"
-    "@salesforce/ts-types" "^2.0.8"
-    "@types/semver" "^7.5.3"
+    "@salesforce/kit" "^3.0.15"
+    "@salesforce/schemas" "^1.6.1"
+    "@salesforce/ts-types" "^2.0.9"
+    "@types/semver" "^7.5.4"
     ajv "^8.12.0"
     change-case "^4.1.2"
     faye "^1.4.0"
@@ -1001,7 +1001,7 @@
     shx "^0.3.3"
     tslib "^2.5.0"
 
-"@salesforce/kit@^3.0.13", "@salesforce/kit@^3.0.14":
+"@salesforce/kit@^3.0.15":
   version "3.0.15"
   resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-3.0.15.tgz#713df3f5767f874c70a2e731c7cb5ba677989559"
   integrity sha512-XkA8jsuLvVnyP460dAbU3pBFP2IkmmmsVxMQVifcKKbNWaIBbZBzAfj+vdaQfnvZyflLhsrFT3q2xkb0vHouPg==
@@ -1014,10 +1014,10 @@
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.5.0.tgz#8bfe2cb5d7cb29d3394b3b9cfb71bb527009c82c"
   integrity sha512-EKFBURBuON7cj8XZCW+ybeSRRw7wUP1XUXZVHzFgx8KiYmSeGiRHBYbDjQOsQMho2uOLsTozMPEt2ehYnji0YA==
 
-"@salesforce/schemas@^1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.6.0.tgz#14505ebad2fb2d4f7b14837545d662766d293561"
-  integrity sha512-SwhDTLucj/GRbPpxlEoDZeqlX22o+G6fiebTXTu1cZKmd1oE0W2L7SlTTgJnWck8bhTeBIgQi9cpD8c2t5ISKA==
+"@salesforce/schemas@^1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.6.1.tgz#7d1c071e1e509ca9d2d8a6e48ac7447dd67a534d"
+  integrity sha512-eVy947ZMxCJReKJdgfddUIsBIbPTa/i8RwQGwxq4/ss38H5sLOAeSTaun9V7HpJ1hkpDznWKfgzYvjsst9K6ig==
 
 "@salesforce/ts-sinon@^1.1.2":
   version "1.4.6"
@@ -1035,7 +1035,7 @@
   dependencies:
     tslib "^2.5.0"
 
-"@salesforce/ts-types@^2.0.6", "@salesforce/ts-types@^2.0.8", "@salesforce/ts-types@^2.0.9":
+"@salesforce/ts-types@^2.0.6", "@salesforce/ts-types@^2.0.9":
   version "2.0.9"
   resolved "https://registry.yarnpkg.com/@salesforce/ts-types/-/ts-types-2.0.9.tgz#66bff7b41720065d6b01631b6f6a3ccca02857c5"
   integrity sha512-boUD9jw5vQpTCPCCmK/NFTWjSuuW+lsaxOynkyNXLW+zxOc4GDjhtKc4j0vWZJQvolpafbyS8ZLFHZJvs12gYA==
@@ -1363,15 +1363,20 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
   integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
 
-"@types/semver@^7.5.0", "@types/semver@^7.5.3":
+"@types/semver@^7.5.0":
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.4.tgz#0a41252ad431c473158b22f9bfb9a63df7541cff"
   integrity sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==
 
-"@types/shelljs@^0.8.14":
-  version "0.8.14"
-  resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.8.14.tgz#87b8817b2397ffe97b86a4d844036ee0d2a1f0ca"
-  integrity sha512-eqKaGPi60riuxI9pUVeCT02EGo94Y6HT119h7w5bXSELsis6+JqzdEy6H/w2xXl881wcN3VDnb/D0WlgSety5w==
+"@types/semver@^7.5.4":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.5.tgz#deed5ab7019756c9c90ea86139106b0346223f35"
+  integrity sha512-+d+WYC1BxJ6yVOgUgzK8gWvp5qF8ssV5r4nsDcZWKRWcDQLQ619tvWAxJQYGgBrO1MnLJC7a5GtiYsAoQ47dJg==
+
+"@types/shelljs@^0.8.15":
+  version "0.8.15"
+  resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.8.15.tgz#22c6ab9dfe05cec57d8e6cb1a95ea173aee9fcac"
+  integrity sha512-vzmnCHl6hViPu9GNLQJ+DZFd6BQI2DBTUeOvYHqkWQLMfKAAQYMb/xAmZkTogZI/vqXHCWkqDRymDI5p0QTi5Q==
   dependencies:
     "@types/glob" "~7.2.0"
     "@types/node" "*"
@@ -6130,9 +6135,9 @@ pino-std-serializers@^6.0.0:
   integrity sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==
 
 pino@^8.16.0:
-  version "8.16.1"
-  resolved "https://registry.yarnpkg.com/pino/-/pino-8.16.1.tgz#dcaf82764b1a27f24101317cdd6453e96290f1d9"
-  integrity sha512-3bKsVhBmgPjGV9pyn4fO/8RtoVDR8ssW1ev819FsRXlRNgW8gR/9Kx+gCK4UPWd4JjrRDLWpzd/pb1AyWm3MGA==
+  version "8.16.2"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-8.16.2.tgz#7a906f2d9a8c5b4c57412c9ca95d6820bd2090cd"
+  integrity sha512-2advCDGVEvkKu9TTVSa/kWW7Z3htI/sBKEZpqiHk6ive0i/7f5b1rsU8jn0aimxqfnSz5bj/nOYkwhBUn5xxvg==
   dependencies:
     atomic-sleep "^1.0.0"
     fast-redact "^3.1.1"
@@ -6201,9 +6206,9 @@ process-on-spawn@^1.0.0:
     fromentries "^1.2.0"
 
 process-warning@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/process-warning/-/process-warning-2.2.0.tgz#008ec76b579820a8e5c35d81960525ca64feb626"
-  integrity sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg==
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/process-warning/-/process-warning-2.3.1.tgz#0caf992272c439f45dd416e1407ee25a3d4c778a"
+  integrity sha512-JjBvFEn7MwFbzUDa2SRtKJSsyO0LlER4V/FmwLMhBlXNbGgGxdyFCxIdMDLerWUycsVUyaoM9QFLvppFy4IWaQ==
 
 process@^0.11.10:
   version "0.11.10"


### PR DESCRIPTION
Context: We want to upgrade from `SfdxCommand` to `SfCommand`. The problem is that `SfCommand` is in a library that doesn't support the E2E test framework we'd been previously using, `fancy-test`. So this PR ports all our old E2E tests to the new NUT (non-Unit Test) framework.