### PR TITLE
NEW (CodeAnalyzer): @W-14689261@: The --target and --projectdir flags are no longer required. Defaults are provided.

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry=https://registry.npmjs.org/

--- a/messages/SfgeEngine.md
+++ b/messages/SfgeEngine.md
@@ -5,7 +5,3 @@ Please wait
 # messages.spinnerStart
 
 Analyzing with Salesforce Graph Engine. See %s for details.
-
-# errors.failedWithoutProjectDir
-
-The --projectdir|-p flag is missing. Rerun your command with --projectdir|-p to allow Graph Engine to run, or with --engine|-e to exclude Graph Engine from execution.

--- a/messages/run-common.md
+++ b/messages/run-common.md
@@ -32,11 +32,11 @@ Writes output to a file.
 
 # flags.projectdirSummary
 
-provide root directory of project
+root directory of project
 
 # flags.projectdirDescription
 
-Provides the relative or absolute root project directory used to set the context for Graph Engine's analysis. Project directory must be a path, not a glob. Specify multiple values as a comma-separated list.
+Provides the relative or absolute root project directory used to set the context for Graph Engine's analysis. Project directory must be a path, not a glob. Specify multiple values as a comma-separated list. If --projectdir is not specified, a default value will be calculated to be a directory containing all of the target files.
 
 # flags.sevthresholdSummary
 
@@ -88,4 +88,4 @@ No files found in target. --target must contain at least one file.
 
 # info.resolvedProjectDir
 
-No project directory was specified by --projectdir. Therefore, the following project directory will be used: %s
+The --projectdir flag was not specified. Therefore, the project directory was calculated to be: %s

--- a/messages/run-common.md
+++ b/messages/run-common.md
@@ -36,7 +36,7 @@ root directory of project
 
 # flags.projectdirDescription
 
-Provides the relative or absolute root project directory used to set the context for Graph Engine's analysis. Project directory must be a path, not a glob. If --projectdir is not specified, a default value will be calculated to be a directory containing all the target files.
+Provides the relative or absolute root project directory used to set the context for Graph Engine's analysis. Project directory must be a path, not a glob. If --projectdir isn’t specified, a default value is calculated. The default value is a directory that contains all the target files.
 
 # flags.sevthresholdSummary
 
@@ -84,8 +84,8 @@ The selected output format doesn't match the output file type. Output format: %s
 
 # validations.noFilesFoundInTarget
 
-No files found in target. --target must contain at least one file.
+No files were found in the target. --target must contain at least one file.
 
 # info.resolvedProjectDir
 
-The --projectdir flag was not specified. Therefore, the project directory was calculated to be: %s
+The --projectdir flag wasn’t specified so the calculated project directory is: %s

--- a/messages/run-common.md
+++ b/messages/run-common.md
@@ -81,3 +81,11 @@ The selected output format doesn't match the output file type. Output format: %s
 # validations.projectdirMustExist
 
 --projectdir must specify existing paths
+
+# validations.noFilesFoundInTarget
+
+No files found in target. --target must contain at least one file.
+
+# info.resolvedProjectDir
+
+No project directory was specified by --projectdir. Therefore, the following project directory will be used: %s

--- a/messages/run-common.md
+++ b/messages/run-common.md
@@ -36,7 +36,7 @@ root directory of project
 
 # flags.projectdirDescription
 
-Provides the relative or absolute root project directory used to set the context for Graph Engine's analysis. Project directory must be a path, not a glob. Specify multiple values as a comma-separated list. If --projectdir is not specified, a default value will be calculated to be a directory containing all of the target files.
+Provides the relative or absolute root project directory used to set the context for Graph Engine's analysis. Project directory must be a path, not a glob. If --projectdir is not specified, a default value will be calculated to be a directory containing all the target files.
 
 # flags.sevthresholdSummary
 

--- a/messages/run-dfa.md
+++ b/messages/run-dfa.md
@@ -33,7 +33,7 @@ Specifies number of rule evaluation threads, or how many entrypoints can be eval
 
 # flags.rulethreadtimeoutSummary
 
-specify timeout for individual rule threads in milliseconds. Alternatively, set the timeout value using environment variable `SFGE_RULE_THREAD_TIMEOUT`. Default: 90000 ms
+specify timeout for individual rule threads in milliseconds. Alternatively, set the timeout value using environment variable `SFGE_RULE_THREAD_TIMEOUT`. Default: 900000 ms
 
 # flags.rulethreadtimeoutDescription
 
@@ -49,11 +49,11 @@ Specifies Java Virtual Machine arguments to override system defaults while execu
 
 # flags.targetSummary
 
-return location of source code
+source code location
 
 # flags.targetDescription
 
-Returns the source code location. Use glob patterns or specify individual methods with #-syntax. Multiple values are specified as a comma-separated list.
+Source code location. Use glob patterns or specify individual methods with #-syntax. Multiple values are specified as a comma-separated list. Default is ".".
 
 # flags.withpilotSummary
 

--- a/messages/run-dfa.md
+++ b/messages/run-dfa.md
@@ -53,7 +53,7 @@ source code location
 
 # flags.targetDescription
 
-Source code location. Use glob patterns or specify individual methods with #-syntax. Multiple values are specified as a comma-separated list. Default is ".".
+Specifies the source code location. Use glob patterns or specify individual methods with #-syntax. Multiple values are specified as a comma-separated list. Default is ".".
 
 # flags.withpilotSummary
 

--- a/messages/run-dfa.md
+++ b/messages/run-dfa.md
@@ -71,10 +71,6 @@ Method-level targets supplied to --target cannot be globs
 
 Method-level target %s must be a real file
 
-# validations.projectdirIsRequired
-
---projectdir is required for this command.
-
 # examples
 
 The paths specified for --projectdir must contain all files specified through --target cumulatively.

--- a/messages/run-pathless.md
+++ b/messages/run-pathless.md
@@ -20,7 +20,7 @@ source code location
 
 # flags.targetDescription
 
-Source code location. May use glob patterns. Specify multiple values as a comma-separated list.
+Source code location. May use glob patterns. Specify multiple values as a comma-separated list. Default is ".".
 
 # flags.envSummary
 

--- a/messages/run-pathless.md
+++ b/messages/run-pathless.md
@@ -20,7 +20,7 @@ source code location
 
 # flags.targetDescription
 
-Source code location. May use glob patterns. Specify multiple values as a comma-separated list. Default is ".".
+Specifies the source code location. May use glob patterns. Specify multiple values as a comma-separated list. Default is ".".
 
 # flags.envSummary
 

--- a/src/commands/scanner/rule/add.ts
+++ b/src/commands/scanner/rule/add.ts
@@ -37,6 +37,6 @@ export default class Add extends ScannerCommand {
 	};
 
 	protected createAction(logger: Logger, display: Display): Action {
-		return new RuleAddAction(logger, display, new InputProcessorImpl(this.config.version));
+		return new RuleAddAction(logger, display, new InputProcessorImpl(this.config.version, display));
 	}
 }

--- a/src/commands/scanner/rule/remove.ts
+++ b/src/commands/scanner/rule/remove.ts
@@ -39,6 +39,6 @@ export default class Remove extends ScannerCommand {
 	};
 
 	protected createAction(logger: Logger, display: Display): Action {
-		return new RuleRemoveAction(logger, display, new InputProcessorImpl(this.config.version));
+		return new RuleRemoveAction(logger, display, new InputProcessorImpl(this.config.version, display));
 	}
 }

--- a/src/commands/scanner/run.ts
+++ b/src/commands/scanner/run.ts
@@ -88,7 +88,7 @@ export default class Run extends ScannerRunCommand {
 	};
 
 	protected createAction(logger: Logger, display: Display): Action {
-		const inputProcessor: InputProcessor = new InputProcessorImpl(this.config.version);
+		const inputProcessor: InputProcessor = new InputProcessorImpl(this.config.version, display);
 		const ruleFilterFactory: RuleFilterFactory = new RuleFilterFactoryImpl();
 		const engineOptionsFactory: EngineOptionsFactory = new RunEngineOptionsFactory(inputProcessor);
 		const resultsProcessorFactory: ResultsProcessorFactory = new ResultsProcessorFactoryImpl();

--- a/src/commands/scanner/run.ts
+++ b/src/commands/scanner/run.ts
@@ -53,8 +53,7 @@ export default class Run extends ScannerRunCommand {
 			summary: getMessage(BundleName.Run, 'flags.targetSummary'),
 			description: getMessage(BundleName.Run, 'flags.targetDescription'),
 			delimiter: ',',
-			multiple: true,
-			required: true
+			multiple: true
 		})(),
 		// END: Targeting-related flags.
 		// BEGIN: Engine config flags.

--- a/src/commands/scanner/run/dfa.ts
+++ b/src/commands/scanner/run/dfa.ts
@@ -41,7 +41,6 @@ export default class Dfa extends ScannerRunCommand {
 			char: 't',
 			summary: getMessage(BundleName.RunDfa, 'flags.targetSummary'),
 			description: getMessage(BundleName.RunDfa, 'flags.targetDescription'),
-			required: true,
 			delimiter: ',',
 			multiple: true
 		})(),

--- a/src/commands/scanner/run/dfa.ts
+++ b/src/commands/scanner/run/dfa.ts
@@ -76,7 +76,7 @@ export default class Dfa extends ScannerRunCommand {
 	};
 
 	protected createAction(logger: Logger, display: Display): Action {
-		const inputProcessor: InputProcessor = new InputProcessorImpl(this.config.version);
+		const inputProcessor: InputProcessor = new InputProcessorImpl(this.config.version, display);
 		const ruleFilterFactory: RuleFilterFactory = new RuleFilterFactoryImpl();
 		const engineOptionsFactory: EngineOptionsFactory = new RunDfaEngineOptionsFactory(inputProcessor);
 		const resultsProcessorFactory: ResultsProcessorFactory = new ResultsProcessorFactoryImpl();

--- a/src/lib/DefaultRuleManager.ts
+++ b/src/lib/DefaultRuleManager.ts
@@ -295,6 +295,8 @@ export class DefaultRuleManager implements RuleManager {
 			if (globby.hasMagic(target)) {
 				// The target is a magic glob. Retrieve paths in the working directory that match it, and then filter against
 				// our pattern matcher.
+				// NOTE: We should consider in the future to resolve target paths based off of the projectdir instead of
+				// the present working directory.
 				const matchingTargets = await globby(targetPath);
 				// Map relative files to absolute paths. This solves ambiguity of current working directory
 				const absoluteMatchingTargets = matchingTargets.map(t => path.resolve(t));

--- a/src/lib/DefaultRuleManager.ts
+++ b/src/lib/DefaultRuleManager.ts
@@ -289,7 +289,7 @@ export class DefaultRuleManager implements RuleManager {
 			const ruleTargetsInitialLength: number = ruleTargets.length;
 			// Positive patterns might use method-level targeting. We only want to do path evaluation against the part
 			// that's actually a path.
-			const targetPortions = target.split('#');
+			const targetPortions = splitOnMethodSpecifier(target)
 			// The array will always have at least one entry, since if there's no '#' then it will return a singleton array.
 			const targetPath = targetPortions[0];
 			if (globby.hasMagic(target)) {
@@ -347,4 +347,10 @@ export class DefaultRuleManager implements RuleManager {
 		}
 		return ruleTargets;
 	}
+}
+
+function splitOnMethodSpecifier(targetPath: string): string[] {
+	// Unlike targetPath.split('#'), this solution only splits on the last '#' instead of all of them
+	const lastHashPos: number = targetPath.lastIndexOf('#');
+	return lastHashPos < 0 ? [targetPath] : [targetPath.substring(0, lastHashPos), targetPath.substring(lastHashPos+1)]
 }

--- a/src/lib/EngineOptionsFactory.ts
+++ b/src/lib/EngineOptionsFactory.ts
@@ -1,5 +1,5 @@
 import {Inputs, LooseObject, SfgeConfig} from "../types";
-import {CUSTOM_CONFIG, INTERNAL_ERROR_CODE} from "../Constants";
+import {CUSTOM_CONFIG, ENGINE, INTERNAL_ERROR_CODE} from "../Constants";
 import {InputProcessor} from "./InputProcessor";
 import {TYPESCRIPT_ENGINE_OPTIONS} from "./eslint/TypescriptEslintStrategy";
 import {SfError} from "@salesforce/core";
@@ -22,18 +22,16 @@ abstract class CommonEngineOptionsFactory implements EngineOptionsFactory {
 		this.inputProcessor = inputProcessor;
 	}
 
+	protected abstract shouldSfgeRun(inputs: Inputs): boolean;
+
 	createEngineOptions(inputs: Inputs): EngineOptions {
 		const options: Map<string,string> = new Map();
-
-		// We should only add a GraphEngine config if we were given a --projectdir flag.
-		const projectDirPath: string = this.inputProcessor.resolveProjectDirPath(inputs);
-		if (projectDirPath.length > 0) {
+		if (this.shouldSfgeRun(inputs)) {
 			const sfgeConfig: SfgeConfig = {
-				projectDir: projectDirPath
+				projectDir: this.inputProcessor.resolveProjectDirPath(inputs)
 			};
 			options.set(CUSTOM_CONFIG.SfgeConfig, JSON.stringify(sfgeConfig));
 		}
-
 		return options;
 	}
 
@@ -42,6 +40,10 @@ abstract class CommonEngineOptionsFactory implements EngineOptionsFactory {
 export class RunEngineOptionsFactory extends CommonEngineOptionsFactory {
 	public constructor(inputProcessor: InputProcessor) {
 		super(inputProcessor);
+	}
+
+	protected shouldSfgeRun(inputs: Inputs): boolean {
+		return inputs.engine && (inputs.engine as string[]).includes(ENGINE.SFGE);
 	}
 
 	public override createEngineOptions(inputs: Inputs): EngineOptions {
@@ -87,6 +89,10 @@ export class RunEngineOptionsFactory extends CommonEngineOptionsFactory {
 export class RunDfaEngineOptionsFactory extends CommonEngineOptionsFactory {
 	public constructor(inputProcessor: InputProcessor) {
 		super(inputProcessor);
+	}
+
+	protected shouldSfgeRun(ignored: Inputs): boolean {
+		return true;
 	}
 
 	public override createEngineOptions(inputs: Inputs): EngineOptions {

--- a/src/lib/EngineOptionsFactory.ts
+++ b/src/lib/EngineOptionsFactory.ts
@@ -26,10 +26,10 @@ abstract class CommonEngineOptionsFactory implements EngineOptionsFactory {
 		const options: Map<string,string> = new Map();
 
 		// We should only add a GraphEngine config if we were given a --projectdir flag.
-		const projectDirPaths: string[] = this.inputProcessor.resolveProjectDirPaths(inputs);
-		if (projectDirPaths.length > 0) {
+		const projectDirPath: string = this.inputProcessor.resolveProjectDirPath(inputs);
+		if (projectDirPath.length > 0) {
 			const sfgeConfig: SfgeConfig = {
-				projectDirs: projectDirPaths
+				projectDir: projectDirPath
 			};
 			options.set(CUSTOM_CONFIG.SfgeConfig, JSON.stringify(sfgeConfig));
 		}

--- a/src/lib/EngineOptionsFactory.ts
+++ b/src/lib/EngineOptionsFactory.ts
@@ -91,7 +91,8 @@ export class RunDfaEngineOptionsFactory extends CommonEngineOptionsFactory {
 		super(inputProcessor);
 	}
 
-	protected shouldSfgeRun(ignored: Inputs): boolean {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	protected shouldSfgeRun(_inputs: Inputs): boolean {
 		return true;
 	}
 

--- a/src/lib/InputProcessor.ts
+++ b/src/lib/InputProcessor.ts
@@ -44,8 +44,9 @@ export class InputProcessorImpl implements InputProcessor {
 	public resolveTargetPaths(inputs: Inputs): string[] {
 		// Turn the paths into normalized Unix-formatted paths and strip out any single- or double-quotes, because
 		// sometimes shells are stupid and will leave them in there.
-		const target: string[] = (inputs.target || []) as string[];
-		return target.map(path => normalize(untildify(path)).replace(/['"]/g, ''));
+		// Note that we do not do a path.resolve since the target input can be globby (which we handle elsewhere).
+		const targetPaths: string[] = (inputs.target || ['.']) as string[];
+		return targetPaths.map(path => normalize(untildify(path)).replace(/['"]/g, ''));
 	}
 
 

--- a/src/lib/InputProcessor.ts
+++ b/src/lib/InputProcessor.ts
@@ -114,19 +114,24 @@ function outputFormatFromInputs(inputs: Inputs): OutputFormat {
 }
 
 function trimMethodSpecifier(targetPath: string): string {
-	return targetPath.split('#')[0];
+	const lastHashPos: number = targetPath.lastIndexOf('#');
+	return lastHashPos < 0 ? targetPath : targetPath.substring(0, lastHashPos)
 }
 
 function getFirstCommonParentFolder(targetFiles: string[]) {
 	const longestCommonStr: string = getLongestCommonPrefix(targetFiles);
 	const commonParentFolder = getParentFolderOf(longestCommonStr);
-	return commonParentFolder.length == 0 ? '/' : commonParentFolder;
+	return commonParentFolder.length == 0 ? path.sep : commonParentFolder;
 }
 
 function getLongestCommonPrefix(strs: string[]): string {
+	// To find the longest common prefix, we first get the select the shortest string from our list of strings
 	const shortestStr = strs.reduce((s1, s2) => s1.length <= s2.length ? s1 : s2);
+
+	// Then we check that each string's ith character is the same as the shortest strings ith character
 	for (let i = 0; i < shortestStr.length; i++) {
 		if(!strs.every(str => str[i] === shortestStr[i])) {
+			// If we find a string that doesn't match the ith character, we return the common prefix from [0,i)
 			return shortestStr.substring(0, i)
 		}
 	}
@@ -144,6 +149,6 @@ function findFolderThatContainsSfdxProjectFile(folder: string): string {
 	return '';
 }
 
-function getParentFolderOf(path: string): string {
-	return path.substring(0, path.lastIndexOf('/'))
+function getParentFolderOf(fileOrFolder: string): string {
+	return fileOrFolder.substring(0, fileOrFolder.lastIndexOf(path.sep))
 }

--- a/src/lib/InputProcessor.ts
+++ b/src/lib/InputProcessor.ts
@@ -1,10 +1,16 @@
 import {Inputs} from "../types";
-import normalize = require('normalize-path');
-import path = require('path');
-import untildify = require("untildify");
 import {RunOptions} from "./RuleManager";
 import {RunOutputOptions} from "./output/RunResultsProcessor";
 import {inferFormatFromOutfile, OutputFormat} from "./output/OutputFormat";
+import {SfError} from "@salesforce/core";
+import {BundleName, getMessage} from "../MessageCatalog";
+import {INTERNAL_ERROR_CODE} from "../Constants";
+import {Display} from "./Display";
+import normalize = require('normalize-path');
+import path = require('path');
+import fs = require('fs');
+import untildify = require("untildify");
+import globby = require('globby');
 
 /**
  * Service for processing inputs
@@ -23,9 +29,11 @@ export interface InputProcessor {
 
 export class InputProcessorImpl implements InputProcessor {
 	private readonly sfVersion: string;
+	private readonly display: Display;
 
-	public constructor(sfVersion: string) {
+	public constructor(sfVersion: string, display: Display) {
 		this.sfVersion = sfVersion;
+		this.display = display
 	}
 
 	public resolvePaths(inputs: Inputs): string[] {
@@ -35,16 +43,31 @@ export class InputProcessorImpl implements InputProcessor {
 	}
 
 	public resolveProjectDirPath(inputs: Inputs): string {
+		// If projectdir is provided, then return it since at this point it has already been validated to exist
 		if (inputs.projectdir && (inputs.projectdir as string).length > 0) {
 			return path.resolve(normalize(untildify(inputs.projectdir as string)))
 		}
-		return '';
+
+		// If projectdir is not provided then:
+		// * We calculate the first common parent directory that includes all the target files.
+		// --> If none of its parent folders contain a sfdx-project.json file, then we return this first common parent.
+		// --> Otherwise we return the folder that contains the sfdx-project.json file.
+		const commonParentFolder = getFirstCommonParentFolder(this.getAllTargetFiles(inputs));
+		let projectFolder: string = findFolderThatContainsSfdxProjectFile(commonParentFolder);
+		projectFolder = projectFolder.length > 0 ? projectFolder : commonParentFolder
+		this.display.displayVerboseInfo(getMessage(BundleName.CommonRun, 'info.resolvedProjectDir', [projectFolder]))
+		return projectFolder;
 	}
 
 	public resolveTargetPaths(inputs: Inputs): string[] {
 		// Turn the paths into normalized Unix-formatted paths and strip out any single- or double-quotes, because
 		// sometimes shells are stupid and will leave them in there.
 		// Note that we do not do a path.resolve since the target input can be globby (which we handle elsewhere).
+
+		// If possible, in the future we should resolve all globs here instead of in the DefaultRuleManager.
+		// Also, I would recommend that we eventually resolve globs based on the projectdir (since it acts as a
+		// root directory) instead of the present working directory.
+
 		const targetPaths: string[] = (inputs.target || ['.']) as string[];
 		return targetPaths.map(path => normalize(untildify(path)).replace(/['"]/g, ''));
 	}
@@ -62,10 +85,19 @@ export class InputProcessorImpl implements InputProcessor {
 	public createRunOutputOptions(inputs: Inputs): RunOutputOptions {
 		return {
 			format: outputFormatFromInputs(inputs),
-			verboseViolations: inputs["verbose-violations"] as boolean,
+			verboseViolations: inputs['verbose-violations'] as boolean,
 			severityForError: inputs['severity-threshold'] as number,
 			outfile: inputs.outfile as string
 		};
+	}
+
+	private getAllTargetFiles(inputs: Inputs): string[] {
+		const targetPaths: string[] = this.resolveTargetPaths(inputs).map(p => trimMethodSpecifier(p))
+		const allAbsoluteTargetFiles: string[] = globby.sync(targetPaths).map(p => path.resolve(p));
+		if (allAbsoluteTargetFiles.length == 0) {
+			throw new SfError(getMessage(BundleName.CommonRun, 'validations.noFilesFoundInTarget'), null, null, INTERNAL_ERROR_CODE);
+		}
+		return allAbsoluteTargetFiles;
 	}
 }
 
@@ -79,4 +111,39 @@ function outputFormatFromInputs(inputs: Inputs): OutputFormat {
 	} else {
 		return OutputFormat.TABLE;
 	}
+}
+
+function trimMethodSpecifier(targetPath: string): string {
+	return targetPath.split('#')[0];
+}
+
+function getFirstCommonParentFolder(targetFiles: string[]) {
+	const longestCommonStr: string = getLongestCommonPrefix(targetFiles);
+	const commonParentFolder = getParentFolderOf(longestCommonStr);
+	return commonParentFolder.length == 0 ? '/' : commonParentFolder;
+}
+
+function getLongestCommonPrefix(strs: string[]): string {
+	const shortestStr = strs.reduce((s1, s2) => s1.length <= s2.length ? s1 : s2);
+	for (let i = 0; i < shortestStr.length; i++) {
+		if(!strs.every(str => str[i] === shortestStr[i])) {
+			return shortestStr.substring(0, i)
+		}
+	}
+	return shortestStr;
+}
+
+function findFolderThatContainsSfdxProjectFile(folder: string): string {
+	let folderToCheck: string = folder;
+	while (folderToCheck.length > 0) {
+		if (fs.existsSync(path.resolve(folderToCheck, 'sfdx-project.json'))) {
+			return folderToCheck;
+		}
+		folderToCheck = getParentFolderOf(folderToCheck);
+	}
+	return '';
+}
+
+function getParentFolderOf(path: string): string {
+	return path.substring(0, path.lastIndexOf('/'))
 }

--- a/src/lib/InputProcessor.ts
+++ b/src/lib/InputProcessor.ts
@@ -14,7 +14,7 @@ export interface InputProcessor {
 
 	resolveTargetPaths(inputs: Inputs): string[];
 
-	resolveProjectDirPaths(inputs: Inputs): string[];
+	resolveProjectDirPath(inputs: Inputs): string;
 
 	createRunOptions(inputs: Inputs, isDfa: boolean): RunOptions;
 
@@ -34,12 +34,11 @@ export class InputProcessorImpl implements InputProcessor {
 		return (inputs.path as string[]).map(p => path.resolve(untildify(p)));
 	}
 
-	public resolveProjectDirPaths(inputs: Inputs): string[] {
-		// TODO: Stop allowing an array of paths - move towards only 1 path (to resolve into 1 output path)
-		if (inputs.projectdir && (inputs.projectdir as string[]).length > 0) {
-			return (inputs.projectdir as string[]).map(p => path.resolve(p));
+	public resolveProjectDirPath(inputs: Inputs): string {
+		if (inputs.projectdir && (inputs.projectdir as string).length > 0) {
+			return path.resolve(normalize(untildify(inputs.projectdir as string)))
 		}
-		return [];
+		return '';
 	}
 
 	public resolveTargetPaths(inputs: Inputs): string[] {

--- a/src/lib/ScannerRunCommand.ts
+++ b/src/lib/ScannerRunCommand.ts
@@ -1,7 +1,5 @@
 import {Flags} from '@salesforce/sf-plugins-core';
 import {ScannerCommand} from './ScannerCommand';
-import untildify = require('untildify');
-import normalize = require('normalize-path');
 import {BundleName, getMessage} from "../MessageCatalog";
 import {OutputFormat} from "./output/OutputFormat";
 
@@ -48,12 +46,11 @@ export abstract class ScannerRunCommand extends ScannerCommand {
 		}),
 		// END: Flags related to results processing.
 		// BEGIN: Flags related to targeting.
-		projectdir: Flags.custom<string[]>({ // TODO: FIGURE OUT WHY WE NEED THIS ON BOTH "run" AND "run dfa"
+		projectdir: Flags.string({
 			char: 'p',
 			summary: getMessage(BundleName.CommonRun, 'flags.projectdirSummary'),
-			description: getMessage(BundleName.CommonRun, 'flags.projectdirDescription'),
-			parse: val => Promise.resolve(val.split(',').map(d => normalize(untildify(d))))
-		})(),
+			description: getMessage(BundleName.CommonRun, 'flags.projectdirDescription')
+		}),
 		// END: Flags related to targeting.
 	};
 }

--- a/src/lib/actions/AbstractRunAction.ts
+++ b/src/lib/actions/AbstractRunAction.ts
@@ -19,6 +19,8 @@ import {inferFormatFromOutfile, OutputFormat} from "../output/OutputFormat";
 import {ResultsProcessor} from "../output/ResultsProcessor";
 import {ResultsProcessorFactory} from "../output/ResultsProcessorFactory";
 import {JsonReturnValueHolder} from "../output/JsonReturnValueHolder";
+import untildify = require('untildify');
+import normalize = require('normalize-path');
 
 /**
  * Abstract Action to share a common implementation behind the "run" and "run dfa" commands
@@ -48,11 +50,12 @@ export abstract class AbstractRunAction implements Action {
 		const fh = new FileHandler();
 		// If there's a --projectdir flag, its entries must be non-glob paths pointing to existing directories.
 		if (inputs.projectdir) {
-			if (globby.hasMagic(inputs.projectdir)) {
+			const projectDir: string = normalize(untildify(inputs.projectdir as string))
+			if (globby.hasMagic(projectDir)) {
 				throw new SfError(getMessage(BundleName.CommonRun, 'validations.projectdirCannotBeGlob'));
-			} else if (!(await fh.exists(inputs.projectdir))) {
+			} else if (!(await fh.exists(projectDir))) {
 				throw new SfError(getMessage(BundleName.CommonRun, 'validations.projectdirMustExist'));
-			} else if (!(await fh.stats(inputs.projectdir)).isDirectory()) {
+			} else if (!(await fh.stats(projectDir)).isDirectory()) {
 				throw new SfError(getMessage(BundleName.CommonRun, 'validations.projectdirMustBeDir'));
 			}
 		}

--- a/src/lib/actions/AbstractRunAction.ts
+++ b/src/lib/actions/AbstractRunAction.ts
@@ -48,15 +48,12 @@ export abstract class AbstractRunAction implements Action {
 		const fh = new FileHandler();
 		// If there's a --projectdir flag, its entries must be non-glob paths pointing to existing directories.
 		if (inputs.projectdir) {
-			// TODO: MOVE AWAY FROM ALLOWING AN ARRAY OF DIRECTORIES HERE AND ERROR IF THERE IS MORE THAN ONE DIRECTORY
-			for (const dir of (inputs.projectdir as string[])) {
-				if (globby.hasMagic(dir)) {
-					throw new SfError(getMessage(BundleName.CommonRun, 'validations.projectdirCannotBeGlob'));
-				} else if (!(await fh.exists(dir))) {
-					throw new SfError(getMessage(BundleName.CommonRun, 'validations.projectdirMustExist'));
-				} else if (!(await fh.stats(dir)).isDirectory()) {
-					throw new SfError(getMessage(BundleName.CommonRun, 'validations.projectdirMustBeDir'));
-				}
+			if (globby.hasMagic(inputs.projectdir)) {
+				throw new SfError(getMessage(BundleName.CommonRun, 'validations.projectdirCannotBeGlob'));
+			} else if (!(await fh.exists(inputs.projectdir))) {
+				throw new SfError(getMessage(BundleName.CommonRun, 'validations.projectdirMustExist'));
+			} else if (!(await fh.stats(inputs.projectdir)).isDirectory()) {
+				throw new SfError(getMessage(BundleName.CommonRun, 'validations.projectdirMustBeDir'));
 			}
 		}
 		// If the user explicitly specified both a format and an outfile, we need to do a bit of validation there.

--- a/src/lib/actions/RunAction.ts
+++ b/src/lib/actions/RunAction.ts
@@ -29,9 +29,11 @@ export class RunAction extends AbstractRunAction {
 			this.display.displayInfo(getMessage(BundleName.Run, 'output.filtersIgnoredCustom', []));
 		}
 		// None of the pathless engines support method-level targeting, so attempting to use it should result in an error.
-		for (const target of (inputs.target as string[])) {
-			if (target.indexOf('#') > -1) {
-				throw new SfError(getMessage(BundleName.Run, 'validations.methodLevelTargetingDisallowed', [target]));
+		if (inputs.target) {
+			for (const target of (inputs.target as string[])) {
+				if (target.indexOf('#') > -1) {
+					throw new SfError(getMessage(BundleName.Run, 'validations.methodLevelTargetingDisallowed', [target]));
+				}
 			}
 		}
 	}

--- a/src/lib/actions/RunDfaAction.ts
+++ b/src/lib/actions/RunDfaAction.ts
@@ -31,15 +31,17 @@ export class RunDfaAction extends AbstractRunAction {
 			throw new SfError(getMessage(BundleName.RunDfa, 'validations.projectdirIsRequired'));
 		}
 		// Entries in the target array may specify methods, but only if the entry is neither a directory nor a glob.
-		for (const target of (inputs.target as string[])) {
-			// The target specifies a method if it includes the `#` syntax.
-			if (target.indexOf('#') > -1) {
-				if(globby.hasMagic(target)) {
-					throw new SfError(getMessage(BundleName.RunDfa, 'validations.methodLevelTargetCannotBeGlob'));
-				}
-				const potentialFilePath = target.split('#')[0];
-				if (!(await fh.isFile(potentialFilePath))) {
-					throw new SfError(getMessage(BundleName.RunDfa, 'validations.methodLevelTargetMustBeRealFile', [potentialFilePath]));
+		if (inputs.target) {
+			for (const target of (inputs.target as string[])) {
+				// The target specifies a method if it includes the `#` syntax.
+				if (target.indexOf('#') > -1) {
+					if (globby.hasMagic(target)) {
+						throw new SfError(getMessage(BundleName.RunDfa, 'validations.methodLevelTargetCannotBeGlob'));
+					}
+					const potentialFilePath = target.split('#')[0];
+					if (!(await fh.isFile(potentialFilePath))) {
+						throw new SfError(getMessage(BundleName.RunDfa, 'validations.methodLevelTargetMustBeRealFile', [potentialFilePath]));
+					}
 				}
 			}
 		}

--- a/src/lib/actions/RunDfaAction.ts
+++ b/src/lib/actions/RunDfaAction.ts
@@ -24,12 +24,6 @@ export class RunDfaAction extends AbstractRunAction {
 		await super.validateInputs(inputs);
 
 		const fh = new FileHandler();
-		// The superclass will validate that --projectdir is well-formed,
-		// but doesn't require that the flag actually be present.
-		// So we should make sure it exists here.
-		if (!inputs.projectdir || (inputs.projectdir as string[]).length === 0) {
-			throw new SfError(getMessage(BundleName.RunDfa, 'validations.projectdirIsRequired'));
-		}
 		// Entries in the target array may specify methods, but only if the entry is neither a directory nor a glob.
 		if (inputs.target) {
 			for (const target of (inputs.target as string[])) {

--- a/src/lib/sfge/SfgePathlessEngine.ts
+++ b/src/lib/sfge/SfgePathlessEngine.ts
@@ -34,8 +34,8 @@ export class SfgePathlessEngine extends AbstractSfgeEngine {
 		// for `scanner run`.
 		if (engineOptions.has(CUSTOM_CONFIG.SfgeConfig)) {
 			const sfgeConfig: SfgeConfig = JSON.parse(engineOptions.get(CUSTOM_CONFIG.SfgeConfig)) as SfgeConfig;
-			if (sfgeConfig.projectDirs && sfgeConfig.projectDirs.length > 0) {
-				// If we've got a config with projectDirs, we're set.
+			if (sfgeConfig.projectDir && sfgeConfig.projectDir.length > 0) {
+				// If we've got a config with projectDir, we're set.
 				return true;
 			}
 		}

--- a/src/lib/sfge/SfgePathlessEngine.ts
+++ b/src/lib/sfge/SfgePathlessEngine.ts
@@ -1,9 +1,7 @@
-import {SfError} from '@salesforce/core';
 import {AbstractSfgeEngine, SfgeViolation} from "./AbstractSfgeEngine";
-import {Rule, RuleGroup, RuleTarget, RuleViolation, SfgeConfig} from '../../types';
+import {Rule, RuleGroup, RuleTarget, RuleViolation} from '../../types';
 import {CUSTOM_CONFIG, RuleType} from '../../Constants';
 import * as EngineUtils from "../util/CommonEngineUtils";
-import {BundleName, getMessage} from "../../MessageCatalog";
 
 export class SfgePathlessEngine extends AbstractSfgeEngine {
 	/**
@@ -32,16 +30,7 @@ export class SfgePathlessEngine extends AbstractSfgeEngine {
 		// For the non-DFA Graph Engine variant, we need to make sure that we have the
 		// necessary info to run the engine, since the relevant flags aren't required
 		// for `scanner run`.
-		if (engineOptions.has(CUSTOM_CONFIG.SfgeConfig)) {
-			const sfgeConfig: SfgeConfig = JSON.parse(engineOptions.get(CUSTOM_CONFIG.SfgeConfig)) as SfgeConfig;
-			if (sfgeConfig.projectDir && sfgeConfig.projectDir.length > 0) {
-				// If we've got a config with projectDir, we're set.
-				return true;
-			}
-		}
-		// If we're here, it's because we're missing the necessary info to run this engine.
-		// We should throw an error indicating this.
-		throw new SfError(getMessage(BundleName.SfgeEngine, 'errors.failedWithoutProjectDir'));
+		return engineOptions.has(CUSTOM_CONFIG.SfgeConfig);
 	}
 
 	protected getSubVariantName(): string {

--- a/src/lib/sfge/SfgeWrapper.ts
+++ b/src/lib/sfge/SfgeWrapper.ts
@@ -41,7 +41,7 @@ type SfgeCatalogOptions = SfgeWrapperOptions & {
 
 type SfgeExecuteOptions = SfgeWrapperOptions & {
 	targets: RuleTarget[];
-	projectDirs: string[];
+	projectDir: string;
 	rules: Rule[];
 	ruleThreadCount?: number;
 	ruleThreadTimeout?: number;
@@ -204,7 +204,7 @@ export class SfgeCatalogWrapper extends AbstractSfgeWrapper {
 
 export class SfgeExecuteWrapper extends AbstractSfgeWrapper {
 	private targets: RuleTarget[];
-	private projectDirs: string[];
+	private projectDir: string;
 	private rules: Rule[];
 	private ruleThreadCount: number;
 	private ruleThreadTimeout: number;
@@ -213,7 +213,7 @@ export class SfgeExecuteWrapper extends AbstractSfgeWrapper {
 	constructor(options: SfgeExecuteOptions) {
 		super(options);
 		this.targets = options.targets;
-		this.projectDirs = options.projectDirs;
+		this.projectDir = options.projectDir;
 		this.rules = options.rules;
 		this.ruleThreadCount = options.ruleThreadCount;
 		this.ruleThreadTimeout = options.ruleThreadTimeout;
@@ -238,7 +238,7 @@ export class SfgeExecuteWrapper extends AbstractSfgeWrapper {
 		const inputObject: SfgeInput = this.createInputJson();
 		const inputFile = await this.createInputFile(inputObject);
 
-		this.logger.trace(`Stored the names of ${this.targets.length} targeted files and ${this.projectDirs.length} source directories in ${inputFile}`);
+		this.logger.trace(`Stored the names of ${this.targets.length} targeted files and 1 source directory in ${inputFile}`);
 		this.logger.trace(`Rules to be executed: ${JSON.stringify(inputObject.rulesToRun)}`);
 		return [inputFile];
 	}
@@ -246,7 +246,9 @@ export class SfgeExecuteWrapper extends AbstractSfgeWrapper {
 	private createInputJson(): SfgeInput {
 		const inputJson: SfgeInput = {
 			targets: [],
-			projectDirs: this.projectDirs,
+			// We should consider changing this to just a string by updating the java side.
+			// The java side current takes in an array, but we only ever supply a single directory (i.e. array of length 1).
+			projectDirs: [this.projectDir],
 			rulesToRun: this.rules.map(rule => rule.name)
 		};
 		this.targets.forEach(t => {
@@ -282,7 +284,7 @@ export class SfgeExecuteWrapper extends AbstractSfgeWrapper {
 	public static async runSfge(targets: RuleTarget[], rules: Rule[], sfgeConfig: SfgeConfig): Promise<string> {
 		const wrapper = await SfgeExecuteWrapper.create({
 			targets,
-			projectDirs: sfgeConfig.projectDirs,
+			projectDir: sfgeConfig.projectDir,
 			action: EXEC_ACTION,
 			rules: rules,
 			// Running rules could take quite a while, so we should use a functional spinner.

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -197,7 +197,7 @@ export type TargetMatchingFunction = (t: string) => Promise<boolean>;
 export type BasicTargetPattern = string;
 
 export type SfgeConfig = {
-	projectDirs: string[];
+	projectDir: string;
 	ruleThreadCount?: number;
 	ruleThreadTimeout?: number;
 	ruleDisableWarningViolation?: boolean;

--- a/test/lib/InputProcessor.test.ts
+++ b/test/lib/InputProcessor.test.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import {Inputs} from "../../src/types";
 import {BundleName, getMessage} from "../../src/MessageCatalog";
 import untildify = require("untildify");
+import normalize = require("normalize-path");
 import {FakeDisplay} from "./FakeDisplay";
 
 describe("InputProcessorImpl Tests", async () => {
@@ -25,7 +26,7 @@ describe("InputProcessorImpl Tests", async () => {
 			expect(resolvedTargetPaths).to.have.length(3);
 			expect(resolvedTargetPaths).to.contain('test/**/*.page');
 			expect(resolvedTargetPaths).to.contain('!test/code-fixtures/cpd');
-			expect(resolvedTargetPaths).to.contain(untildify('~/*.class'))
+			expect(resolvedTargetPaths).to.contain(normalize(untildify('~/*.class')))
 		})
 
 		it("Specified target with method specifier", async () => {
@@ -67,7 +68,7 @@ describe("InputProcessorImpl Tests", async () => {
 				projectdir: '~/someFolder'
 			};
 			const resolvedProjectDir: string = inputProcessor.resolveProjectDirPath(inputs);
-			expect(resolvedProjectDir).to.equal(untildify('~/someFolder'))
+			expect(resolvedProjectDir).to.equal(normalize(untildify('~/someFolder')))
 		})
 
 		it("Unspecified projectdir and unspecified target", async() => {

--- a/test/lib/InputProcessor.test.ts
+++ b/test/lib/InputProcessor.test.ts
@@ -1,11 +1,140 @@
 import {InputProcessor, InputProcessorImpl} from "../../src/lib/InputProcessor";
-import {expect} from "chai";
+import {assert, expect} from "chai";
+import * as path from "path";
+import {Inputs} from "../../src/types";
+import {BundleName, getMessage} from "../../src/MessageCatalog";
+import untildify = require("untildify");
+import {FakeDisplay} from "./FakeDisplay";
 
 describe("InputProcessorImpl Tests", async () => {
-	it("Test that missing target resolves to current directory", async () => {
-		const inputProcessor: InputProcessor = new InputProcessorImpl("2.11.8")
-		const resolvedTargetPaths: string[] = inputProcessor.resolveTargetPaths({})
-		expect(resolvedTargetPaths).to.have.length(1)
-		expect(resolvedTargetPaths).to.contain('.')
+	let display: FakeDisplay;
+	let inputProcessor: InputProcessor;
+	beforeEach(async () => {
+		display = new FakeDisplay();
+		inputProcessor = new InputProcessorImpl("2.11.8", display);
+	});
+
+	describe("resolveTargetPaths Tests", async () => {
+		it("Specified glob target stays as glob", async () => {
+			// Note that we may want to change this behavior in the future instead of waiting to resolve the globs
+			// in the DefaultRuleManager. But for now, adding this test.
+			const inputs: Inputs = {
+				target: ['test\\**\\*.page', '!test/code-fixtures/cpd', '~/*.class']
+			};
+			const resolvedTargetPaths: string[] = inputProcessor.resolveTargetPaths(inputs);
+			expect(resolvedTargetPaths).to.have.length(3);
+			expect(resolvedTargetPaths).to.contain('test/**/*.page');
+			expect(resolvedTargetPaths).to.contain('!test/code-fixtures/cpd');
+			expect(resolvedTargetPaths).to.contain(untildify('~/*.class'))
+		})
+
+		it("Specified target with method specifier", async () => {
+			const inputs: Inputs = {
+				target: ['test/code-fixtures/apex/SomeTestClass.cls#testMethodWithoutAsserts']
+			};
+			const resolvedTargetPaths: string[] = inputProcessor.resolveTargetPaths(inputs);
+			expect(resolvedTargetPaths).to.have.length(1);
+			expect(resolvedTargetPaths).to.contain('test/code-fixtures/apex/SomeTestClass.cls#testMethodWithoutAsserts');
+		})
+
+		it("Unspecified target resolves to current directory", async () => {
+			const inputs: Inputs = {}
+			const resolvedTargetPaths: string[] = inputProcessor.resolveTargetPaths(inputs);
+			expect(resolvedTargetPaths).to.have.length(1);
+			expect(resolvedTargetPaths).to.contain('.');
+		})
+	})
+
+	describe("resolveProjectDirPath Tests", async () => {
+		it("Specified relative projectdir", async () => {
+			const inputs: Inputs = {
+				projectdir: 'test/code-fixtures'
+			};
+			const resolvedProjectDir: string = inputProcessor.resolveProjectDirPath(inputs);
+			expect(resolvedProjectDir).to.equal(path.resolve('test/code-fixtures'))
+		})
+
+		it("Specified absolute projectdir", async () => {
+			const inputs: Inputs = {
+				projectdir: path.resolve('test/code-fixtures')
+			};
+			const resolvedProjectDir: string = inputProcessor.resolveProjectDirPath(inputs);
+			expect(resolvedProjectDir).to.equal(path.resolve('test/code-fixtures'))
+		})
+
+		it("Specified tildified projectdir", async () => {
+			const inputs: Inputs = {
+				projectdir: '~/someFolder'
+			};
+			const resolvedProjectDir: string = inputProcessor.resolveProjectDirPath(inputs);
+			expect(resolvedProjectDir).to.equal(untildify('~/someFolder'))
+		})
+
+		it("Unspecified projectdir and unspecified target", async() => {
+			const inputs: Inputs = {}
+			const resolvedProjectDir: string = inputProcessor.resolveProjectDirPath(inputs);
+			expect(resolvedProjectDir).to.equal(path.resolve('.'));
+		})
+
+		it("Unspecified projectdir with non-glob relative targets supplied", async () => {
+			const inputs: Inputs = {
+				target: ['test/code-fixtures/apex', 'test/catalog-fixtures/DefaultCatalogFixture.json']
+			};
+			const resolvedProjectDir: string = inputProcessor.resolveProjectDirPath(inputs);
+			expect(resolvedProjectDir).to.equal(path.resolve('test'));
+
+			expect(display.getOutputText()).to.equal('[VerboseInfo]: ' +
+				getMessage(BundleName.CommonRun, 'info.resolvedProjectDir', [path.resolve('test')]))
+		})
+
+		it("Unspecified projectdir with glob targets supplied (with sfdx-project.json in parents)", async () => {
+			const resolvedProjectDir: string = inputProcessor.resolveProjectDirPath({
+				target: ['test/**/*.page', '!test/code-fixtures/cpd']
+			});
+			// Note that test/code-fixtures/projects/app/force-app/main/default/pages is the first most common parent
+			// but test/code-fixtures/projects/app contains a sfdx-project.json and so we return this instead
+			expect(resolvedProjectDir).to.equal(path.resolve('test/code-fixtures/projects/app'));
+		})
+
+		it("Unspecified projectdir with glob targets supplied (with no sfdx-project.json in parents)", async () => {
+			const resolvedProjectDir: string = inputProcessor.resolveProjectDirPath({
+				target: ['test/code-fixtures/**/*.cls']
+			});
+			expect(resolvedProjectDir).to.equal(path.resolve('test/code-fixtures'));
+		})
+
+		it("Unspecified projectdir with target containing method specifiers", async () => {
+			const resolvedProjectDir: string = inputProcessor.resolveProjectDirPath({
+				target: [
+					'test/code-fixtures/apex/SomeTestClass.cls#testMethodWithoutAsserts',
+					'test/code-fixtures/apex/SomeOtherTestClass.cls#someTestMethodWithoutAsserts',
+				]
+			});
+			expect(resolvedProjectDir).to.equal(path.resolve('test/code-fixtures/apex'));
+		})
+
+		it("Unspecified projectdir with non-glob target that resolves to no files", async () => {
+			const inputs: Inputs = {
+				target: ['thisFileDoesNotExist.xml', 'thisFileAlsoDoesNotExist.json']
+			};
+			try {
+				inputProcessor.resolveProjectDirPath(inputs);
+				assert.fail("Expected error to be thrown")
+			} catch (e) {
+				expect(e.message).to.equal(getMessage(BundleName.CommonRun, 'validations.noFilesFoundInTarget'));
+			}
+		})
+
+		it("Unspecified projectdir with glob target that resolves to no files", async () => {
+			const inputs: Inputs = {
+				target: ['**.filesOfThisTypeShouldNotExist']
+			};
+			try {
+				inputProcessor.resolveProjectDirPath(inputs);
+				assert.fail("Expected error to be thrown")
+			} catch (e) {
+				expect(e.message).to.equal(getMessage(BundleName.CommonRun, 'validations.noFilesFoundInTarget'));
+			}
+		})
 	})
 })

--- a/test/lib/InputProcessor.test.ts
+++ b/test/lib/InputProcessor.test.ts
@@ -52,15 +52,15 @@ describe("InputProcessorImpl Tests", async () => {
 				projectdir: 'test/code-fixtures'
 			};
 			const resolvedProjectDir: string = inputProcessor.resolveProjectDirPath(inputs);
-			expect(resolvedProjectDir).to.equal(path.resolve('test/code-fixtures'))
+			expect(resolvedProjectDir).to.equal(toAbsPath('test/code-fixtures'))
 		})
 
 		it("Specified absolute projectdir", async () => {
 			const inputs: Inputs = {
-				projectdir: path.resolve('test/code-fixtures')
+				projectdir: toAbsPath('test/code-fixtures')
 			};
 			const resolvedProjectDir: string = inputProcessor.resolveProjectDirPath(inputs);
-			expect(resolvedProjectDir).to.equal(path.resolve('test/code-fixtures'))
+			expect(resolvedProjectDir).to.equal(toAbsPath('test/code-fixtures'))
 		})
 
 		it("Specified tildified projectdir", async () => {
@@ -68,13 +68,13 @@ describe("InputProcessorImpl Tests", async () => {
 				projectdir: '~/someFolder'
 			};
 			const resolvedProjectDir: string = inputProcessor.resolveProjectDirPath(inputs);
-			expect(resolvedProjectDir).to.equal(normalize(untildify('~/someFolder')))
+			expect(resolvedProjectDir).to.equal(toAbsPath(normalize(untildify('~/someFolder'))))
 		})
 
 		it("Unspecified projectdir and unspecified target", async() => {
 			const inputs: Inputs = {}
 			const resolvedProjectDir: string = inputProcessor.resolveProjectDirPath(inputs);
-			expect(resolvedProjectDir).to.equal(path.resolve('.'));
+			expect(resolvedProjectDir).to.equal(toAbsPath('.'));
 		})
 
 		it("Unspecified projectdir with non-glob relative targets supplied", async () => {
@@ -82,10 +82,10 @@ describe("InputProcessorImpl Tests", async () => {
 				target: ['test/code-fixtures/apex', 'test/catalog-fixtures/DefaultCatalogFixture.json']
 			};
 			const resolvedProjectDir: string = inputProcessor.resolveProjectDirPath(inputs);
-			expect(resolvedProjectDir).to.equal(path.resolve('test'));
+			expect(resolvedProjectDir).to.equal(toAbsPath('test'));
 
 			expect(display.getOutputText()).to.equal('[VerboseInfo]: ' +
-				getMessage(BundleName.CommonRun, 'info.resolvedProjectDir', [path.resolve('test')]))
+				getMessage(BundleName.CommonRun, 'info.resolvedProjectDir', [toAbsPath('test')]))
 		})
 
 		it("Unspecified projectdir with glob targets supplied (with sfdx-project.json in parents)", async () => {
@@ -94,14 +94,14 @@ describe("InputProcessorImpl Tests", async () => {
 			});
 			// Note that test/code-fixtures/projects/app/force-app/main/default/pages is the first most common parent
 			// but test/code-fixtures/projects/app contains a sfdx-project.json and so we return this instead
-			expect(resolvedProjectDir).to.equal(path.resolve('test/code-fixtures/projects/app'));
+			expect(resolvedProjectDir).to.equal(toAbsPath('test/code-fixtures/projects/app'));
 		})
 
 		it("Unspecified projectdir with glob targets supplied (with no sfdx-project.json in parents)", async () => {
 			const resolvedProjectDir: string = inputProcessor.resolveProjectDirPath({
 				target: ['test/code-fixtures/**/*.cls']
 			});
-			expect(resolvedProjectDir).to.equal(path.resolve('test/code-fixtures'));
+			expect(resolvedProjectDir).to.equal(toAbsPath('test/code-fixtures'));
 		})
 
 		it("Unspecified projectdir with target containing method specifiers", async () => {
@@ -111,7 +111,7 @@ describe("InputProcessorImpl Tests", async () => {
 					'test/code-fixtures/apex/SomeOtherTestClass.cls#someTestMethodWithoutAsserts',
 				]
 			});
-			expect(resolvedProjectDir).to.equal(path.resolve('test/code-fixtures/apex'));
+			expect(resolvedProjectDir).to.equal(toAbsPath('test/code-fixtures/apex'));
 		})
 
 		it("Unspecified projectdir with non-glob target that resolves to no files", async () => {
@@ -139,3 +139,7 @@ describe("InputProcessorImpl Tests", async () => {
 		})
 	})
 })
+
+function toAbsPath(fileOrFolder: string): string {
+	return path.resolve(fileOrFolder)
+}

--- a/test/lib/InputProcessor.test.ts
+++ b/test/lib/InputProcessor.test.ts
@@ -1,0 +1,11 @@
+import {InputProcessor, InputProcessorImpl} from "../../src/lib/InputProcessor";
+import {expect} from "chai";
+
+describe("InputProcessorImpl Tests", async () => {
+	it("Test that missing target resolves to current directory", async () => {
+		const inputProcessor: InputProcessor = new InputProcessorImpl("2.11.8")
+		const resolvedTargetPaths: string[] = inputProcessor.resolveTargetPaths({})
+		expect(resolvedTargetPaths).to.have.length(1)
+		expect(resolvedTargetPaths).to.contain('.')
+	})
+})

--- a/test/lib/sfge/SfgePathlessEngine.test.ts
+++ b/test/lib/sfge/SfgePathlessEngine.test.ts
@@ -4,7 +4,6 @@ import {SfgeConfig} from '../../../src/types';
 import {CUSTOM_CONFIG} from '../../../src/Constants';
 import {SfgePathlessEngine} from '../../../src/lib/sfge/SfgePathlessEngine';
 import * as TestOverrides from '../../test-related-lib/TestOverrides';
-import {BundleName, getMessage} from "../../../src/MessageCatalog";
 
 TestOverrides.initializeTestSetup();
 
@@ -66,52 +65,6 @@ describe('SfgePathlessEngine', () => {
 			const shouldEngineRun = engine.shouldEngineRun([], [], [], engineOptions);
 			// ==== ASSERTIONS ====
 			expect(shouldEngineRun).to.be.true;
-		});
-
-		it('Throws error when SfgeConfig has empty projectdir string', async () => {
-			// ==== SETUP ====
-			const engine = new SfgePathlessEngine();
-			await engine.init();
-			const sfgeConfig: SfgeConfig = {
-				projectDir: ''
-			};
-			const engineOptions: Map<string,string> = new Map();
-			engineOptions.set(CUSTOM_CONFIG.SfgeConfig, JSON.stringify(sfgeConfig));
-			// ==== TESTED METHOD ====
-			const invocationOfShouldEngineRun = () => {
-				// The only parameter that matters should be the engine options.
-				return engine.shouldEngineRun([], [], [], engineOptions);
-			};
-			// ==== ASSERTIONS ====
-			expect(invocationOfShouldEngineRun).to.throw(getMessage(BundleName.SfgeEngine, 'errors.failedWithoutProjectDir', []));
-		});
-
-		it('Throws error when SfgeConfig lacks projectdir string', async () => {
-			// ==== SETUP ====
-			const engine = new SfgePathlessEngine();
-			await engine.init();
-			const engineOptions: Map<string,string> = new Map();
-			engineOptions.set(CUSTOM_CONFIG.SfgeConfig, "{}");
-			// ==== TESTED METHOD ====
-			const invocationOfShouldEngineRun = () => {
-				// The only parameter that matters should be the engine options.
-				return engine.shouldEngineRun([], [], [], engineOptions);
-			};
-			// ==== ASSERTIONS ====
-			expect(invocationOfShouldEngineRun).to.throw(getMessage(BundleName.SfgeEngine, 'errors.failedWithoutProjectDir', []));
-		});
-
-		it('Throws error when SfgeConfig is outright absent', async () => {
-			// ==== SETUP ====
-			const engine = new SfgePathlessEngine();
-			await engine.init();
-			// ==== TESTED METHOD ====
-			const invocationOfShouldEngineRun = () => {
-				// The only parameter that matters should be the engine options.
-				return engine.shouldEngineRun([], [], [], new Map());
-			};
-			// ==== ASSERTIONS ====
-			expect(invocationOfShouldEngineRun).to.throw(getMessage(BundleName.SfgeEngine, 'errors.failedWithoutProjectDir', []));
 		});
 	});
 });

--- a/test/lib/sfge/SfgePathlessEngine.test.ts
+++ b/test/lib/sfge/SfgePathlessEngine.test.ts
@@ -52,12 +52,12 @@ describe('SfgePathlessEngine', () => {
 	});
 
 	describe('#shouldEngineRun()', () => {
-		it('Returns true when SfgeConfig has non-empty projectdirs array', async () => {
+		it('Returns true when SfgeConfig has non-empty projectdir string', async () => {
 			// ==== SETUP ====
 			const engine = new SfgePathlessEngine();
 			await engine.init();
 			const sfgeConfig: SfgeConfig = {
-				projectDirs: ['specific/value/is/irrelevant']
+				projectDir: 'specific/value/is/irrelevant'
 			};
 			const engineOptions: Map<string,string> = new Map();
 			engineOptions.set(CUSTOM_CONFIG.SfgeConfig, JSON.stringify(sfgeConfig));
@@ -68,12 +68,12 @@ describe('SfgePathlessEngine', () => {
 			expect(shouldEngineRun).to.be.true;
 		});
 
-		it('Throws error when SfgeConfig has empty projectdirs array', async () => {
+		it('Throws error when SfgeConfig has empty projectdir string', async () => {
 			// ==== SETUP ====
 			const engine = new SfgePathlessEngine();
 			await engine.init();
 			const sfgeConfig: SfgeConfig = {
-				projectDirs: []
+				projectDir: ''
 			};
 			const engineOptions: Map<string,string> = new Map();
 			engineOptions.set(CUSTOM_CONFIG.SfgeConfig, JSON.stringify(sfgeConfig));
@@ -86,7 +86,7 @@ describe('SfgePathlessEngine', () => {
 			expect(invocationOfShouldEngineRun).to.throw(getMessage(BundleName.SfgeEngine, 'errors.failedWithoutProjectDir', []));
 		});
 
-		it('Throws error when SfgeConfig lacks projectdirs array', async () => {
+		it('Throws error when SfgeConfig lacks projectdir string', async () => {
 			// ==== SETUP ====
 			const engine = new SfgePathlessEngine();
 			await engine.init();


### PR DESCRIPTION
In this change:
* The --target flag is no longer required. The default value is "." (i.e. the current working directory)
* The --projectdir flag is no longer required. The default value is automatically calculated to be a folder that contains all of the target files. More specifically, we attempt to find the salesforce project directory that contains the sfdx-project.json file. Otherwise, we use the first common parent of all target files.
* If --projectdir is not specified, then users can turn on --verbose to see an echo of which project directory was calculated.
* The ability to supply a list of directories to projectdir has been removed. We have never documented this ability anyway and so until we hear about a valid use case for supplying more than one, a scalar it will now need to be.