### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/production-heartbeat.yml
+++ b/.github/workflows/production-heartbeat.yml
@@ -64,9 +64,9 @@ jobs:
         # If the first attempt fails, wait a minute and try again. After a second failure, wait 5 minutes then try again. Then give up.
         # Set an output parameter, `retry_count`, indicating the number of retry attempts that were made.
         run: |
-          (echo "retry_count=0" >> $GITHUB_OUTPUT && npm install -g @salesforce/cli${{ env.CLI_VERSION }}) ||
-          (echo "retry_count=1" >> $GITHUB_OUTPUT && sleep 60 && npm install -g @salesforce/cli${{ env.CLI_VERSION }}) ||
-          (echo "retry_count=2" >> $GITHUB_OUTPUT && sleep 300 && npm install -g @salesforce/cli${{ env.CLI_VERSION }})
+          (echo "retry_count=0" >> "$GITHUB_OUTPUT" && npm install -g @salesforce/cli${{ env.CLI_VERSION }}) ||
+          (echo "retry_count=1" >> "$GITHUB_OUTPUT" && sleep 60 && npm install -g @salesforce/cli${{ env.CLI_VERSION }}) ||
+          (echo "retry_count=2" >> "$GITHUB_OUTPUT" && sleep 300 && npm install -g @salesforce/cli${{ env.CLI_VERSION }})
 
       # === Make three attempts to install the scanner plugin through sf ===
       - name: Install Scanner Plugin
@@ -74,9 +74,9 @@ jobs:
         # If the first attempt fails, wait a minute and try again. After a second failure, wait 5 minutes then try again. Then give up.
         # Set an output parameter, `retry_count`, indicating the number of retry attempts that were made.
         run: |
-          (echo "retry_count=0" >> $GITHUB_OUTPUT && sf plugins install @salesforce/sfdx-scanner${{ env.SCANNER_VERSION }}) ||
-          (echo "retry_count=1" >> $GITHUB_OUTPUT && sleep 60 && sf plugins install @salesforce/sfdx-scanner${{ env.SCANNER_VERSION }}) ||
-          (echo "retry_count=2" >> $GITHUB_OUTPUT && sleep 300 && sf plugins install @salesforce/sfdx-scanner${{ env.SCANNER_VERSION }})
+          (echo "retry_count=0" >> "$GITHUB_OUTPUT" && sf plugins install @salesforce/sfdx-scanner${{ env.SCANNER_VERSION }}) ||
+          (echo "retry_count=1" >> "$GITHUB_OUTPUT" && sleep 60 && sf plugins install @salesforce/sfdx-scanner${{ env.SCANNER_VERSION }}) ||
+          (echo "retry_count=2" >> "$GITHUB_OUTPUT" && sleep 300 && sf plugins install @salesforce/sfdx-scanner${{ env.SCANNER_VERSION }})
 
       # === Log the installed plugins for easier debugging ===
       - name: Log plugins

--- a/.github/workflows/production-heartbeat.yml
+++ b/.github/workflows/production-heartbeat.yml
@@ -64,9 +64,9 @@ jobs:
         # If the first attempt fails, wait a minute and try again. After a second failure, wait 5 minutes then try again. Then give up.
         # Set an output parameter, `retry_count`, indicating the number of retry attempts that were made.
         run: |
-          (echo "::set-output name=retry_count::0" && npm install -g @salesforce/cli${{ env.CLI_VERSION }}) ||
-          (echo "::set-output name=retry_count::1" && sleep 60 && npm install -g @salesforce/cli${{ env.CLI_VERSION }}) ||
-          (echo "::set-output name=retry_count::2" && sleep 300 && npm install -g @salesforce/cli${{ env.CLI_VERSION }})
+          (echo "retry_count=0" >> $GITHUB_OUTPUT && npm install -g @salesforce/cli${{ env.CLI_VERSION }}) ||
+          (echo "retry_count=1" >> $GITHUB_OUTPUT && sleep 60 && npm install -g @salesforce/cli${{ env.CLI_VERSION }}) ||
+          (echo "retry_count=2" >> $GITHUB_OUTPUT && sleep 300 && npm install -g @salesforce/cli${{ env.CLI_VERSION }})
 
       # === Make three attempts to install the scanner plugin through sf ===
       - name: Install Scanner Plugin
@@ -74,9 +74,9 @@ jobs:
         # If the first attempt fails, wait a minute and try again. After a second failure, wait 5 minutes then try again. Then give up.
         # Set an output parameter, `retry_count`, indicating the number of retry attempts that were made.
         run: |
-          (echo "::set-output name=retry_count::0" && sf plugins install @salesforce/sfdx-scanner${{ env.SCANNER_VERSION }}) ||
-          (echo "::set-output name=retry_count::1" && sleep 60 && sf plugins install @salesforce/sfdx-scanner${{ env.SCANNER_VERSION }}) ||
-          (echo "::set-output name=retry_count::2" && sleep 300 && sf plugins install @salesforce/sfdx-scanner${{ env.SCANNER_VERSION }})
+          (echo "retry_count=0" >> $GITHUB_OUTPUT && sf plugins install @salesforce/sfdx-scanner${{ env.SCANNER_VERSION }}) ||
+          (echo "retry_count=1" >> $GITHUB_OUTPUT && sleep 60 && sf plugins install @salesforce/sfdx-scanner${{ env.SCANNER_VERSION }}) ||
+          (echo "retry_count=2" >> $GITHUB_OUTPUT && sleep 300 && sf plugins install @salesforce/sfdx-scanner${{ env.SCANNER_VERSION }})
 
       # === Log the installed plugins for easier debugging ===
       - name: Log plugins

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -19,13 +19,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: 'release'
-      - run: echo "COMMIT_ID=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+      - run: echo "COMMIT_ID=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
         id: get-branch-commit
       # Checkout the tag we want to release, and get its head commit as output for later.
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.release.tag_name || inputs.tag }}
-      - run: echo "COMMIT_ID=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+      - run: echo "COMMIT_ID=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
         id: get-tag-commit
       # If the two commits aren't identical, the tag isn't eligible for release.
       - name: Fail non-matching commits


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter