### PR TITLE
Edit MD and TS files associated with "scanner run dfa" so they adhere to our CLI standards for --help

### DIFF
--- a/messages/run-dfa.md
+++ b/messages/run-dfa.md
@@ -1,67 +1,50 @@
 # commandSummary
 
-scan codebase with all DFA rules
+Scan codebase with all DFA rules by default.
 
 # commandDescription
 
-Scans codebase with all DFA rules by default.
-	Specify the format of output and print results directly or as contents of a file that you provide with --outfile flag.
+Specify the format of output and print results directly or as contents of a file that you provide with --outfile flag.
 
 # flags.pathexplimitSummary
 
-specify a path expansion  upper boundary to limit the complexity of code that Graph Engine analyzes. Alternatively, set the value using environment variable `SFGE_PATH_EXPANSION_LIMIT`
+Path expansion upper boundary to limit the complexity of code that Graph Engine analyzes before failing test. Inherits its value from the "SFGE_PATH_EXPANSION_LIMIT" environment variable, if set.
 
 # flags.pathexplimitDescription
 
-Specifies a path expansion upper boundary to limit the complexity of code Graph Engine analyzes before failing fast. Set the value to -1 to remove any upper boundary. --pathexplimit inherits value from SFGE_PATH_EXPANSION_LIMIT env-var, if set. Its default value is derived from JVM heap space allocation.
+Set the value to -1 to remove any upper boundary. Its default value is derived from JVM heap space allocation.
 
 # flags.ruledisablewarningviolationSummary
 
-disable warning violations from Salesforce Graph Engine. Alternatively, set value using environment variable `SFGE_RULE_DISABLE_WARNING_VIOLATION`
+Disable warning violations from Salesforce Graph Engine. Inherits its value from the "SFGE_RULE_DISABLE_WARNING_VIOLATION" environment variable, if set.
 
 # flags.ruledisablewarningviolationDescription
 
-Disables warning violations, such as those on StripInaccessible READ access, to get only high-severity violations (default: false). Inherits value from SFGE_RULE_DISABLE_WARNING_VIOLATION env-var if set.
+Examples of warning violations include those on StripInaccessible READ access, to get only high-severity violations (default: false).
 
 # flags.rulethreadcountSummary
 
-specify number of threads that evaluate DFA rules. Alternatively, set value using environment variable `SFGE_RULE_THREAD_COUNT`. Default is 4
-
-# flags.rulethreadcountDescription
-
-Specifies the number of rule-evaluation threads or how many entry points can be evaluated concurrently. Inherits its value from the SFGE_RULE_THREAD_COUNT environment variable, if set. The default is 4.
+Number of DFA rule-evaluation threads or how many entry points can be evaluated concurrently. Inherits its value from the "SFGE_RULE_THREAD_COUNT" environment variable, if set.
 
 # flags.rulethreadtimeoutSummary
 
-specify timeout for individual rule threads in milliseconds. Alternatively, set the timeout value using environment variable `SFGE_RULE_THREAD_TIMEOUT`. Default: 900000 ms
-
-# flags.rulethreadtimeoutDescription
-
-Specifies the time limit for evaluating a single entry point in milliseconds. Inherits its value from the SFGE_RULE_THREAD_TIMEOUT environment variable, if set. The default is 900,000 ms or 15 minutes.
+Time limt, in milliseconds, for evaluating a single entry point for individual rule threads. Inherits its value from the "SFGE_RULE_THREAD_TIMEOUT" environment variable, if set.
 
 # flags.sfgejvmargsSummary
 
-specify Java Virtual Machine (JVM) arguments to optimize Salesforce Graph Engine execution to your system (optional)
-
-# flags.sfgejvmargsDescription
-
-Specifies Java Virtual Machine arguments to override system defaults while executing Salesforce Graph Engine. For multiple arguments, add them to the same string separated by space.
+Java Virtual Machine (JVM) arguments to override system defaults while executing Salesforce Graph Engine; separate multiple arguments by a space.
 
 # flags.targetSummary
 
-source code location
+Source code location.
 
 # flags.targetDescription
 
-Specifies the source code location. Use glob patterns or specify individual methods with #-syntax. Multiple values are specified as a comma-separated list. Default is ".".
+Use glob patterns or specify individual methods with #-syntax. Multiple values are specified as a comma-separated list.
 
 # flags.withpilotSummary
 
-allow pilot rules to execute
-
-# flags.withpilotDescription
-
-Allows pilot rules to execute.
+Allow pilot rules to execute.
 
 # validations.methodLevelTargetCannotBeGlob
 
@@ -73,30 +56,48 @@ Method-level target %s must be a real file
 
 # examples
 
-The paths specified for --projectdir must contain all files specified through --target cumulatively.
-	$ <%= config.bin %> <%= command.id %> --target "./myproject/main/default/classes/*.cls" --projectdir "./myproject/"
-	$ <%= config.bin %> <%= command.id %> --target "./**/*.cls" --projectdir "./"
-	$ <%= config.bin %> <%= command.id %> --target "./dir1/file1.cls,./dir2/file2.cls" --projectdir "./dir1/,./dir2/"
-This example fails because the set of files included in --target is larger than that contained in --projectdir:
-	$ <%= config.bin %> <%= command.id %> --target "./**/*.cls" --projectdir "./myproject/"
-Globs must be wrapped in quotes, as in these Windows and Unix examples, which evaluate rules against all .cls files in the current directory and subdirectories except for IgnoreMe.cls:
-Unix example:
-	$ <%= config.bin %> <%= command.id %> --target "./**/*.cls,!./**/IgnoreMe.cls" ...
-Windows example:
-	$ <%= config.bin %> <%= command.id %> --target ".\**\*.cls,!.\**\IgnoreMe.cls" ...
-You can target individual methods within a file with a suffix hash (#) on the file's path, and with a semi-colon-delimited list of method names. This syntax is incompatible with globs and directories. This example evaluates rules against all methods named Method1 or Method2 in File1.cls, and all methods named Method3 in File2.cls:
-	$ <%= config.bin %> <%= command.id %> --target "./File1.cls#Method1;Method2,./File2.cls#Method3" ...
-Use --normalize-severity to output a normalized severity across all engines, in addition to the engine-specific severity. Normalized severity is 1 (high), 2 (moderate), and 3 (low):
-	$ <%= config.bin %> <%= command.id %> --target "./some-project/" --projectdir "./some-project/" --format csv --normalize-severity
-Use --severity-threshold to throw a non-zero exit code when rule violations of a specific normalized severity or greater are found. If there are any rule violations with a severity of 2 or 1, the exit code is equal to the severity of the most severe violation:
-	$ <%= config.bin %> <%= command.id %> --target "./some-project/" --projectdir "./some-project/" --severity-threshold 2
-use --rule-thread-count to allow more (or fewer) entrypoints to be evaluated concurrently:
-	$ <%= config.bin %> <%= command.id %> --rule-thread-count 6 ...
-Use --rule-thread-timeout to increase or decrease the maximum runtime for a single entrypoint evaluation. This increases the timeout from the 15-minute default to 150 minutes:
-	$ <%= config.bin %> <%= command.id %> --rule-thread-timeout 9000000 ...
-Use --sfgejvmargs to pass Java Virtual Machine args to override system defaults while executing Salesforce Graph Engine's rules.
-The example overrides the system's default heap space allocation to 8 GB and decreases chances of encountering OutOfMemory error.
-	$ <%= config.bin %> <%= command.id %> --sfgejvmargs "-Xmx8g" ...
-Use --with-pilot to allow execution of pilot rules:
-This example allows pilot rules in the "Performance" category to execute.
-	$ <%= config.bin %> <%= command.id %> --category 'Performance' --with-pilot ...
+- These examples show how the paths specified for --projectdir must contain all files specified through --target cumulatively:
+
+  <%= config.bin %> <%= command.id %> --target "./myproject/main/default/classes/*.cls" --projectdir "./myproject/"
+  <%= config.bin %> <%= command.id %> --target "./**/*.cls" --projectdir "./"
+  <%= config.bin %> <%= command.id %> --target "./dir1/file1.cls,./dir2/file2.cls" --projectdir "./dir1/,./dir2/"
+
+- This example fails because the set of files included in --target is larger than that contained in --projectdir:
+
+  <%= config.bin %> <%= command.id %> --target "./**/*.cls" --projectdir "./myproject/"
+
+- Globs must be wrapped in quotes, as in these Windows and Unix examples, which evaluate rules against all .cls files in the current directory and subdirectories except for IgnoreMe.cls. Unix example:
+
+  <%= config.bin %> <%= command.id %> --target "./**/*.cls,!./**/IgnoreMe.cls" ...
+
+- Windows example:
+
+  <%= config.bin %> <%= command.id %> --target ".\**\*.cls,!.\**\IgnoreMe.cls" ...
+
+- You can target individual methods within a file with a suffix hash (#) on the file's path, and with a semi-colon-delimited list of method names. This syntax is incompatible with globs and directories. This example evaluates rules against all methods named Method1 or Method2 in File1.cls, and all methods named Method3 in File2.cls:
+
+  <%= config.bin %> <%= command.id %> --target "./File1.cls#Method1;Method2,./File2.cls#Method3" ...
+
+- Use --normalize-severity to output a normalized severity across all engines, in addition to the engine-specific severity. Normalized severity is 1 (high), 2 (moderate), and 3 (low):
+
+  <%= config.bin %> <%= command.id %> --target "./some-project/" --projectdir "./some-project/" --format csv --normalize-severity
+
+- Use --severity-threshold to throw a non-zero exit code when rule violations of a specific normalized severity or greater are found. If there are any rule violations with a severity of 2 or 1, the exit code is equal to the severity of the most severe violation:
+
+  <%= config.bin %> <%= command.id %> --target "./some-project/" --projectdir "./some-project/" --severity-threshold 2
+
+- Use --rule-thread-count to allow more (or fewer) entrypoints to be evaluated concurrently:
+
+  <%= config.bin %> <%= command.id %> --rule-thread-count 6 ...
+
+- Use --rule-thread-timeout to increase or decrease the maximum runtime for a single entrypoint evaluation. This increases the timeout from the 15-minute default to 150 minutes:
+
+  <%= config.bin %> <%= command.id %> --rule-thread-timeout 9000000 ...
+
+- Use --sfgejvmargs to pass Java Virtual Machine args to override system defaults while executing Salesforce Graph Engine's rules.  The example overrides the system's default heap space allocation to 8 GB and decreases chances of encountering OutOfMemory error.
+
+  <%= config.bin %> <%= command.id %> --sfgejvmargs "-Xmx8g" ...
+
+- Use --with-pilot to allow execution of pilot rules.  This example allows pilot rules in the "Performance" category to execute.
+
+  <%= config.bin %> <%= command.id %> --category 'Performance' --with-pilot ...

--- a/package.json
+++ b/package.json
@@ -108,10 +108,13 @@
 		"bin": "sf",
 		"topics": {
 			"scanner": {
-				"description": "scan code to detect code quality issues and security vulnerabilities",
+				"description": "Scan code to detect code quality issues and security vulnerabilities.",
 				"subtopics": {
 					"rule": {
-						"description": "view or add rules to scan code"
+						"description": "View or add rules to scan code."
+					},
+					"run": {
+						"description": "Scan code."
 					}
 				}
 			},

--- a/src/commands/scanner/run/dfa.ts
+++ b/src/commands/scanner/run/dfa.ts
@@ -49,7 +49,6 @@ export default class Dfa extends ScannerRunCommand {
 		// BEGIN: Config-overrideable engine flags.
 		'rule-thread-count': Flags.integer({
 			summary: getMessage(BundleName.RunDfa, 'flags.rulethreadcountSummary'),
-			description: getMessage(BundleName.RunDfa, 'flags.rulethreadcountDescription'),
 			default: 4,
 			env: 'SFGE_RULE_THREAD_COUNT'
 		}),

--- a/src/commands/scanner/run/dfa.ts
+++ b/src/commands/scanner/run/dfa.ts
@@ -31,8 +31,7 @@ export default class Dfa extends ScannerRunCommand {
 		...ScannerRunCommand.flags,
 		// BEGIN: Filter-related flags.
 		'with-pilot': Flags.boolean({
-			summary: getMessage(BundleName.RunDfa, 'flags.withpilotSummary'),
-			description: getMessage(BundleName.RunDfa, 'flags.withpilotDescription')
+			summary: getMessage(BundleName.RunDfa, 'flags.withpilotSummary')
 		}),
 		// END: Filter-related flags.
 		// BEGIN: Flags for targeting files.
@@ -43,6 +42,7 @@ export default class Dfa extends ScannerRunCommand {
 			summary: getMessage(BundleName.RunDfa, 'flags.targetSummary'),
 			description: getMessage(BundleName.RunDfa, 'flags.targetDescription'),
 			delimiter: ',',
+			default: '.',
 			multiple: true
 		})(),
 		// END: Flags for targeting files.
@@ -50,11 +50,12 @@ export default class Dfa extends ScannerRunCommand {
 		'rule-thread-count': Flags.integer({
 			summary: getMessage(BundleName.RunDfa, 'flags.rulethreadcountSummary'),
 			description: getMessage(BundleName.RunDfa, 'flags.rulethreadcountDescription'),
+			default: 4,
 			env: 'SFGE_RULE_THREAD_COUNT'
 		}),
 		'rule-thread-timeout': Flags.integer({
 			summary: getMessage(BundleName.RunDfa, 'flags.rulethreadtimeoutSummary'),
-			description: getMessage(BundleName.RunDfa, 'flags.rulethreadtimeoutDescription'),
+			default: 90000,
 			env: 'SFGE_RULE_THREAD_TIMEOUT'
 		}),
 		// NOTE: This flag can't use the `env` property to inherit a value automatically, because OCLIF boolean flags
@@ -65,7 +66,6 @@ export default class Dfa extends ScannerRunCommand {
 		}),
 		'sfgejvmargs': Flags.string({
 			summary: getMessage(BundleName.RunDfa, 'flags.sfgejvmargsSummary'),
-			description: getMessage(BundleName.RunDfa, 'flags.sfgejvmargsDescription'),
 			env: 'SFGE_JVM_ARGS'
 		}),
 		'pathexplimit': Flags.integer({


### PR DESCRIPTION
Hi @stephen-carter-at-sf  and @teresa-allen-sfdc .

I put my suggestions in a PR off a fork, but no need to actually _merge_ my PR -- I did it this way just because I thought it was easier to share my suggestions.

note that I did a _bit_ of editing, but I didn't catch everything -- I mostly wanted to show the high-level suggestions rather than do a full edit for language/grammar/punctuation, etc. Teresa can help you with that.

Here's what I did:

- Added some default flag values in their TS definition so they're automatically outputted in help and aren't hard-coded in the MD file.
- Removed duplicate content in the command summary that was also the command description. Not duplicating content makes the help shorter and easier to read.
- Similarly *removed* some flag descriptions if they simply repeated the summary. I reworked the summary to include stuff in the desc when necessary, but it's just an example. Only add a flag description if there's more to say, but it doesn't fit nicely in the top flag summary.
- Did some formatting work in the examples. But I couldn't get the --help output to put newlines between each example, which is what the core command help does.  Not sure what the problem is, but I reached the limit of my troubleshooting so will let you investigate 😀
- Updated the "package.json" file to use correct style and add the "run" sub-topic.

The generated DITA for this command is now correct, and I can successfully include it in the full CLI Reference without manual fixes. See [this link](https://sfciteam.sfci.buildndeliver-s.aws-esvc1-useast2.aws.sfdc.cl/ccx-public-pipelines/job/remote-build-pipeline/4850/artifact/output/cli_reference.ditamap/en/devdocportal/en/content/en-us/248.0/sfdx_cli_reference/cli_reference_scanner_commands_unified.htm#cli_reference_scanner_commands_unified) for an example.  Our internal doc builds have worse formatting than the public one, but at least you can see your command is now consistent with the core command reference.

I tried to fix the examples for "scanner run" too, but I couldn't get them to work.  I don't know why, so I leave that up to you to figure out! In general, all the command Markdown files should follow the style that's in the run-dfa.md file.

Let me know if you have questions!