### PR TITLE
CHANGE (CodeAnalyzer): @W-14645433@: Fixed some broken tests.

### DIFF
--- a/test/lib/InputProcessor.test.ts
+++ b/test/lib/InputProcessor.test.ts
@@ -1,5 +1,5 @@
 import {InputProcessor, InputProcessorImpl} from "../../src/lib/InputProcessor";
-import {assert, expect} from "chai";
+import {expect} from "chai";
 import * as path from "path";
 import {Inputs} from "../../src/types";
 import {BundleName, getMessage} from "../../src/MessageCatalog";
@@ -129,24 +129,34 @@ describe("InputProcessorImpl Tests", async () => {
 			const inputs: Inputs = {
 				target: ['thisFileDoesNotExist.xml', 'thisFileAlsoDoesNotExist.json']
 			};
+			let errorThrown: boolean;
+			let message: string;
 			try {
 				inputProcessor.resolveProjectDirPaths(inputs);
-				assert.fail("Expected error to be thrown")
+				errorThrown = false;
 			} catch (e) {
-				expect(e.message).to.equal(getMessage(BundleName.CommonRun, 'validations.noFilesFoundInTarget'));
+				errorThrown = true;
+				message = e.message;
 			}
+			expect(errorThrown).to.equal(true, 'Error should have been thrown');
+			expect(message).to.equal(getMessage(BundleName.CommonRun, 'validations.noFilesFoundInTarget'));
 		})
 
 		it("Unspecified projectdir with glob target that resolves to no files", async () => {
 			const inputs: Inputs = {
 				target: ['**.filesOfThisTypeShouldNotExist']
 			};
+			let errorThrown: boolean;
+			let message: string;
 			try {
 				inputProcessor.resolveProjectDirPaths(inputs);
-				assert.fail("Expected error to be thrown")
+				errorThrown = false;
 			} catch (e) {
-				expect(e.message).to.equal(getMessage(BundleName.CommonRun, 'validations.noFilesFoundInTarget'));
+				errorThrown = true;
+				message = e.message;
 			}
+			expect(errorThrown).to.equal(true, 'Error should have been thrown');
+			expect(message).to.equal(getMessage(BundleName.CommonRun, 'validations.noFilesFoundInTarget'));
 		})
 	})
 })

--- a/test/lib/JreSetupManager.test.ts
+++ b/test/lib/JreSetupManager.test.ts
@@ -1,4 +1,4 @@
-import {assert, expect} from 'chai';
+import {expect} from 'chai';
 import {FileHandler} from '../../src/lib/util/FileHandler';
 import {Config} from '../../src/lib/util/Config';
 import Sinon = require('sinon');
@@ -196,13 +196,19 @@ describe('JreSetupManager #verifyJreSetup', () => {
 			const statStub = Sinon.stub(FileHandler.prototype, 'stats').throws(error);
 
 			// Execute and verify
+			let errorThrown: boolean;
+			let errName: string;
 			try {
 				await verifyJreSetup();
-				assert.fail('Should have failed');
+				errorThrown = false;
 			} catch (err) {
-				expect(err.name).equals('InvalidJavaHome');
-				expect(uniqueWarningCounter).to.equal(0);
+				errorThrown = true;
+				errName = err.name;
 			}
+			expect(errorThrown).to.equal(true, 'Should have failed');
+			expect(errName).equals('InvalidJavaHome');
+			expect(uniqueWarningCounter).to.equal(0);
+
 
 			configGetJavaHomeStub.restore();
 			statStub.restore();
@@ -216,13 +222,19 @@ describe('JreSetupManager #verifyJreSetup', () => {
 			const execStub = Sinon.stub(childProcess, 'execFile').yields(noError, emptyStdout, invalidVersion);
 
 			// Execute and verify
+			let errorThrown: boolean;
+			let errName: string;
 			try {
 				await verifyJreSetup();
-				assert.fail('Should have failed');
+				errorThrown = false;
 			} catch (err) {
-				expect(err.name).equals('InvalidVersion');
-				expect(uniqueWarningCounter).to.equal(0);
+				errorThrown = true;
+				errName = err.name;
 			}
+			expect(errorThrown).to.equal(true, 'Should have failed');
+			expect(errName).equals('InvalidVersion');
+			expect(uniqueWarningCounter).to.equal(0);
+
 
 			configGetJavaHomeStub.restore();
 			statStub.restore();

--- a/test/lib/actions/RuleAddAction.test.ts
+++ b/test/lib/actions/RuleAddAction.test.ts
@@ -1,5 +1,5 @@
 import {Logger} from '@salesforce/core';
-import {assert, expect} from 'chai';
+import {expect} from 'chai';
 import sinon = require('sinon');
 import path = require('path');
 import untildify = require('untildify');
@@ -68,12 +68,17 @@ describe('RuleAddAction', () => {
 				path: ['this/does/not/matter']
 			};
 
+			let errorThrown: boolean;
+			let message: string;
 			try {
 				await testAction.validateInputs(inputs);
-				assert.fail('Exception should have been thrown');
+				errorThrown = false;
 			} catch (e) {
-				expect(e.message).to.equal(getMessage(BundleName.Add, 'validations.languageCannotBeEmpty', []));
+				errorThrown = true;
+				message = e.message;
 			}
+			expect(errorThrown).to.equal(true, 'Error should be thrown');
+			expect(message).to.equal(getMessage(BundleName.Add, 'validations.languageCannotBeEmpty', []));
 		});
 
 		it('Rejects empty `.language` property', async () => {
@@ -82,12 +87,17 @@ describe('RuleAddAction', () => {
 				path: ['this/does/not/matter']
 			};
 
+			let errorThrown: boolean;
+			let message: string;
 			try {
 				await testAction.validateInputs(inputs);
-				assert.fail('Exception should have been thrown');
+				errorThrown = false;
 			} catch (e) {
-				expect(e.message).to.equal(getMessage(BundleName.Add, 'validations.languageCannotBeEmpty', []));
+				errorThrown = true;
+				message = e.message;
 			}
+			expect(errorThrown).to.equal(true, 'Error should be thrown');
+			expect(message).to.equal(getMessage(BundleName.Add, 'validations.languageCannotBeEmpty', []));
 		});
 
 		it('Rejects missing `.path` property', async () => {
@@ -95,12 +105,17 @@ describe('RuleAddAction', () => {
 				language: 'apex'
 			};
 
+			let errorThrown: boolean;
+			let message: string;
 			try {
 				await testAction.validateInputs(inputs);
-				assert.fail('Exception should have been thrown');
+				errorThrown = false;
 			} catch (e) {
-				expect(e.message).to.equal(getMessage(BundleName.Add, 'validations.pathCannotBeEmpty', []));
+				errorThrown = true;
+				message = e.message;
 			}
+			expect(errorThrown).to.equal(true, 'Error should be thrown');
+			expect(message).to.equal(getMessage(BundleName.Add, 'validations.pathCannotBeEmpty', []));
 		});
 
 		it('Rejects empty `.path` property', async () => {
@@ -109,12 +124,17 @@ describe('RuleAddAction', () => {
 				path: []
 			};
 
+			let errorThrown: boolean;
+			let message: string;
 			try {
 				await testAction.validateInputs(inputs);
-				assert.fail('Exception should have been thrown');
+				errorThrown = false;
 			} catch (e) {
-				expect(e.message).to.equal(getMessage(BundleName.Add, 'validations.pathCannotBeEmpty', []));
+				errorThrown = true;
+				message = e.message;
 			}
+			expect(errorThrown).to.equal(true, 'Error should be thrown');
+			expect(message).to.equal(getMessage(BundleName.Add, 'validations.pathCannotBeEmpty', []));
 		});
 
 		it('Rejects `.path` containing empty string', async () => {
@@ -123,12 +143,17 @@ describe('RuleAddAction', () => {
 				path: [""]
 			}
 
+			let errorThrown: boolean;
+			let message: string;
 			try {
 				await testAction.validateInputs(inputs);
-				assert.fail('Exception should have been thrown');
+				errorThrown = false;
 			} catch (e) {
-				expect(e.message).to.equal(getMessage(BundleName.Add, 'validations.pathCannotBeEmpty', []));
+				errorThrown = true;
+				message = e.message;
 			}
+			expect(errorThrown).to.equal(true, 'Error should be thrown');
+			expect(message).to.equal(getMessage(BundleName.Add, 'validations.pathCannotBeEmpty', []));
 		});
 	});
 

--- a/test/lib/actions/RuleRemoveAction.test.ts
+++ b/test/lib/actions/RuleRemoveAction.test.ts
@@ -1,5 +1,5 @@
 import {Logger} from '@salesforce/core';
-import {assert, expect} from 'chai';
+import {expect} from 'chai';
 import {FileHandler} from '../../../src/lib/util/FileHandler';
 import sinon = require('sinon');
 import path = require('path');
@@ -34,12 +34,17 @@ describe('RuleRemoveAction', () => {
 				path: []
 			};
 
+			let errorThrown: boolean;
+			let message: string;
 			try {
 				await testAction.validateInputs(inputs);
-				assert.fail('Exception should have been thrown');
+				errorThrown = false;
 			} catch (e) {
-				expect(e.message).to.equal(getMessage(BundleName.Remove, 'validations.pathCannotBeEmpty', []));
+				errorThrown = true;
+				message = e.message;
 			}
+			expect(errorThrown).to.equal(true, 'Error should have been thrown');
+			expect(message).to.equal(getMessage(BundleName.Remove, 'validations.pathCannotBeEmpty', []));
 		});
 
 		it('rejects `.path` containing empty string', async () => {
@@ -47,12 +52,17 @@ describe('RuleRemoveAction', () => {
 				path: ['']
 			};
 
+			let errorThrown: boolean;
+			let message: string;
 			try {
 				await testAction.validateInputs(inputs);
-				assert.fail('Exception should have been thrown');
+				errorThrown = false;
 			} catch (e) {
-				expect(e.message).to.equal(getMessage(BundleName.Remove, 'validations.pathCannotBeEmpty', []));
+				errorThrown = true;
+				message = e.message;
 			}
+			expect(errorThrown).to.equal(true, 'Error should have been thrown');
+			expect(message).to.equal(getMessage(BundleName.Remove, 'validations.pathCannotBeEmpty', []));
 		});
 	});
 
@@ -97,13 +107,19 @@ describe('RuleRemoveAction', () => {
 				const inputs: Inputs = {
 					path: [FAKE_PATH_1]
 				};
+				let errorThrown: boolean;
+				let message: string;
 				try {
 					await testAction.run(inputs);
-					assert.fail('Error should have been thrown');
+					errorThrown = false;
 				} catch (e) {
-					// ==== ASSERTIONS ====
-					expect(e.message).to.equal(getMessage(BundleName.Remove, 'errors.noMatchingPaths'));
+					errorThrown = true;
+					message = e.message;
 				}
+
+				// ==== ASSERTIONS ====
+				expect(errorThrown).to.equal(true, 'Error should have been thrown');
+				expect(message).to.equal(getMessage(BundleName.Remove, 'errors.noMatchingPaths'));
 			});
 		});
 
@@ -188,12 +204,17 @@ describe('RuleRemoveAction', () => {
 					const inputs = {
 						path: [FAKE_PATH_4]
 					};
+					let errorThrown: boolean;
+					let message: string;
 					try {
 						await testAction.run(inputs);
-						assert.fail('Error should have thrown');
+						errorThrown = false;
 					} catch (e) {
-						expect(e.message).to.equal(getMessage(BundleName.Remove, 'errors.noMatchingPaths', []));
+						errorThrown = true;
+						message = e.message;
 					}
+					expect(errorThrown).to.equal(true, 'Error should have been thrown');
+					expect(message).to.equal(getMessage(BundleName.Remove, 'errors.noMatchingPaths', []));
 				});
 
 				it('Test Case: Action can be aborted during confirmation prompt', async () => {
@@ -246,12 +267,17 @@ describe('RuleRemoveAction', () => {
 						path: [FAKE_PATH_4],
 						force: true
 					};
+					let errorThrown: boolean;
+					let message: string;
 					try {
 						await testAction.run(inputs);
-						assert.fail('Error should have thrown');
+						errorThrown = false;
 					} catch (e) {
-						expect(e.message).to.equal(getMessage(BundleName.Remove, 'errors.noMatchingPaths', []));
+						errorThrown = true;
+						message = e.message;
 					}
+					expect(errorThrown).to.equal(true, 'Error should have been thrown');
+					expect(message).to.equal(getMessage(BundleName.Remove, 'errors.noMatchingPaths', []));
 				});
 			});
 		});

--- a/test/lib/actions/RunDfaAction.test.ts
+++ b/test/lib/actions/RunDfaAction.test.ts
@@ -1,5 +1,5 @@
 import {Logger} from '@salesforce/core';
-import {assert, expect} from 'chai';
+import {expect} from 'chai';
 import path = require('path');
 
 import {FakeDisplay} from '../FakeDisplay';
@@ -42,12 +42,17 @@ describe('RunDfaAction', () => {
 				'projectdir': ['./**/*.cls']
 			};
 
+			let errorThrown: boolean;
+			let message: string;
 			try {
 				await runDfaAction.validateInputs(inputs);
-				assert.fail('Error should have been thrown');
+				errorThrown = false;
 			} catch (e) {
-				expect(e.message).to.equal(getMessage(BundleName.CommonRun, 'validations.projectdirCannotBeGlob'));
+				errorThrown = true;
+				message = e.message;
 			}
+			expect(errorThrown).to.equal(true, 'Error should have been thrown');
+			expect(message).to.equal(getMessage(BundleName.CommonRun, 'validations.projectdirCannotBeGlob'));
 		});
 
 		it('--projectdir must be real', async () => {
@@ -55,12 +60,17 @@ describe('RunDfaAction', () => {
 				'projectdir': ['./not/a/real/file.txt']
 			};
 
+			let errorThrown: boolean;
+			let message: string;
 			try {
 				await runDfaAction.validateInputs(inputs);
-				assert.fail('Error should have been thrown');
+				errorThrown = false;
 			} catch (e) {
-				expect(e.message).to.equal(getMessage(BundleName.CommonRun, 'validations.projectdirMustExist'));
+				errorThrown = true;
+				message = e.message;
 			}
+			expect(errorThrown).to.equal(true, 'Error should have been thrown');
+			expect(message).to.equal(getMessage(BundleName.CommonRun, 'validations.projectdirMustExist'));
 		});
 
 		it('--projectdir must be directory', async () => {
@@ -69,12 +79,17 @@ describe('RunDfaAction', () => {
 				'projectdir': [path.resolve('./src/Controller.ts')]
 			};
 
+			let errorThrown: boolean;
+			let message: string;
 			try {
 				await runDfaAction.validateInputs(inputs);
-				assert.fail('Error should have been thrown');
+				errorThrown = false;
 			} catch (e) {
-				expect(e.message).to.equal(getMessage(BundleName.CommonRun, 'validations.projectdirMustBeDir'));
+				errorThrown = true;
+				message = e.message;
 			}
+			expect(errorThrown).to.equal(true, 'Error should have been thrown');
+			expect(message).to.equal(getMessage(BundleName.CommonRun, 'validations.projectdirMustBeDir'));
 		});
 
 		it('--outfile cannot be used if --format is "table"', async () => {
@@ -83,12 +98,17 @@ describe('RunDfaAction', () => {
 				'format': 'table'
 			};
 
+			let errorThrown: boolean;
+			let message: string;
 			try {
 				await runDfaAction.validateInputs(inputs);
-				assert.fail('Error should have been thrown');
+				errorThrown = false;
 			} catch (e) {
-				expect(e.message).to.equal(getMessage(BundleName.CommonRun, 'validations.cannotWriteTableToFile'));
+				errorThrown = true;
+				message = e.message;
 			}
+			expect(errorThrown).to.equal(true, 'Error should have been thrown');
+			expect(message).to.equal(getMessage(BundleName.CommonRun, 'validations.cannotWriteTableToFile'));
 		});
 
 		it('If --outfile and --format conflict, message is logged', async () => {
@@ -106,12 +126,17 @@ describe('RunDfaAction', () => {
 				'target': ['./**/*.cls#beep']
 			};
 
+			let errorThrown: boolean;
+			let message: string;
 			try {
 				await runDfaAction.validateInputs(inputs);
-				assert.fail('Error should have been thrown');
+				errorThrown = false;
 			} catch (e) {
-				expect(e.message).to.equal(getMessage(BundleName.RunDfa, 'validations.methodLevelTargetCannotBeGlob'));
+				errorThrown = true;
+				message = e.message;
 			}
+			expect(errorThrown).to.equal(true, 'Error should have been thrown');
+			expect(message).to.equal(getMessage(BundleName.RunDfa, 'validations.methodLevelTargetCannotBeGlob'));
 		});
 
 		it('Method-level --target values must be a real file', async () => {
@@ -120,12 +145,17 @@ describe('RunDfaAction', () => {
 				'target': [`${file}#beep`]
 			};
 
+			let errorThrown: boolean;
+			let message: string;
 			try {
 				await runDfaAction.validateInputs(inputs);
-				assert.fail('Error should have been thrown');
+				errorThrown = false;
 			} catch (e) {
-				expect(e.message).to.equal(getMessage(BundleName.RunDfa, 'validations.methodLevelTargetMustBeRealFile', [file]));
+				errorThrown = true;
+				message = e.message;
 			}
+			expect(errorThrown).to.equal(true, 'Error should have been thrown');
+			expect(message).to.equal(getMessage(BundleName.RunDfa, 'validations.methodLevelTargetMustBeRealFile', [file]));
 		});
 	});
 

--- a/test/lib/eslint/CustomEslintEngine.test.ts
+++ b/test/lib/eslint/CustomEslintEngine.test.ts
@@ -1,4 +1,4 @@
-import { assert, expect } from 'chai';
+import { expect } from 'chai';
 import { CustomEslintEngine } from '../../../src/lib/eslint/CustomEslintEngine';
 import * as DataGenerator from './EslintTestDataGenerator';
 import { CUSTOM_CONFIG, HARDCODED_RULES } from '../../../src/Constants';
@@ -152,18 +152,21 @@ describe("Tests for CustomEslintEngine", () => {
 
 			const customEslintEngine = await getCustomEslintEngine(fileHandlerMock);
 
+			let errorThrown: boolean;
+			let message: string;
 			try {
 				await customEslintEngine.run(
 					[],
 					[],
 					[DataGenerator.getDummyTarget()],
 					engineOptionsWithEslintCustom);
-
-				assert.fail('Expected exception');
+				errorThrown = false;
 			} catch (err) {
-				expect(err.message).to.equal(getMessage(BundleName.CustomEslintEngine, 'ConfigFileDoesNotExist', [configFilePath]));
+				errorThrown = true;
+				message = err.message;
 			}
-
+			expect(errorThrown).to.equal(true, 'Error should be thrown');
+			expect(message).to.equal(getMessage(BundleName.CustomEslintEngine, 'ConfigFileDoesNotExist', [configFilePath]));
 		});
 
 		it('Throws error when JSON in config file cannot be parsed', async () => {
@@ -172,6 +175,8 @@ describe("Tests for CustomEslintEngine", () => {
 			const fileHandlerMock = mockFileHandlerToReturnContentForFile(configFilePath, invalidJsonContent);
 			const customEslintEngine = await getCustomEslintEngine(fileHandlerMock);
 
+			let errorThrown: boolean;
+			let message: string;
 			try {
 
 				await customEslintEngine.run(
@@ -179,12 +184,13 @@ describe("Tests for CustomEslintEngine", () => {
 					[],
 					[target],
 					engineOptionsWithEslintCustom);
-
-				assert.fail('Expected exception');
+				errorThrown = false;
 			} catch (err) {
-				expect(err.message).contains(`Something in the ESLint config JSON is invalid. Check ESLint's JSON specifications: ${configFilePath}`);
+				errorThrown = true;
+				message = err.message;
 			}
-
+			expect(errorThrown).to.equal(true, 'Error should have been thrown');
+			expect(message).contains(`Something in the ESLint config JSON is invalid. Check ESLint's JSON specifications: ${configFilePath}`);
 		});
 
 		it('Invokes Eslint when config can be fetched', async () => {

--- a/test/lib/sfge/SfgeDfaEngine.test.ts
+++ b/test/lib/sfge/SfgeDfaEngine.test.ts
@@ -4,7 +4,7 @@ import * as TestOverrides from '../../test-related-lib/TestOverrides';
 import Sinon = require('sinon');
 import path = require('path');
 import fs = require('fs');
-import {assert, expect} from 'chai';
+import {expect} from 'chai';
 
 import {RuleResult} from '../../../src/types';
 import {SfgeDfaEngine} from '../../../src/lib/sfge/SfgeDfaEngine';
@@ -118,15 +118,18 @@ describe('SfgeDfaEngine', () => {
 			const expectedError = spoofedOutput.split('\n').slice(21).join('\n').trimStart();
 
 			// ==== TESTED METHOD ====
+			let errorThrown: boolean;
 			let err: string = null;
 			try {
-				const results = await testEngine.processExecutionFailure(spoofedOutput);
-				assert.fail(`Expected error, received ${JSON.stringify(results)}`);
+				await testEngine.processExecutionFailure(spoofedOutput);
+				errorThrown = false;
 			} catch (e) {
+				errorThrown = true;
 				err = e instanceof Error ? e.message : e as string;
 			}
 
 			// ==== ASSERTIONS ====
+			expect(errorThrown).to.equal(true, 'Error should have been thrown');
 			expect(err).to.equal(expectedError, 'Wrong error returned');
 			Sinon.assert.callCount(uxSpy, 0);
 		});


### PR DESCRIPTION
Several tests were doing `assert.fail()` inside a `try-catch`, which meant that the exception thrown by the assertion was actually being caught, thereby preventing the test from properly failing. This has been corrected.