### PR TITLE
FIX(CodeAnalyzer): @W-14186382@: Fix issue where error message is missing java version

### DIFF
--- a/src/lib/JreSetupManager.ts
+++ b/src/lib/JreSetupManager.ts
@@ -133,19 +133,16 @@ class JreSetupManager extends AsyncCreatable {
 
 		const majorVersion = parseInt(matchedParts[1]);
 		const minorVersion = matchedParts[3] ? parseInt(matchedParts[3]) : '';
-		let version = '';
+		const version = `${majorVersion}${minorVersion ? `.${minorVersion}` : ''}`;
+
 		// We want to allow 1.8 and greater.
-		// Upto JDK8, the version scheme is 1.blah
+		// Up to JDK8, the version scheme is 1.blah
 		// Starting JDK 9, the version scheme is 9.blah for 9, 10.blah for 10, etc.
 		// If either version part clicks, we should be good.
-		if (majorVersion >= 9) {
-			// Accept if Major version is greater than or equal to 9
-			version = `${majorVersion}${minorVersion ? `.${minorVersion}` : ''}`;
-		} else if (majorVersion === 1 && minorVersion === 8) {
+		if (majorVersion === 1 && minorVersion === 8) {
 			// Accommodating 1.8
-			version = `${majorVersion}.${minorVersion}`;
 			uxEvents.emit(EVENTS.WARNING_ALWAYS_UNIQUE, getMessage(BundleName.JreSetupManager, 'warning.JavaV8Deprecated', [path.join(Controller.getSfdxScannerPath(), CONFIG_FILE)]));
-		} else {
+		} else if (majorVersion < 9) {
 			// Not matching what we are looking for
 			const errName = 'InvalidVersion';
 			throw new SfError(getMessage(BundleName.JreSetupManager, errName, [version]), errName);
@@ -153,8 +150,6 @@ class JreSetupManager extends AsyncCreatable {
 
 		this.logger.trace(`Java version found as ${version}`);
 		return;
-
-
 	}
 
 	private async fetchJavaVersion(javaHome: string): Promise<string> {

--- a/test/lib/JreSetupManager.test.ts
+++ b/test/lib/JreSetupManager.test.ts
@@ -222,17 +222,13 @@ describe('JreSetupManager #verifyJreSetup', () => {
 			const execStub = Sinon.stub(childProcess, 'execFile').yields(noError, emptyStdout, invalidVersion);
 
 			// Execute and verify
-			let errorThrown: boolean;
-			let errName: string;
 			try {
 				await verifyJreSetup();
-				errorThrown = false;
+				expect.fail('Should have thrown an exception');
 			} catch (err) {
-				errorThrown = true;
-				errName = err.name;
+				expect(err.name).equals('InvalidVersion');
+				expect(err.message).contains('1.5');
 			}
-			expect(errorThrown).to.equal(true, 'Should have failed');
-			expect(errName).equals('InvalidVersion');
 			expect(uniqueWarningCounter).to.equal(0);
 
 


### PR DESCRIPTION
Fixes #1196 

Using test driven development:
* First updated our test to check for that the version number shows up in the error message.
* Ran test to verify it failed (to catch the issue)
* Updated source code
* Ran test to verify it now passes