### PR TITLE
CHANGE (CodeAnalyzer): @W-15244567@: Updated release to support v4.x

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -33,6 +33,12 @@ jobs:
         run: |
           echo "Tag commit must match latest commit in release. Branch is ${{ steps.get-branch-commit.outputs.COMMIT_ID }}. Tag is ${{ steps.get-tag-commit.outputs.COMMIT_ID }}"
           exit 1
+      # Verify that the `package.json`'s version property is 4.Y.Z, as we want to restrict the `dev` and `release`
+      # branches to publishing v4.x.
+      - name: Verify major version
+        run: |
+          MAJOR_VERSION=`cat package.json | jq '.version | split(".") | .[0]'`
+          [[ ${MAJOR_VERSION} == 4 ]] || (echo "package.json version must be 4.x" && exit 1)
       # Verify that the tag is of the format "vX.Y.Z", where the X, Y, and Z exactly match the corresponding values in
       # `package.json`'s version property.
       - name: Compare tag to package.json


### PR DESCRIPTION
This PR does the following:
- Adds a check to the publishing workflow to abort publishing if the `package.json` version property isn't "4.[whatever]", to effectively convert `dev` and `release` into a v4.x publishing pipeline.

`dev-3` and `release-3` have already been forked from `dev` and `release` prior to this PR being created, and a corresponding PR will be created to convert those branches into a parallel pipeline for v3.x, in case we need to do any subsequent 3.x releases.