### PR TITLE
CHANGE (CodeAnalyzer): @W-15244567@: Added additional guardrails to prevent bad merges.

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -37,7 +37,7 @@ jobs:
       # branches to publishing v4.x.
       - name: Verify major version
         run: |
-          MAJOR_VERSION=`cat package.json | jq '.version | split(".") | .[0]'`
+          MAJOR_VERSION=`cat package.json | jq '.version | split(".") | .[0]' | xargs`
           [[ ${MAJOR_VERSION} == 4 ]] || (echo "package.json version must be 4.x" && exit 1)
       # Verify that the tag is of the format "vX.Y.Z", where the X, Y, and Z exactly match the corresponding values in
       # `package.json`'s version property.

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -4,6 +4,15 @@ on:
     types: [edited, opened, reopened, synchronize]
 
 jobs:
+  # We want to prevent cross-contamination between the 3.x and 4.x pipelines. So we should prevent PRs
+  # based on this flow to merge into `dev-3` or `release-3`.
+  verify_target_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - if: ${{ github.base_ref == "dev-3" || github.base_ref == "release-3" }}
+        run: |
+          echo "Forbidden to merge this branch into dev-3 or release-3"
+          exit 1
   # We need to verify that the Pull Request's title matches the desired format.
   verify_pr_title:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -9,7 +9,7 @@ jobs:
   verify_target_branch:
     runs-on: ubuntu-latest
     steps:
-      - if: ${{ github.base_ref == "dev-3" || github.base_ref == "release-3" }}
+      - if: ${{ github.base_ref == 'dev-3' || github.base_ref == 'release-3' }}
         run: |
           echo "Forbidden to merge this branch into dev-3 or release-3"
           exit 1


### PR DESCRIPTION
This PR is a follow-up to #1398 , and does the following:
- Corrects a typo in the changes to the `publish-to-npm.yml` script that would have prevented publishing entirely.
- Adds a guardrail during feature branch evaluation to prevent merging a branch descended from this one into `dev-3` or `release-3`.
