### PR TITLE
CHANGE (CodeAnalyzer): @W-15244567@: Converted dev-3 into v3 release pipeline with guardrails.

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -18,7 +18,7 @@ jobs:
       # Check out the release branch, and get its head commit as output for later.
       - uses: actions/checkout@v3
         with:
-          ref: 'release'
+          ref: 'release-3'
       - run: echo "COMMIT_ID=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
         id: get-branch-commit
       # Checkout the tag we want to release, and get its head commit as output for later.
@@ -31,8 +31,14 @@ jobs:
       - name: Fail non-matching commits
         if: ${{ steps.get-branch-commit.outputs.COMMIT_ID != steps.get-tag-commit.outputs.COMMIT_ID }}
         run: |
-          echo "Tag commit must match latest commit in release. Branch is ${{ steps.get-branch-commit.outputs.COMMIT_ID }}. Tag is ${{ steps.get-tag-commit.outputs.COMMIT_ID }}"
+          echo "Tag commit must match latest commit in release-3. Branch is ${{ steps.get-branch-commit.outputs.COMMIT_ID }}. Tag is ${{ steps.get-tag-commit.outputs.COMMIT_ID }}"
           exit 1
+      # Verify that the `package.json`'s version property is 3.Y.Z, as we want to restrict the `dev-3` and `release-3`
+      # branches to publishing v3.x.
+      - name: Verify major version
+        run: |
+          MAJOR_VERSION=`cat package.json | jq '.version | split(".") | .[0]' | xargs`
+          [[ ${MAJOR_VERSION} == 3 ]] || (echo "package.json version must be 3.x" && exit 1)
       # Verify that the tag is of the format "vX.Y.Z", where the X, Y, and Z exactly match the corresponding values in
       # `package.json`'s version property.
       - name: Compare tag to package.json
@@ -47,7 +53,7 @@ jobs:
     with:
       ctc: false # We've been told we don't have to care about this until someone makes us care.
       sign: true
-      tag: latest-rc # Publish as a release candidate, so we can do our validations against it.
+      tag: latest-rc-v3 # Publish as a release candidate, so we can do our validations against it.
       githubTag: ${{ github.event.release.tag_name || inputs.tag }}
     secrets: inherit
   # Step 3: Run smoke tests against the release candidate.
@@ -75,7 +81,7 @@ jobs:
           java-version: '11' # For now, Java version is hardcoded.
       # Install SF, and the release candidate version.
       - run: npm install -g @salesforce/cli
-      - run: sf plugins install @salesforce/sfdx-scanner@latest-rc
+      - run: sf plugins install @salesforce/sfdx-scanner@latest-rc-v3
       # Log the installed plugins for easier debugging.
       - run: sf plugins
       # Attempt to run the smoke tests.
@@ -96,4 +102,4 @@ jobs:
           node-version: 'lts/*'
       - run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
-          npm dist-tag add @salesforce/sfdx-scanner@${{ github.event.release.tag_name || inputs.tag }} latest
+          npm dist-tag add @salesforce/sfdx-scanner@${{ github.event.release.tag_name || inputs.tag }} latest-v3

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -4,6 +4,15 @@ on:
     types: [edited, opened, reopened, synchronize]
 
 jobs:
+  # We want to prevent cross-contamination between the 3.x and 4.x pipelines, so we should prevent PRS based on this flow
+  # to merge into `dev` or `release`.
+  verify_target_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - if: ${{ github.base_ref == 'dev' || github.base_ref == 'release' }}
+        run: |
+          echo "Forbidden to merge this branch into dev or release."
+          exit 1
   # We need to verify that the Pull Request's title matches the desired format.
   verify_pr_title:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR is the v3.x equivalent to PRs #1398  and #1399 . It does the following:
- Changes the `publish-to-npm.yml` workflow so that:
    - it only allows publishing of a tag that matches the head commit of `release-3`
    - It only allows publishing if the `package.json` version property is 3.something
    - The release is published as `latest-rc-v3` and `latest-v3`
- Changes the `validate-pr.yml` workflow so it prevents merging to `dev` or `release`, to prevent cross-contamination of branches.