### PR TITLE
FIX (GraphEngine): @W-15491246@: Implemented lazy path expansion.

### DIFF
--- a/sfge/src/main/java/com/salesforce/graph/ops/expander/ApexPathExpanderUtil.java
+++ b/sfge/src/main/java/com/salesforce/graph/ops/expander/ApexPathExpanderUtil.java
@@ -162,14 +162,15 @@ public final class ApexPathExpanderUtil {
 
         private void expand(
                 Stack<ApexPathExpander> apexPathExpanders, ApexPathCollector resultCollector) {
-
-            // Continue while there is work to do. This stack is updated as the path is forked.
-            // Forked expanders are pushed to the front of the stack, causing the paths to be
-            // traversed
-            // depth first in order
-            // to keep the peak number of active expanders lower.
-            while (!apexPathExpanders.isEmpty()) {
-                ApexPathExpander apexPathExpander = apexPathExpanders.pop();
+            // Since ApexPathExpanders are so memory intensive, we want to limit the number
+            // that exist at once. So we use this stack to lazily create them as needed, storing
+            // only the information that is used to create them. This allows us to do a reasonably
+            // efficient depth-first expansion.
+            PendingForkStack pendingForkStack = new PendingForkStack(apexPathCollapser);
+            Optional<ApexPathExpander> nextExpander;
+            while ((nextExpander = getNextExpander(apexPathExpanders, pendingForkStack))
+                    .isPresent()) {
+                ApexPathExpander apexPathExpander = nextExpander.get();
                 ContextProviders.CLASS_STATIC_SCOPE.push(apexPathExpander);
                 ContextProviders.ENGINE_DIRECTIVE_CONTEXT.push(apexPathExpander);
                 try {
@@ -288,29 +289,9 @@ public final class ApexPathExpanderUtil {
                         LOGGER.warn("expand-StackDepthLimit. ex=" + ex);
                     }
                 } catch (MethodPathForkedException ex) {
-                    List<ApexPathExpander> forkedPathExpanders = new ArrayList<>();
-                    for (ApexPathExpander forkedApexPathExpander : getForkedExpanders(ex)) {
-                        if (forkedApexPathExpander.getTopMostPath().endsInException()) {
-                            // This happens when a path invokes a method that only throws an
-                            // exception
-                            ThrowStatementVertex throwStatementVertex =
-                                    forkedApexPathExpander
-                                            .getTopMostPath()
-                                            .getThrowStatementVertex()
-                                            .get();
-                            logFilteredOutPath(throwStatementVertex);
-                            forkedApexPathExpander.finished();
-                        } else {
-                            apexPathExpanders.push(forkedApexPathExpander);
-                            forkedPathExpanders.add(forkedApexPathExpander);
-                        }
-                    }
-                    apexPathCollapser.pathForked(
-                            ex.getForkEvent(), apexPathExpander, forkedPathExpanders);
-                    apexPathExpander.finished();
-                    if (LOGGER.isInfoEnabled()) {
-                        LOGGER.info("expand-Forked. ex=" + ex);
-                    }
+                    // Add this exception to the PendingForkStack, so it can be lazily processed
+                    // later.
+                    pendingForkStack.addStackFrame(ex);
                 } catch (RuntimeException ex) {
                     if (LOGGER.isErrorEnabled()) {
                         LOGGER.error(
@@ -345,27 +326,157 @@ public final class ApexPathExpanderUtil {
             }
         }
 
-        /** Returns the number of ApexPathExpanders indicated by the exception */
-        private List<ApexPathExpander> getForkedExpanders(MethodPathForkedException ex) {
-            List<ApexPathExpander> result = new ArrayList<>();
+        /**
+         * Returns the next {@link ApexPathExpander} to be processed, either by lazily creating it
+         * with {@code pendingForkStack} or by popping it off of {@code baseExpanderStack}.
+         *
+         * @param baseExpanderStack A stack of the base expanders that will need to be processed
+         * @param pendingForkStack A stack of fork events that are waiting to be processed.
+         */
+        private Optional<ApexPathExpander> getNextExpander(
+                Stack<ApexPathExpander> baseExpanderStack, PendingForkStack pendingForkStack) {
+            // If the pending fork stack can give us an expander, we should use that in order to
+            // keep the expansion truly depth-first.
+            Optional<ApexPathExpander> nextExpander = pendingForkStack.getNextExpander();
+            if (nextExpander.isPresent()) {
+                return nextExpander;
+            } else if (!baseExpanderStack.isEmpty()) {
+                // Otherwise, if there are still expanders in the base stack, use one of those.
+                return Optional.of(baseExpanderStack.pop());
+            } else {
+                // Otherwise, we're just done.
+                return Optional.empty();
+            }
+        }
+    }
 
-            // TODO: Efficiency. We could iterate to size() - 1 and reuse the existing path
-            for (int i = 0; i < ex.getPaths().size(); i++) {
-                ApexPath forkedPath = ex.getPaths().get(i);
-                if (forkedPath.endsInException()) {
-                    logFilteredOutPath(forkedPath.getThrowStatementVertex().get());
-                    continue;
-                }
-                // Establish a context so that objects passed by reference are only cloned once
+    /**
+     * Since {@link ApexPathExpander}s have a large memory footprint, we want to minimize the number
+     * of instances that exist simultaneously. This class allows us to lazily create the expanders
+     * as needed, and perform a true depth-first expansion.
+     */
+    private static class PendingForkStack {
+        /**
+         * We use a Stack instead of a List to allow for a true depth-first expansion. i.e., when a
+         * new fork is encountered, it's added to the top of the stack, meaning it gets processed
+         * first.
+         */
+        private final Stack<PendingForkStackFrame> stack;
+        /** The collapser is present to allow each stack frame to handle forks. */
+        private final ApexPathCollapser apexPathCollapser;
+
+        PendingForkStack(ApexPathCollapser apexPathCollapser) {
+            stack = new Stack<>();
+            this.apexPathCollapser = apexPathCollapser;
+        }
+
+        /**
+         * Use the provide Exception to create a new {@link PendingForkStackFrame} and add it to the
+         * top of the stack.
+         *
+         * @param ex An exception thrown when a method is determined to fork.
+         */
+        void addStackFrame(MethodPathForkedException ex) {
+            stack.push(new PendingForkStackFrame(ex, apexPathCollapser));
+        }
+
+        /**
+         * @return An Optional containing either the next {@link ApexPathExpander} to be processed,
+         *     or nothing.
+         */
+        Optional<ApexPathExpander> getNextExpander() {
+            // Base Case: The stack is empty, so there are no more frames to inspect.
+            // Return an empty optional.
+            if (stack.empty()) {
+                return Optional.empty();
+            }
+            PendingForkStackFrame frame = stack.peek();
+            Optional<ApexPathExpander> nextExpanderOptional = frame.getNextExpander();
+            if (nextExpanderOptional.isEmpty()) {
+                // Recursive Case: The current frame is empty. Pop it off, and call recursively
+                // to move to the next frame.
+                stack.pop();
+                return getNextExpander();
+            } else {
+                // Base Case: The current frame returned an Expander. Return it.
+                return nextExpanderOptional;
+            }
+        }
+    }
+
+    /**
+     * Each frame in the {@link PendingForkStack} represents a fork event currently being processed.
+     */
+    private static class PendingForkStackFrame {
+        /** The exception that triggered the fork. */
+        private final MethodPathForkedException ex;
+        /** The collapser used to process forks. */
+        private final ApexPathCollapser apexPathCollapser;
+        /**
+         * The index of the next {@link ApexPath} that should be turned into an {@link
+         * ApexPathExpander}.
+         */
+        private int idx;
+
+        PendingForkStackFrame(MethodPathForkedException ex, ApexPathCollapser apexPathCollapser) {
+            this.ex = ex;
+            this.apexPathCollapser = apexPathCollapser;
+            this.idx = 0;
+        }
+
+        /**
+         * @return {@code true} if this frame is out of paths to turn into expanders; else {@link
+         *     false}.
+         */
+        private boolean done() {
+            return idx >= ex.getPaths().size();
+        }
+
+        /**
+         * @return An Optional containing either the next {@link ApexPathExpander} or nothing.
+         */
+        Optional<ApexPathExpander> getNextExpander() {
+            // Base Case: There are no more unprocessed paths on this frame.
+            if (done()) {
+                // Finish the expander and return an empty optional.
+                ex.getApexPathExpander().finished();
+                return Optional.empty();
+            }
+            ApexPath nextPotentialPath = ex.getPaths().get(idx);
+            if (nextPotentialPath.endsInException()) {
+                // Recursive Case: This particular path ends in an exception, so we skip it, log it,
+                // and do a recursive call.
+                logFilteredOutPath(nextPotentialPath.getThrowStatementVertex().get());
+                idx += 1;
+                return getNextExpander();
+            } else {
                 DeepCloneContextProvider.establish();
+                ApexPathExpander tentativeResult;
                 try {
-                    result.add(new ApexPathExpander(ex.getApexPathExpander(), ex, i));
+                    tentativeResult = new ApexPathExpander(ex.getApexPathExpander(), ex, idx);
                 } finally {
                     DeepCloneContextProvider.release();
                 }
+                if (tentativeResult.getTopMostPath().endsInException()) {
+                    // Recursive case: The topmost path ends in an exception, so we skip it, log it,
+                    // and do a recursive call.
+                    logFilteredOutPath(
+                            tentativeResult.getTopMostPath().getThrowStatementVertex().get());
+                    idx += 1;
+                    // Make sure to call `finished()` before we discard it, otherwise it won't get
+                    // garbage-collected.
+                    tentativeResult.finished();
+                    return getNextExpander();
+                } else {
+                    // Base Case: We have an expander.
+                    apexPathCollapser.pathForked(
+                            ex.getForkEvent(),
+                            ex.getApexPathExpander(),
+                            Collections.singletonList(tentativeResult));
+                    idx += 1;
+                    return Optional.of(tentativeResult);
+                }
             }
-
-            return result;
         }
     }
 }


### PR DESCRIPTION
This PR changes how `ApexPathExpanders` are processed. Previously, they were put into a stack and processed one at a time. The new system stacks the information from which the expanders are generated instead, and uses that information to generate them on-demand instead of preemptively. This reduces memory pressure and prevents certain code patterns from throwing `LimitReached` violations or `OutOfMemory` errors.