### PR TITLE
CHANGE @W-16607090@ Run command outputs summary

### DIFF
--- a/messages/results-viewer.md
+++ b/messages/results-viewer.md
@@ -1,19 +1,3 @@
-# summary.found-no-results
-
-Found 0 violations.
-
-# summary.breakdown.header
-
-Summary
-
-# summary.breakdown.total
-
-Found %d violation(s):
-
-# summary.breakdown.item
-
-%d %s severity violation(s) found
-
 # summary.detail.found-results
 
 Found %d violation(s) across %d file(s):

--- a/messages/run-summary-viewer.md
+++ b/messages/run-summary-viewer.md
@@ -12,7 +12,7 @@ Found %d violation(s):
 
 # summary.violations-item
 
-%d %s severity violation(s) found
+%d %s severity violation(s) found.
 
 # summary.no-outfiles
 

--- a/messages/run-summary-viewer.md
+++ b/messages/run-summary-viewer.md
@@ -20,8 +20,8 @@ No results files were specified.
 
 # summary.outfiles-total
 
-Results were written to:
+Results written to:
 
 # summary.log-file-location
 
-Additional log information was written to:
+Additional log information written to:

--- a/messages/run-summary-viewer.md
+++ b/messages/run-summary-viewer.md
@@ -1,0 +1,27 @@
+# summary.header
+
+Summary
+
+# summary.found-no-violations
+
+Found 0 violations.
+
+# summary.violations-total
+
+Found %d violation(s):
+
+# summary.violations-item
+
+%d %s severity violation(s) found
+
+# summary.no-outfiles
+
+No results files were specified.
+
+# summary.outfiles-total
+
+Results were written to:
+
+# summary.log-file-location
+
+Additional log information was written to:

--- a/src/commands/code-analyzer/rules.ts
+++ b/src/commands/code-analyzer/rules.ts
@@ -2,7 +2,7 @@ import {Flags, SfCommand} from '@salesforce/sf-plugins-core';
 import {View} from '../../Constants';
 import {CodeAnalyzerConfigFactoryImpl} from '../../lib/factories/CodeAnalyzerConfigFactory';
 import {EnginePluginsFactoryImpl} from '../../lib/factories/EnginePluginsFactory';
-import {RuleDetailViewer, RuleTableViewer} from '../../lib/viewers/RuleViewer';
+import {RuleDetailDisplayer, RuleTableDisplayer} from '../../lib/viewers/RuleViewer';
 import {RulesAction, RulesDependencies} from '../../lib/actions/RulesAction';
 import {BundleName, getMessage, getMessages} from '../../lib/messages';
 import {Displayable, UxDisplay} from '../../lib/Display';
@@ -53,7 +53,7 @@ export default class RulesCommand extends SfCommand<void> implements Displayable
 	public async run(): Promise<void> {
 		// TODO: Update when we go to Beta and when we go GA
 		this.warn(getMessage(BundleName.Shared, "warning.command-state", [getMessage(BundleName.Shared, 'label.command-state')]));
-		
+
 		const parsedFlags = (await this.parse(RulesCommand)).flags;
 		const dependencies: RulesDependencies = this.createDependencies(parsedFlags.view as View);
 		const action: RulesAction = RulesAction.createAction(dependencies);
@@ -67,7 +67,7 @@ export default class RulesCommand extends SfCommand<void> implements Displayable
 			pluginsFactory: new EnginePluginsFactoryImpl(),
 			logEventListeners: [new LogEventDisplayer(uxDisplay)],
 			progressListeners: [new RuleSelectionProgressSpinner(uxDisplay)],
-			viewer: view === View.TABLE ? new RuleTableViewer(uxDisplay) : new RuleDetailViewer(uxDisplay)
+			viewer: view === View.TABLE ? new RuleTableDisplayer(uxDisplay) : new RuleDetailDisplayer(uxDisplay)
 		};
 	}
 }

--- a/src/commands/code-analyzer/run.ts
+++ b/src/commands/code-analyzer/run.ts
@@ -6,6 +6,7 @@ import {CodeAnalyzerConfigFactoryImpl} from '../../lib/factories/CodeAnalyzerCon
 import {EnginePluginsFactoryImpl} from '../../lib/factories/EnginePluginsFactory';
 import {CompositeResultsWriter} from '../../lib/writers/ResultsWriter';
 import {ResultsDetailDisplayer, ResultsTableDisplayer} from '../../lib/viewers/ResultsViewer';
+import {RunSummaryDisplayer} from '../../lib/viewers/RunSummaryViewer';
 import {BundleName, getMessage, getMessages} from '../../lib/messages';
 import {LogEventDisplayer} from '../../lib/listeners/LogEventListener';
 import {EngineRunProgressSpinner, RuleSelectionProgressSpinner} from '../../lib/listeners/ProgressEventListener';
@@ -86,6 +87,7 @@ export default class RunCommand extends SfCommand<void> implements Displayable {
 		const action: RunAction = RunAction.createAction(dependencies);
 		const runInput: RunInput = {
 			'config-file': parsedFlags['config-file'],
+			'output-file': parsedFlags['output-file'] ?? [],
 			'path-start': parsedFlags['path-start'], // TODO: We should move validation of this here instead of having it in the RunAction.
 			'rule-selector': parsedFlags['rule-selector'],
 			'workspace': parsedFlags['workspace'],
@@ -103,9 +105,10 @@ export default class RunCommand extends SfCommand<void> implements Displayable {
 			writer: CompositeResultsWriter.fromFiles(outputFiles),
 			logEventListeners: [new LogEventDisplayer(uxDisplay)],
 			progressListeners: [new EngineRunProgressSpinner(uxDisplay), new RuleSelectionProgressSpinner(uxDisplay)],
-			viewer: view === View.TABLE
+			resultsViewer: view === View.TABLE
 				? new ResultsTableDisplayer(uxDisplay)
-				: new ResultsDetailDisplayer(uxDisplay)
+				: new ResultsDetailDisplayer(uxDisplay),
+			runSummaryViewer: new RunSummaryDisplayer(uxDisplay)
 		};
 	}
 }

--- a/src/commands/code-analyzer/run.ts
+++ b/src/commands/code-analyzer/run.ts
@@ -5,7 +5,7 @@ import {View} from '../../Constants';
 import {CodeAnalyzerConfigFactoryImpl} from '../../lib/factories/CodeAnalyzerConfigFactory';
 import {EnginePluginsFactoryImpl} from '../../lib/factories/EnginePluginsFactory';
 import {CompositeResultsWriter} from '../../lib/writers/ResultsWriter';
-import {ResultsDetailViewer, ResultsTableViewer} from '../../lib/viewers/ResultsViewer';
+import {ResultsDetailDisplayer, ResultsTableDisplayer} from '../../lib/viewers/ResultsViewer';
 import {BundleName, getMessage, getMessages} from '../../lib/messages';
 import {LogEventDisplayer} from '../../lib/listeners/LogEventListener';
 import {EngineRunProgressSpinner, RuleSelectionProgressSpinner} from '../../lib/listeners/ProgressEventListener';
@@ -104,8 +104,8 @@ export default class RunCommand extends SfCommand<void> implements Displayable {
 			logEventListeners: [new LogEventDisplayer(uxDisplay)],
 			progressListeners: [new EngineRunProgressSpinner(uxDisplay), new RuleSelectionProgressSpinner(uxDisplay)],
 			viewer: view === View.TABLE
-				? new ResultsTableViewer(uxDisplay)
-				: new ResultsDetailViewer(uxDisplay)
+				? new ResultsTableDisplayer(uxDisplay)
+				: new ResultsDetailDisplayer(uxDisplay)
 		};
 	}
 }

--- a/src/lib/actions/RunAction.ts
+++ b/src/lib/actions/RunAction.ts
@@ -13,6 +13,7 @@ import {EnginePluginsFactory} from '../factories/EnginePluginsFactory';
 import {createPathStarts} from '../utils/PathStartUtil';
 import {createWorkspace} from '../utils/WorkspaceUtil';
 import {ResultsViewer} from '../viewers/ResultsViewer';
+import {RunSummaryViewer} from '../viewers/RunSummaryViewer';
 import {ResultsWriter} from '../writers/ResultsWriter';
 import {LogFileWriter} from '../writers/LogWriter';
 import {LogEventListener, LogEventLogger} from '../listeners/LogEventListener';
@@ -25,15 +26,18 @@ export type RunDependencies = {
 	logEventListeners: LogEventListener[];
 	progressListeners: ProgressEventListener[];
 	writer: ResultsWriter;
-	viewer: ResultsViewer;
+	resultsViewer: ResultsViewer;
+	runSummaryViewer: RunSummaryViewer;
 }
 
 export type RunInput = {
 	'config-file'?: string;
+	'output-file': string[];
 	'path-start'?: string[];
 	'rule-selector': string[];
 	'severity-threshold'?: SeverityLevel;
 	workspace: string[];
+
 }
 
 export class RunAction {
@@ -75,7 +79,8 @@ export class RunAction {
 		this.dependencies.progressListeners.forEach(listener => listener.stopListening());
 		this.dependencies.logEventListeners.forEach(listener => listener.stopListening());
 		this.dependencies.writer.write(results);
-		this.dependencies.viewer.view(results);
+		this.dependencies.resultsViewer.view(results);
+		this.dependencies.runSummaryViewer.view(results, config, input['output-file']);
 
 		const thresholdValue = input['severity-threshold'];
 		if (thresholdValue) {

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -16,6 +16,7 @@ export enum BundleName {
 	ResultsWriter = 'results-writer',
 	RunAction = 'run-action',
 	RunCommand = 'run-command',
+	RunSummaryViewer = 'run-summary-viewer',
 	Shared = 'shared',
 	WorkspaceUtil = 'workspace-util'
 }

--- a/src/lib/viewers/ResultsViewer.ts
+++ b/src/lib/viewers/ResultsViewer.ts
@@ -9,7 +9,7 @@ export interface ResultsViewer {
 	view(results: RunResults): void;
 }
 
-abstract class AbstractResultsViewer implements ResultsViewer {
+abstract class AbstractResultsDisplayer implements ResultsViewer {
 	protected display: Display;
 
 	public constructor(display: Display) {
@@ -56,7 +56,7 @@ abstract class AbstractResultsViewer implements ResultsViewer {
 	protected abstract _view(results: RunResults): void;
 }
 
-export class ResultsDetailViewer extends AbstractResultsViewer {
+export class ResultsDetailDisplayer extends AbstractResultsDisplayer {
 	protected _view(results: RunResults): void {
 		const violations = sortViolations(results.getViolations());
 
@@ -119,7 +119,7 @@ const TABLE_COLUMNS: Ux.Table.Columns<ResultRow> = {
 	}
 };
 
-export class ResultsTableViewer extends AbstractResultsViewer {
+export class ResultsTableDisplayer extends AbstractResultsDisplayer {
 	protected _view(results: RunResults) {
 		const violations: Violation[] = sortViolations(results.getViolations());
 		const parentFolder: string = findLongestCommonParentFolderOf(violations.map(v =>

--- a/src/lib/viewers/ResultsViewer.ts
+++ b/src/lib/viewers/ResultsViewer.ts
@@ -1,7 +1,7 @@
 import {Ux} from '@salesforce/sf-plugins-core';
 import {CodeLocation, RunResults, SeverityLevel, Violation} from '@salesforce/code-analyzer-core';
 import {Display} from '../Display';
-import {toStyledHeaderAndBody, toStyledHeader, indent} from '../utils/StylingUtil';
+import {toStyledHeaderAndBody} from '../utils/StylingUtil';
 import {BundleName, getMessage} from '../messages';
 import path from "node:path";
 
@@ -18,11 +18,10 @@ abstract class AbstractResultsDisplayer implements ResultsViewer {
 
 	public view(results: RunResults): void {
 		if (results.getViolationCount() === 0) {
-			this.display.displayLog(getMessage(BundleName.ResultsViewer, 'summary.found-no-results'));
+			return;
 		} else {
 			this._view(results);
 			this.display.displayLog('\n');
-			this.displayBreakdown(results);
 		}
 	}
 
@@ -36,21 +35,6 @@ abstract class AbstractResultsDisplayer implements ResultsViewer {
 			}
 		});
 		return fileSet.size;
-	}
-
-	private displayBreakdown(results: RunResults): void {
-		this.display.displayLog(toStyledHeader(getMessage(BundleName.ResultsViewer, 'summary.breakdown.header')));
-		this.display.displayLog(getMessage(BundleName.ResultsViewer, 'summary.breakdown.total', [results.getViolationCount()]));
-		for (const sev of Object.values(SeverityLevel)) {
-			// Some of the keys will be numbers, since the enum is numerical. Skip those.
-			if (typeof sev !== 'string') {
-				continue;
-			}
-			const sevCount = results.getViolationCountOfSeverity(SeverityLevel[sev] as SeverityLevel);
-			if (sevCount > 0) {
-				this.display.displayLog(indent(getMessage(BundleName.ResultsViewer, 'summary.breakdown.item', [sevCount, sev])));
-			}
-		}
 	}
 
 	protected abstract _view(results: RunResults): void;

--- a/src/lib/viewers/RuleViewer.ts
+++ b/src/lib/viewers/RuleViewer.ts
@@ -9,7 +9,7 @@ export interface RuleViewer {
 }
 
 
-abstract class AbstractRuleViewer implements RuleViewer {
+abstract class AbstractRuleDisplayer implements RuleViewer {
 	protected display: Display;
 
 	public constructor(display: Display) {
@@ -28,7 +28,7 @@ abstract class AbstractRuleViewer implements RuleViewer {
 	protected abstract _view(rules: Rule[]): void;
 }
 
-export class RuleDetailViewer extends AbstractRuleViewer {
+export class RuleDetailDisplayer extends AbstractRuleDisplayer {
 	protected _view(rules: Rule[]): void {
 		const styledRules: string[] = [];
 		for (let i = 0; i < rules.length; i++) {
@@ -76,7 +76,7 @@ const TABLE_COLUMNS: Ux.Table.Columns<RuleRow> = {
 	}
 };
 
-export class RuleTableViewer extends AbstractRuleViewer {
+export class RuleTableDisplayer extends AbstractRuleDisplayer {
 	protected _view(rules: Rule[]): void {
 		const ruleJsons: RuleRow[] = rules.map((rule, idx) => {
 			const severity = rule.getSeverityLevel();

--- a/src/lib/viewers/RunSummaryViewer.ts
+++ b/src/lib/viewers/RunSummaryViewer.ts
@@ -16,20 +16,24 @@ export class RunSummaryDisplayer {
 
 	public view(results: RunResults, config: CodeAnalyzerConfig, outfiles: string[]): void {
 		this.display.displayLog(toStyledHeader(getMessage(BundleName.RunSummaryViewer, 'summary.header')));
+		// Use empty line as a visual separator
+		this.display.displayLog('');
 
 		if (results.getViolationCount() === 0) {
 			this.display.displayLog(getMessage(BundleName.RunSummaryViewer, 'summary.found-no-violations'));
 		} else {
 			this.displayResultsSummary(results);
 		}
-		this.display.displayLog('\n');
+		// Use empty line as a visual separator
+		this.display.displayLog('');
 
 		if (outfiles.length === 0) {
 			this.display.displayLog(getMessage(BundleName.RunSummaryViewer, 'summary.no-outfiles'));
 		} else {
 			this.displayOutfiles(outfiles);
 		}
-		this.display.displayLog('\n');
+		// Use empty line as a visual separator
+		this.display.displayLog('');
 
 		this.display.displayLog(getMessage(BundleName.RunSummaryViewer, 'summary.log-file-location'));
 		this.display.displayLog(indent(config.getLogFolder()));

--- a/src/lib/viewers/RunSummaryViewer.ts
+++ b/src/lib/viewers/RunSummaryViewer.ts
@@ -1,0 +1,58 @@
+import {CodeAnalyzerConfig, RunResults, SeverityLevel} from '@salesforce/code-analyzer-core';
+import {Display} from '../Display';
+import {indent, toStyledHeader} from '../utils/StylingUtil';
+import {BundleName, getMessage} from '../messages';
+
+export interface RunSummaryViewer {
+	view(results: RunResults, config: CodeAnalyzerConfig, outfiles: string[]): void;
+}
+
+export class RunSummaryDisplayer {
+	protected display: Display;
+
+	public constructor(display: Display) {
+		this.display = display;
+	}
+
+	public view(results: RunResults, config: CodeAnalyzerConfig, outfiles: string[]): void {
+		this.display.displayLog(toStyledHeader(getMessage(BundleName.RunSummaryViewer, 'summary.header')));
+
+		if (results.getViolationCount() === 0) {
+			this.display.displayLog(getMessage(BundleName.RunSummaryViewer, 'summary.found-no-violations'));
+		} else {
+			this.displayResultsSummary(results);
+		}
+		this.display.displayLog('\n');
+
+		if (outfiles.length === 0) {
+			this.display.displayLog(getMessage(BundleName.RunSummaryViewer, 'summary.no-outfiles'));
+		} else {
+			this.displayOutfiles(outfiles);
+		}
+		this.display.displayLog('\n');
+
+		this.display.displayLog(getMessage(BundleName.RunSummaryViewer, 'summary.log-file-location'));
+		this.display.displayLog(indent(config.getLogFolder()));
+	}
+
+	private displayResultsSummary(results: RunResults): void {
+		this.display.displayLog(getMessage(BundleName.RunSummaryViewer, 'summary.violations-total', [results.getViolationCount()]));
+		for (const sev of Object.values(SeverityLevel)) {
+			// Some of the keys will be numbers, since the enum is numerical. Skip those.
+			if (typeof sev !== 'string') {
+				continue;
+			}
+			const sevCount = results.getViolationCountOfSeverity(SeverityLevel[sev] as SeverityLevel);
+			if (sevCount > 0) {
+				this.display.displayLog(indent(getMessage(BundleName.RunSummaryViewer, 'summary.violations-item', [sevCount, sev])));
+			}
+		}
+	}
+
+	private displayOutfiles(outfiles: string[]): void {
+		this.display.displayLog(getMessage(BundleName.RunSummaryViewer, 'summary.outfiles-total'));
+		for (const outfile of outfiles) {
+			this.display.displayLog(indent(outfile));
+		}
+	}
+}

--- a/test/commands/code-analyzer/rules.test.ts
+++ b/test/commands/code-analyzer/rules.test.ts
@@ -110,7 +110,7 @@ describe('`code-analyzer rules` tests', () => {
 			expect(executeSpy).toHaveBeenCalled();
 			expect(receivedActionInput).toHaveProperty('view', inputValue);
 			expect(createActionSpy).toHaveBeenCalled();
-			expect(receivedActionDependencies.viewer.constructor.name).toEqual('RuleTableViewer');
+			expect(receivedActionDependencies.viewer.constructor.name).toEqual('RuleTableDisplayer');
 		});
 
 		it('Accepts the value, "detail"', async () => {
@@ -119,7 +119,7 @@ describe('`code-analyzer rules` tests', () => {
 			expect(executeSpy).toHaveBeenCalled();
 			expect(receivedActionInput).toHaveProperty('view', inputValue);
 			expect(createActionSpy).toHaveBeenCalled();
-			expect(receivedActionDependencies.viewer.constructor.name).toEqual('RuleDetailViewer');
+			expect(receivedActionDependencies.viewer.constructor.name).toEqual('RuleDetailDisplayer');
 		});
 
 		it('Rejects all other values', async () => {
@@ -134,7 +134,7 @@ describe('`code-analyzer rules` tests', () => {
 			expect(executeSpy).toHaveBeenCalled();
 			expect(receivedActionInput).toHaveProperty('view', 'table');
 			expect(createActionSpy).toHaveBeenCalled();
-			expect(receivedActionDependencies.viewer.constructor.name).toEqual('RuleTableViewer');
+			expect(receivedActionDependencies.viewer.constructor.name).toEqual('RuleTableDisplayer');
 		});
 
 		it('Can be supplied only once', async () => {
@@ -152,7 +152,7 @@ describe('`code-analyzer rules` tests', () => {
 			expect(executeSpy).toHaveBeenCalled();
 			expect(receivedActionInput).toHaveProperty('view', inputValue);
 			expect(createActionSpy).toHaveBeenCalled();
-			expect(receivedActionDependencies.viewer.constructor.name).toEqual('RuleDetailViewer');
+			expect(receivedActionDependencies.viewer.constructor.name).toEqual('RuleDetailDisplayer');
 		});
 	});
 

--- a/test/commands/code-analyzer/run.test.ts
+++ b/test/commands/code-analyzer/run.test.ts
@@ -295,14 +295,14 @@ describe('`code-analyzer run` tests', () => {
 			const inputValue = 'table';
 			await RunCommand.run(['--view', inputValue]);
 			expect(createActionSpy).toHaveBeenCalled();
-			expect(receivedActionDependencies.viewer.constructor.name).toEqual('ResultsTableDisplayer');
+			expect(receivedActionDependencies.resultsViewer.constructor.name).toEqual('ResultsTableDisplayer');
 		});
 
 		it('Accepts the value, "detail"', async () => {
 			const inputValue = 'detail';
 			await RunCommand.run(['--view', inputValue]);
 			expect(createActionSpy).toHaveBeenCalled();
-			expect(receivedActionDependencies.viewer.constructor.name).toEqual('ResultsDetailDisplayer');
+			expect(receivedActionDependencies.resultsViewer.constructor.name).toEqual('ResultsDetailDisplayer');
 		});
 
 		it('Rejects all other values', async () => {
@@ -315,7 +315,7 @@ describe('`code-analyzer run` tests', () => {
 		it('Defaults to value of "table"', async () => {
 			await RunCommand.run([]);
 			expect(createActionSpy).toHaveBeenCalled();
-			expect(receivedActionDependencies.viewer.constructor.name).toEqual('ResultsTableDisplayer');
+			expect(receivedActionDependencies.resultsViewer.constructor.name).toEqual('ResultsTableDisplayer');
 		});
 
 		it('Can be supplied only once', async () => {
@@ -331,7 +331,7 @@ describe('`code-analyzer run` tests', () => {
 			const inputValue = 'detail';
 			await RunCommand.run(['-v', inputValue]);
 			expect(createActionSpy).toHaveBeenCalled();
-			expect(receivedActionDependencies.viewer.constructor.name).toEqual('ResultsDetailDisplayer');
+			expect(receivedActionDependencies.resultsViewer.constructor.name).toEqual('ResultsDetailDisplayer');
 		});
 	});
 });

--- a/test/commands/code-analyzer/run.test.ts
+++ b/test/commands/code-analyzer/run.test.ts
@@ -295,14 +295,14 @@ describe('`code-analyzer run` tests', () => {
 			const inputValue = 'table';
 			await RunCommand.run(['--view', inputValue]);
 			expect(createActionSpy).toHaveBeenCalled();
-			expect(receivedActionDependencies.viewer.constructor.name).toEqual('ResultsTableViewer');
+			expect(receivedActionDependencies.viewer.constructor.name).toEqual('ResultsTableDisplayer');
 		});
 
 		it('Accepts the value, "detail"', async () => {
 			const inputValue = 'detail';
 			await RunCommand.run(['--view', inputValue]);
 			expect(createActionSpy).toHaveBeenCalled();
-			expect(receivedActionDependencies.viewer.constructor.name).toEqual('ResultsDetailViewer');
+			expect(receivedActionDependencies.viewer.constructor.name).toEqual('ResultsDetailDisplayer');
 		});
 
 		it('Rejects all other values', async () => {
@@ -315,7 +315,7 @@ describe('`code-analyzer run` tests', () => {
 		it('Defaults to value of "table"', async () => {
 			await RunCommand.run([]);
 			expect(createActionSpy).toHaveBeenCalled();
-			expect(receivedActionDependencies.viewer.constructor.name).toEqual('ResultsTableViewer');
+			expect(receivedActionDependencies.viewer.constructor.name).toEqual('ResultsTableDisplayer');
 		});
 
 		it('Can be supplied only once', async () => {
@@ -331,7 +331,7 @@ describe('`code-analyzer run` tests', () => {
 			const inputValue = 'detail';
 			await RunCommand.run(['-v', inputValue]);
 			expect(createActionSpy).toHaveBeenCalled();
-			expect(receivedActionDependencies.viewer.constructor.name).toEqual('ResultsDetailViewer');
+			expect(receivedActionDependencies.viewer.constructor.name).toEqual('ResultsDetailDisplayer');
 		});
 	});
 });

--- a/test/fixtures/comparison-files/lib/viewers/ResultsViewer.test.ts/four-identical-violations-summary.txt
+++ b/test/fixtures/comparison-files/lib/viewers/ResultsViewer.test.ts/four-identical-violations-summary.txt
@@ -1,3 +1,0 @@
-=== Summary
-Found 4 violation(s):
-    4 Low severity violation(s) found

--- a/test/fixtures/comparison-files/lib/viewers/RunSummaryViewer.test.ts/four-unique-violations-summary.txt
+++ b/test/fixtures/comparison-files/lib/viewers/RunSummaryViewer.test.ts/four-unique-violations-summary.txt
@@ -1,3 +1,3 @@
 Found 4 violation(s):
-    1 High severity violation(s) found
-    3 Low severity violation(s) found
+    1 High severity violation(s) found.
+    3 Low severity violation(s) found.

--- a/test/fixtures/comparison-files/lib/viewers/RunSummaryViewer.test.ts/four-unique-violations-summary.txt
+++ b/test/fixtures/comparison-files/lib/viewers/RunSummaryViewer.test.ts/four-unique-violations-summary.txt
@@ -1,4 +1,3 @@
-=== Summary
 Found 4 violation(s):
     1 High severity violation(s) found
     3 Low severity violation(s) found

--- a/test/lib/viewers/ResultsViewer.test.ts
+++ b/test/lib/viewers/ResultsViewer.test.ts
@@ -48,7 +48,7 @@ describe('ResultsViewer implementations', () => {
 			viewer = new ResultsDetailDisplayer(spyDisplay);
 		});
 
-		it('When given no results, outputs top-level count and nothing else', async () => {
+		it('When given no results, outputs nothing', async () => {
 			// ==== TEST SETUP ====
 			// "Run" the plugin without assigning any violations.
 			const workspace = await codeAnalyzerCore.createWorkspace(['package.json']);
@@ -60,13 +60,9 @@ describe('ResultsViewer implementations', () => {
 			viewer.view(results);
 
 			// ==== ASSERTIONS ====
-			// Assert against our messages.
+			// Expect nothing to have been displayed.
 			const displayEvents = spyDisplay.getDisplayEvents();
-			expect(displayEvents).toHaveLength(1);
-			expect(displayEvents).toEqual([{
-				type: DisplayEventType.LOG,
-				data: getMessage(BundleName.ResultsViewer, 'summary.found-no-results')
-			}]);
+			expect(displayEvents).toHaveLength(0);
 		});
 
 		it(`When there are violations, all are shown`, async () => {
@@ -95,9 +91,7 @@ describe('ResultsViewer implementations', () => {
 			const actualEventText = ansis.strip(actualDisplayEvents.map(e => e.data).join('\n'));
 			const expectedViolationDetails = (await readComparisonFile('four-identical-violations-details.txt'))
 				.replace(/__PATH_TO_SOME_FILE__/g, PATH_TO_SOME_FILE);
-			const expectedViolationSummary = await readComparisonFile('four-identical-violations-summary.txt');
 			expect(actualEventText).toContain(expectedViolationDetails);
-			expect(actualEventText).toContain(expectedViolationSummary);
 		});
 
 		// The reasoning behind this sorting order is so that the Detail view can function as a "show me the N most
@@ -136,9 +130,7 @@ describe('ResultsViewer implementations', () => {
 			const expectedViolationDetails = (await readComparisonFile('four-unique-violations-details.txt'))
 				.replace(/__PATH_TO_FILE_A__/g, PATH_TO_FILE_A)
 				.replace(/__PATH_TO_FILE_Z__/g, PATH_TO_FILE_Z);
-			const expectedViolationSummary = await readComparisonFile('four-unique-violations-summary.txt');
 			expect(actualEventText).toContain(expectedViolationDetails);
-			expect(actualEventText).toContain(expectedViolationSummary);
 		});
 	});
 
@@ -149,24 +141,21 @@ describe('ResultsViewer implementations', () => {
 			viewer = new ResultsTableDisplayer(spyDisplay);
 		})
 
-		it('When given no results, outputs top-level count and nothing else', async () => {
-			// ==== SETUP ====
+		it('When given no results, outputs nothing', async () => {
+			// ==== TEST SETUP ====
+			// "Run" the plugin without assigning any violations.
 			const workspace = await codeAnalyzerCore.createWorkspace(['package.json']);
-			const rules = await codeAnalyzerCore.selectRules(['all']);
-			// Run without having assigned any violations.
+			const rules = await codeAnalyzerCore.selectRules(['all'], {workspace});
 			const results = await codeAnalyzerCore.run(rules, {workspace});
 
-			// ==== TESTED BEHAVIOR ====
-			// Pass the empty results object into the viewer.
+			// ==== TESTED METHOD ====
+			// Pass the empty result object into the viewer.
 			viewer.view(results);
 
 			// ==== ASSERTIONS ====
+			// Expect nothing to have been displayed.
 			const displayEvents = spyDisplay.getDisplayEvents();
-			expect(displayEvents).toHaveLength(1);
-			expect(displayEvents).toEqual([{
-				type: DisplayEventType.LOG,
-				data: getMessage(BundleName.ResultsViewer, 'summary.found-no-results')
-			}]);
+			expect(displayEvents).toHaveLength(0);
 		});
 
 		it('When given violations, they are displayed as a table', async () => {
@@ -187,14 +176,11 @@ describe('ResultsViewer implementations', () => {
 
 			// ==== ASSERTIONS ====
 			const displayEvents = spyDisplay.getDisplayEvents();
-			expect(displayEvents).toHaveLength(6);
+			expect(displayEvents).toHaveLength(3);
 			expect(displayEvents[0].type).toEqual(DisplayEventType.LOG);
 			expect(displayEvents[0].data).toEqual(getMessage(BundleName.ResultsViewer, 'summary.table.found-results', [4, 1, PATH_TO_SAMPLE_CODE]));
 			expect(displayEvents[1].type).toEqual(DisplayEventType.TABLE);
 			expect(displayEvents[1].data).toEqual(`{"columns":["#","Severity","Rule","Location","Message"],"rows":[{"num":1,"location":"someFile.cls:1:1","rule":"stubEngine1:stub1RuleA","severity":"4 (Low)","message":"This is a message"},{"num":2,"location":"someFile.cls:1:1","rule":"stubEngine1:stub1RuleA","severity":"4 (Low)","message":"This is a message"},{"num":3,"location":"someFile.cls:1:1","rule":"stubEngine1:stub1RuleA","severity":"4 (Low)","message":"This is a message"},{"num":4,"location":"someFile.cls:1:1","rule":"stubEngine1:stub1RuleA","severity":"4 (Low)","message":"This is a message"}]}`);
-			const expectedViolationSummary = await readComparisonFile('four-identical-violations-summary.txt');
-			const actualEventText = ansis.strip(displayEvents.map(e => e.data).join('\n'));
-			expect(actualEventText).toContain(expectedViolationSummary);
 		});
 
 		// The reasoning behind this sorting order is so that the Table view can function as a "show me all the violations
@@ -222,14 +208,11 @@ describe('ResultsViewer implementations', () => {
 
 			// ==== ASSERTIONS ====
 			const displayEvents = spyDisplay.getDisplayEvents();
-			expect(displayEvents).toHaveLength(7);
+			expect(displayEvents).toHaveLength(3);
 			expect(displayEvents[0].type).toEqual(DisplayEventType.LOG);
 			expect(displayEvents[0].data).toEqual(getMessage(BundleName.ResultsViewer, 'summary.table.found-results', [4, 2, PATH_TO_SAMPLE_CODE]));
 			expect(displayEvents[1].type).toEqual(DisplayEventType.TABLE);
 			expect(displayEvents[1].data).toEqual(`{"columns":["#","Severity","Rule","Location","Message"],"rows":[{"num":1,"location":"fileZ.cls:20:1","rule":"stubEngine1:stub1RuleB","severity":"2 (High)","message":"This is a message"},{"num":2,"location":"fileA.cls:1:1","rule":"stubEngine1:stub1RuleA","severity":"4 (Low)","message":"This is a message"},{"num":3,"location":"fileA.cls:20:1","rule":"stubEngine1:stub1RuleA","severity":"4 (Low)","message":"This is a message"},{"num":4,"location":"fileZ.cls:1:1","rule":"stubEngine1:stub1RuleA","severity":"4 (Low)","message":"This is a message"}]}`);
-			const expectedViolationSummary = await readComparisonFile('four-unique-violations-summary.txt');
-			const actualEventText = ansis.strip(displayEvents.map(e => e.data).join('\n'));
-			expect(actualEventText).toContain(expectedViolationSummary);
 		});
 	});
 });

--- a/test/lib/viewers/ResultsViewer.test.ts
+++ b/test/lib/viewers/ResultsViewer.test.ts
@@ -6,8 +6,8 @@ import {RuleDescription, Violation} from '@salesforce/code-analyzer-engine-api';
 
 import {
 	findLongestCommonParentFolderOf,
-	ResultsDetailViewer,
-	ResultsTableViewer
+	ResultsDetailDisplayer,
+	ResultsTableDisplayer
 } from '../../../src/lib/viewers/ResultsViewer';
 import {BundleName, getMessage} from '../../../src/lib/messages';
 import {DisplayEvent, DisplayEventType, SpyDisplay} from '../../stubs/SpyDisplay';
@@ -41,11 +41,11 @@ describe('ResultsViewer implementations', () => {
 		rule2 = (await engine1.describeRules())[1];
 	});
 
-	describe('ResultsDetailViewer', () => {
-		let viewer: ResultsDetailViewer;
+	describe('ResultsDetailDisplayer', () => {
+		let viewer: ResultsDetailDisplayer;
 
 		beforeEach(() => {
-			viewer = new ResultsDetailViewer(spyDisplay);
+			viewer = new ResultsDetailDisplayer(spyDisplay);
 		});
 
 		it('When given no results, outputs top-level count and nothing else', async () => {
@@ -142,11 +142,11 @@ describe('ResultsViewer implementations', () => {
 		});
 	});
 
-	describe('ResultsTableViewer', () => {
-		let viewer: ResultsTableViewer;
+	describe('ResultsTableDisplayer', () => {
+		let viewer: ResultsTableDisplayer;
 
 		beforeEach(() => {
-			viewer = new ResultsTableViewer(spyDisplay);
+			viewer = new ResultsTableDisplayer(spyDisplay);
 		})
 
 		it('When given no results, outputs top-level count and nothing else', async () => {

--- a/test/lib/viewers/RuleViewer.test.ts
+++ b/test/lib/viewers/RuleViewer.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'path';
 import ansis from 'ansis';
-import {RuleDetailViewer, RuleTableViewer} from '../../../src/lib/viewers/RuleViewer';
+import {RuleDetailDisplayer, RuleTableDisplayer} from '../../../src/lib/viewers/RuleViewer';
 import {DisplayEventType, SpyDisplay} from '../../stubs/SpyDisplay';
 import * as StubRules from '../../stubs/StubRules';
 
@@ -9,10 +9,10 @@ const PATH_TO_COMPARISON_FILES = path.resolve(__dirname, '..', '..', '..', 'test
 	'viewers', 'RuleViewer.test.ts');
 
 describe('RuleViewer implementations', () => {
-	describe('RuleDetailViewer', () => {
+	describe('RuleDetailDisplayer', () => {
 		it('When given no rules, outputs summary and nothing else', () => {
 			const display = new SpyDisplay();
-			const viewer = new RuleDetailViewer(display);
+			const viewer = new RuleDetailDisplayer(display);
 
 			viewer.view([]);
 
@@ -26,7 +26,7 @@ describe('RuleViewer implementations', () => {
 
 		it('When given one rule, outputs correct summary and correctly styled rule data', () => {
 			const display = new SpyDisplay();
-			const viewer = new RuleDetailViewer(display);
+			const viewer = new RuleDetailDisplayer(display);
 			const rule = new StubRules.StubRule1();
 
 			viewer.view([
@@ -47,7 +47,7 @@ describe('RuleViewer implementations', () => {
 
 		it('When given multiple rules, outputs correct summary and correctly styled rule data', () => {
 			const display = new SpyDisplay();
-			const viewer = new RuleDetailViewer(display);
+			const viewer = new RuleDetailDisplayer(display);
 			const rule1 = new StubRules.StubRule1();
 			const rule2 = new StubRules.StubRule2();
 
@@ -69,10 +69,10 @@ describe('RuleViewer implementations', () => {
 		});
 	});
 
-	describe('RuleTableViewer', () => {
+	describe('RuleTableDisplayer', () => {
 		it('When given no rules, outputs summary and nothing else', () => {
 			const display = new SpyDisplay();
-			const viewer = new RuleTableViewer(display);
+			const viewer = new RuleTableDisplayer(display);
 
 			viewer.view([]);
 
@@ -86,7 +86,7 @@ describe('RuleViewer implementations', () => {
 
 		it('When given one rule, outputs correct summary and rule data', () => {
 			const display = new SpyDisplay();
-			const viewer = new RuleTableViewer(display);
+			const viewer = new RuleTableDisplayer(display);
 			const rule = new StubRules.StubRule1();
 
 			viewer.view([
@@ -115,7 +115,7 @@ describe('RuleViewer implementations', () => {
 
 		it('When given multiple rules, outputs correct summary and rule data', () => {
 			const display = new SpyDisplay();
-			const viewer = new RuleTableViewer(display);
+			const viewer = new RuleTableDisplayer(display);
 			const rule1 = new StubRules.StubRule1();
 			const rule2 = new StubRules.StubRule2();
 

--- a/test/lib/viewers/RunSummaryViewer.test.ts
+++ b/test/lib/viewers/RunSummaryViewer.test.ts
@@ -1,0 +1,149 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import ansis from 'ansis';
+import {CodeAnalyzer, CodeAnalyzerConfig, RunResults} from '@salesforce/code-analyzer-core';
+import {Violation} from "@salesforce/code-analyzer-engine-api";
+
+import {RunSummaryDisplayer} from '../../../src/lib/viewers/RunSummaryViewer';
+
+import {DisplayEvent, DisplayEventType, SpyDisplay} from "../../stubs/SpyDisplay";
+import {FunctionalStubEnginePlugin1, StubEngine1} from '../../stubs/StubEnginePlugins';
+
+const PATH_TO_COMPARISON_FILES = path.resolve(__dirname, '..', '..', '..', 'test', 'fixtures', 'comparison-files', 'lib',
+	'viewers', 'RunSummaryViewer.test.ts');
+const PATH_TO_SAMPLE_CODE = path.resolve(__dirname, '..', '..', '..', 'test', 'sample-code');
+const PATH_TO_OUTFILE1 = path.join('the', 'specifics', 'of', 'this', 'path', 'do', 'not', 'matter.csv');
+const PATH_TO_OUTFILE2 = path.join('neither', 'do', 'the', 'specifics', 'of', 'this', 'one.json');
+const PATH_TO_FILE_A = path.resolve(PATH_TO_SAMPLE_CODE, 'fileA.cls');
+const PATH_TO_FILE_Z = path.resolve(PATH_TO_SAMPLE_CODE, 'fileZ.cls');
+
+describe('RunSummaryViewer implementations', () => {
+	// We need SpyDisplays for the cases where inputs are empty and non-empty.
+	const emptyInputsSpyDisplay: SpyDisplay = new SpyDisplay();
+	const nonEmptyInputsSpyDisplay: SpyDisplay = new SpyDisplay();
+
+	// We need a config, core, and plugin.
+	const config: CodeAnalyzerConfig = CodeAnalyzerConfig.withDefaults();
+	const codeAnalyzerCore: CodeAnalyzer = new CodeAnalyzer(config);
+	const stubEnginePlugin: FunctionalStubEnginePlugin1 = new FunctionalStubEnginePlugin1();
+
+	let emptyResults: RunResults;
+	let nonEmptyResults: RunResults;
+
+	// The tests are similar enough that we can do all of the setup in the `beforeAll()` functions.
+	beforeAll(async () => {
+		// Add the stub plugin to the core.
+		await codeAnalyzerCore.addEnginePlugin(stubEnginePlugin);
+
+		// Run the core once without assigning any violations.
+		const workspace = await codeAnalyzerCore.createWorkspace(['package.json']);
+		const rules = await codeAnalyzerCore.selectRules(['all'], {workspace});
+		emptyResults = await codeAnalyzerCore.run(rules, {workspace});
+
+		// Assign some violations and then run the core again.
+		const engine1 = stubEnginePlugin.getCreatedEngine(`stubEngine1`) as StubEngine1;
+		const rule1 = (await engine1.describeRules())[0];
+		const rule2 = (await engine1.describeRules())[1];
+		const violations: Violation[] = [
+			// A low-severity violation late in a high-alphabetical file.
+			createViolation(rule1.name, PATH_TO_FILE_A, 20, 1),
+			// A low-severity violation early in the same high-alphabetical file.
+			createViolation(rule1.name, PATH_TO_FILE_A, 1, 1),
+			// A low-severity violation early in a low-alphabetical file.
+			createViolation(rule1.name, PATH_TO_FILE_Z, 1, 1),
+			// A high-severity violation later in the same low-alphabetical file.
+			createViolation(rule2.name, PATH_TO_FILE_Z, 20, 1)
+		];
+		engine1.resultsToReturn = {violations};
+
+		nonEmptyResults = await codeAnalyzerCore.run(rules, {workspace});
+	});
+
+	describe('RunSummaryDisplayer', () => {
+		// Create Displayers for the empty-input and non-empty-input cases.
+		const emptyInputsDisplayer: RunSummaryDisplayer = new RunSummaryDisplayer(emptyInputsSpyDisplay);
+		const nonEmptyInputsDisplayer: RunSummaryDisplayer = new RunSummaryDisplayer(nonEmptyInputsSpyDisplay);
+
+		let emptyInputsDisplayEvents: DisplayEvent[];
+		let nonEmptyInputsDisplayEvents: DisplayEvent[];
+
+		beforeAll(() => {
+			emptyInputsDisplayer.view(emptyResults, config, []);
+			emptyInputsDisplayEvents = emptyInputsSpyDisplay.getDisplayEvents();
+			nonEmptyInputsDisplayer.view(nonEmptyResults, config, [PATH_TO_OUTFILE1, PATH_TO_OUTFILE2])
+			nonEmptyInputsDisplayEvents = nonEmptyInputsSpyDisplay.getDisplayEvents();
+		});
+
+		describe('Formatting', () => {
+			it('Output has correct header', () => {
+				expect(ansis.strip(emptyInputsDisplayEvents[0].data)).toEqual('=== Summary');
+				expect(ansis.strip(nonEmptyInputsDisplayEvents[0].data)).toEqual('=== Summary');
+			});
+
+			it('Output has correct log level', () => {
+				for (const event of emptyInputsDisplayEvents) {
+					expect(event.type).toEqual(DisplayEventType.LOG);
+				}
+				for (const event of nonEmptyInputsDisplayEvents) {
+					expect(event.type).toEqual(DisplayEventType.LOG);
+				}
+			});
+		});
+
+		describe('Results breakdown', () => {
+			it('When no violations exist, correctly outputs this fact', () => {
+				const contents = emptyInputsDisplayEvents.map(e => e.data).join('\n');
+				expect(contents).toContain('Found 0 violations.\n');
+			});
+
+			it('When violations exist, they are broken down by severity', async () => {
+				const contents = nonEmptyInputsDisplayEvents.map(e => e.data).join('\n');
+				const expectedViolationSummary = await readComparisonFile('four-unique-violations-summary.txt');
+				expect(contents).toContain(expectedViolationSummary);
+			});
+		});
+
+		describe('Outfile breakdown', () => {
+			it('When no outfiles were provided, correctly outputs this fact', () => {
+				const contents = emptyInputsDisplayEvents.map(e => e.data).join('\n');
+				expect(contents).toContain('No results files were specified.\n');
+			});
+
+			it('When outfiles were provided, they are properly listed', () => {
+				const contents = nonEmptyInputsDisplayEvents.map(e => e.data).join('\n');
+				const expectation = `Results were written to:\n` +
+					`    ${PATH_TO_OUTFILE1}\n` +
+					`    ${PATH_TO_OUTFILE2}\n`;
+				expect(contents).toContain(expectation);
+			});
+		});
+
+		describe('Logging breakdown', () => {
+			it('Logfile is correctly displayed', () => {
+				const expectation = `Additional log information was written to:\n` +
+					`    ${config.getLogFolder()}`;
+				const emptyContents = emptyInputsDisplayEvents.map(e => e.data).join('\n');
+				const nonEmptyContents = nonEmptyInputsDisplayEvents.map(e => e.data).join('\n');
+				expect(emptyContents).toContain(expectation);
+				expect(nonEmptyContents).toContain(expectation);
+			});
+		});
+	});
+});
+
+function createViolation(ruleName: string, file: string, startLine: number, startColumn: number): Violation {
+	return {
+		ruleName,
+		message: 'This is a message',
+		codeLocations: [{
+			file,
+			startLine,
+			startColumn
+		}],
+		primaryLocationIndex: 0
+	};
+}
+
+function readComparisonFile(fileName: string): Promise<string> {
+	return fs.readFile(path.join(PATH_TO_COMPARISON_FILES, fileName), {encoding: 'utf-8'});
+}

--- a/test/lib/viewers/RunSummaryViewer.test.ts
+++ b/test/lib/viewers/RunSummaryViewer.test.ts
@@ -111,7 +111,7 @@ describe('RunSummaryViewer implementations', () => {
 
 			it('When outfiles were provided, they are properly listed', () => {
 				const contents = nonEmptyInputsDisplayEvents.map(e => e.data).join('\n');
-				const expectation = `Results were written to:\n` +
+				const expectation = `Results written to:\n` +
 					`    ${PATH_TO_OUTFILE1}\n` +
 					`    ${PATH_TO_OUTFILE2}\n`;
 				expect(contents).toContain(expectation);
@@ -120,7 +120,7 @@ describe('RunSummaryViewer implementations', () => {
 
 		describe('Logging breakdown', () => {
 			it('Logfile is correctly displayed', () => {
-				const expectation = `Additional log information was written to:\n` +
+				const expectation = `Additional log information written to:\n` +
 					`    ${config.getLogFolder()}`;
 				const emptyContents = emptyInputsDisplayEvents.map(e => e.data).join('\n');
 				const nonEmptyContents = nonEmptyInputsDisplayEvents.map(e => e.data).join('\n');

--- a/test/stubs/SpyRunSummaryViewer.ts
+++ b/test/stubs/SpyRunSummaryViewer.ts
@@ -1,0 +1,14 @@
+import {CodeAnalyzerConfig, RunResults} from '@salesforce/code-analyzer-core';
+import {RunSummaryViewer} from '../../src/lib/viewers/RunSummaryViewer'
+
+export class SpyRunSummaryViewer implements RunSummaryViewer {
+	private callHistory: {results: RunResults, config: CodeAnalyzerConfig, outfiles: string[]}[] = [];
+
+	public view(results: RunResults, config: CodeAnalyzerConfig, outfiles: string[]): void {
+		this.callHistory.push({results, config, outfiles});
+	}
+
+	public getCallHistory(): {results: RunResults, config: CodeAnalyzerConfig, outfiles: string[]}[] {
+		return this.callHistory;
+	}
+}


### PR DESCRIPTION
Previously, the run summary only had a breakdown of violations by severity.
Now it also includes information about which results files and log files were written to.
E.g.,
```
=== Summary

Found 4 violation(s):
  1 High severity violation(s) found
  1 Moderate severity violation(s) found
  2 Low severity violation(s) found

Results were written to:
  /Users/me/sampleProject/results/report.html
  /Users/me/sampleProject/results/output.json

Additional log information was written to:
  /tmp/sfca_logs/code-analyzer-run-2024-04-18-15460159.10g
```