### PR TITLE
CHANGE @W-16606246@ config command asks confirmation before overwriting existing file

### DIFF
--- a/messages/config-writer.md
+++ b/messages/config-writer.md
@@ -1,3 +1,7 @@
 # error.unrecognized-file-format
 
 The output file %s has an unsupported extension. Valid extensions include: .yaml/.yml.
+
+# prompt.overwrite-existing-file
+
+A file named %s already exists. Overwrite?

--- a/messages/config-writer.md
+++ b/messages/config-writer.md
@@ -4,4 +4,4 @@ The output file %s has an unsupported extension. Valid extensions include: .yaml
 
 # prompt.overwrite-existing-file
 
-A file named %s already exists. Overwrite?
+A file named %s already exists. Do you want to overwrite it?

--- a/src/commands/code-analyzer/config.ts
+++ b/src/commands/code-analyzer/config.ts
@@ -73,7 +73,7 @@ export default class ConfigCommand extends SfCommand<void> implements Displayabl
 			viewer: new ConfigStyledYamlViewer(uxDisplay)
 		};
 		if (outputFile) {
-			dependencies.writer = ConfigFileWriter.fromFile(outputFile);
+			dependencies.writer = ConfigFileWriter.fromFile(outputFile, uxDisplay);
 		}
 		return dependencies;
 	}

--- a/src/lib/Display.ts
+++ b/src/lib/Display.ts
@@ -33,6 +33,12 @@ export interface Display {
 	 */
 	displayTable<R extends Ux.Table.Data>(data: R[], columns: Ux.Table.Columns<R>): void;
 
+	/**
+	 * Prompt the user to confirm that the described action should be carried out, and block until they respond (or a timeout
+	 * elapses). Resolves to {@code true} if the user confirms, or {@code false} if they don't.
+	 */
+	confirm(message: string): Promise<boolean>;
+
 	spinnerStart(msg: string, status?: string): void;
 
 	spinnerUpdate(status: string): void;
@@ -71,6 +77,10 @@ export class UxDisplay implements Display {
 		this.displayable.table(data, columns);
 	}
 
+	public confirm(message: string): Promise<boolean> {
+		return this.displayable.confirm(message);
+	}
+
 	public spinnerStart(msg: string, status?: string): void {
 		this.spinner.start(msg, status);
 	}
@@ -99,6 +109,9 @@ export interface Displayable {
 
 	// Output message to stdout at log-level (non-blocking) only when "--json" flag is not present.  [Implemented by Command]
 	log(message?: string): void;
+
+	// Prompt the user to confirm that the described action should be performed.                     [Implemented by SfCommand]
+	confirm(message: string): Promise<boolean>;
 
 	// Output table to stdout only when "--json" flag is not present.                                [Implemented by SfCommand]
 	table<R extends Ux.Table.Data>(data: R[], columns: Ux.Table.Columns<R>, options?: Ux.Table.Options): void;

--- a/src/lib/actions/ConfigAction.ts
+++ b/src/lib/actions/ConfigAction.ts
@@ -118,7 +118,7 @@ export class ConfigAction {
 		const configModel: ConfigModel = this.dependencies.modelGenerator(relevantEngines, userConfigContext, defaultConfigContext);
 
 		this.dependencies.viewer.view(configModel);
-		this.dependencies.writer?.write(configModel);
+		await this.dependencies.writer?.write(configModel);
 		return Promise.resolve();
 	}
 

--- a/src/lib/utils/FileUtil.ts
+++ b/src/lib/utils/FileUtil.ts
@@ -1,0 +1,10 @@
+import * as fs from 'node:fs';
+
+export async function exists(filename: string): Promise<boolean> {
+	try {
+		await fs.promises.access(filename, fs.constants.F_OK);
+		return true;
+	} catch (e) {
+		return false;
+	}
+}

--- a/src/lib/writers/ConfigWriter.ts
+++ b/src/lib/writers/ConfigWriter.ts
@@ -2,28 +2,35 @@ import path from 'node:path';
 import fs from 'node:fs';
 import {ConfigModel, OutputFormat} from '../models/ConfigModel';
 import {BundleName, getMessage} from '../messages';
+import {Display} from '../Display';
+import {exists} from '../utils/FileUtil';
 
 export interface ConfigWriter {
-	write(model: ConfigModel): void;
+	write(model: ConfigModel): Promise<void>;
 }
 
 export class ConfigFileWriter implements ConfigWriter {
 	private readonly file: string;
 	private readonly format: OutputFormat;
+	private readonly display: Display;
 
-	private constructor(file: string, format: OutputFormat) {
+	private constructor(file: string, format: OutputFormat, display: Display) {
 		this.file = file;
 		this.format = format;
+		this.display = display;
 	}
 
-	public write(model: ConfigModel): void {
-		fs.writeFileSync(this.file, model.toFormattedOutput(this.format));
+	public async write(model: ConfigModel): Promise<void> {
+		// Only write to the file if it doesn't already exist, or if the user confirms that they want to overwrite it.
+		if (!(await exists(this.file)) || await this.display.confirm(getMessage(BundleName.ConfigWriter, 'prompt.overwrite-existing-file', [this.file]))) {
+			fs.writeFileSync(this.file, model.toFormattedOutput(this.format));
+		}
 	}
 
-	public static fromFile(file: string): ConfigFileWriter {
+	public static fromFile(file: string, display: Display): ConfigFileWriter {
 		const ext = path.extname(file).toLowerCase();
 		if (ext === '.yaml' || ext === '.yml') {
-			return new ConfigFileWriter(file, OutputFormat.RAW_YAML);
+			return new ConfigFileWriter(file, OutputFormat.RAW_YAML, display);
 		} else {
 			throw new Error(getMessage(BundleName.ConfigWriter, 'error.unrecognized-file-format', [file]));
 		}

--- a/test/commands/code-analyzer/config.test.ts
+++ b/test/commands/code-analyzer/config.test.ts
@@ -3,6 +3,7 @@ import {TestContext} from '@salesforce/core/lib/testSetup';
 import ConfigCommand from '../../../src/commands/code-analyzer/config';
 import {ConfigAction, ConfigInput} from '../../../src/lib/actions/ConfigAction';
 import {ConfigFileWriter} from '../../../src/lib/writers/ConfigWriter';
+import {SpyDisplay} from '../../stubs/SpyDisplay';
 
 describe('`code-analyzer config` tests', () => {
 	const $$ = new TestContext();
@@ -164,7 +165,7 @@ describe('`code-analyzer config` tests', () => {
 				const originalFromFile = ConfigFileWriter.fromFile;
 				fromFileSpy = jest.spyOn(ConfigFileWriter, 'fromFile').mockImplementation(file => {
 					receivedFile = file;
-					return originalFromFile(file);
+					return originalFromFile(file, new SpyDisplay());
 				});
 			});
 

--- a/test/lib/writers/ConfigWriter.test.ts
+++ b/test/lib/writers/ConfigWriter.test.ts
@@ -58,7 +58,7 @@ describe('ConfigWriter implementations', () => {
 			expect(displayEvents).toHaveLength(1);
 			// The user should be prompted to confirm override.
 			expect(displayEvents[0].type).toEqual(DisplayEventType.CONFIRM);
-			expect(displayEvents[0].data).toContain('Overwrite');
+			expect(displayEvents[0].data).toContain('overwrite');
 			expect(writeFileSpy).toHaveBeenCalledTimes(expectedCallCount);
 		});
 

--- a/test/lib/writers/ConfigWriter.test.ts
+++ b/test/lib/writers/ConfigWriter.test.ts
@@ -1,7 +1,9 @@
 import fs from 'node:fs';
+import path from 'node:path';
 import {OutputFormat} from '../../../src/lib/models/ConfigModel';
 import {ConfigFileWriter} from '../../../src/lib/writers/ConfigWriter';
 import {StubConfigModel} from '../../stubs/StubConfigModel';
+import {DisplayEvent, DisplayEventType, SpyDisplay} from '../../stubs/SpyDisplay';
 
 describe('ConfigWriter implementations', () => {
 	describe('ConfigWriterImpl', () => {
@@ -22,13 +24,16 @@ describe('ConfigWriter implementations', () => {
 		it.each([
 			{ext: '.yaml', expectedOutput: `# This is a leading comment\nResults formatted as ${OutputFormat.RAW_YAML}`},
 			{ext: '.yml', expectedOutput: `# This is a leading comment\nResults formatted as ${OutputFormat.RAW_YAML}`}
-		])('Accepts and outputs valid file format: *$ext', ({ext, expectedOutput}) => {
+		])('Accepts and outputs valid file format: *$ext', async ({ext, expectedOutput}) => {
 			const validFile = `beep${ext}`;
-			const configFileWriter = ConfigFileWriter.fromFile(validFile);
+			const spyDisplay: SpyDisplay = new SpyDisplay(true);
+			const configFileWriter = ConfigFileWriter.fromFile(validFile, spyDisplay);
 
 			const stubbedConfig = new StubConfigModel();
 
-			configFileWriter.write(stubbedConfig);
+			await configFileWriter.write(stubbedConfig);
+
+			expect(spyDisplay.getDisplayEvents()).toHaveLength(0);
 
 			expect(writeFileSpy).toHaveBeenCalled();
 			expect(writeFileInvocations).toEqual([{
@@ -37,9 +42,30 @@ describe('ConfigWriter implementations', () => {
 			}]);
 		});
 
-		it('Rejects invalid file format: *.txt', () => {
+		it.each([
+			{case: 'Confirmation granted', confirmation: true, expectedCallCount: 1},
+			{case: 'Confirmation denied', confirmation: false, expectedCallCount: 0}
+		])('Only overwrites existing file after requesting user confirmation. Case: $case', async ({confirmation, expectedCallCount}) => {
+			const validFile = path.resolve(__dirname, '..', '..', 'fixtures', 'example-workspaces', 'workspace-with-yml-config', 'code-analyzer.yml');
+			const spyDisplay: SpyDisplay = new SpyDisplay(confirmation);
+			const configFileWriter = ConfigFileWriter.fromFile(validFile, spyDisplay);
+
+			const stubbedConfig = new StubConfigModel();
+
+			await configFileWriter.write(stubbedConfig);
+
+			const displayEvents: DisplayEvent[] = spyDisplay.getDisplayEvents();
+			expect(displayEvents).toHaveLength(1);
+			// The user should be prompted to confirm override.
+			expect(displayEvents[0].type).toEqual(DisplayEventType.CONFIRM);
+			expect(displayEvents[0].data).toContain('Overwrite');
+			expect(writeFileSpy).toHaveBeenCalledTimes(expectedCallCount);
+		});
+
+		it('Rejects invalid file format: *.txt', async () => {
 			const invalidFile = 'beep.txt';
-			expect(() => ConfigFileWriter.fromFile(invalidFile)).toThrow(invalidFile);
+			const spyDisplay: SpyDisplay = new SpyDisplay(true);
+			expect(() => ConfigFileWriter.fromFile(invalidFile, spyDisplay)).toThrow(invalidFile);
 		})
 	});
 });

--- a/test/stubs/SpyConfigWriter.ts
+++ b/test/stubs/SpyConfigWriter.ts
@@ -4,8 +4,9 @@ import {ConfigWriter} from '../../src/lib/writers/ConfigWriter';
 export class SpyConfigWriter implements ConfigWriter {
 	private callHistory: ConfigModel[] = [];
 
-	public write(config: ConfigModel): void {
+	public write(config: ConfigModel): Promise<void> {
 		this.callHistory.push(config);
+		return Promise.resolve();
 	}
 
 	public getCallHistory(): ConfigModel[] {

--- a/test/stubs/SpyDisplay.ts
+++ b/test/stubs/SpyDisplay.ts
@@ -7,6 +7,12 @@ import {Ux} from '@salesforce/sf-plugins-core';
 export class SpyDisplay implements Display {
 	private displayEvents: DisplayEvent[] = [];
 
+	private readonly confirmReturnValue: boolean;
+
+	public constructor(confirmReturnValue: boolean = true) {
+		this.confirmReturnValue = confirmReturnValue;
+	}
+
 	/**
 	 * Track that the provided message was displayed as an Error-level output.
 	 */
@@ -58,6 +64,14 @@ export class SpyDisplay implements Display {
 		});
 	}
 
+	public confirm(message: string): Promise<boolean> {
+		this.displayEvents.push({
+			type: DisplayEventType.CONFIRM,
+			data: message
+		});
+		return Promise.resolve(this.confirmReturnValue);
+	}
+
 	/**
 	 * Track that the spinner was started with the provided message, and optionally status.
 	 */
@@ -103,6 +117,7 @@ export enum DisplayEventType {
 	INFO,
 	LOG,
 	TABLE,
+	CONFIRM,
 	SPINNER_START,
 	SPINNER_UPDATE,
 	SPINNER_STOP


### PR DESCRIPTION
When the `code-analyzer config` command is told to write to a file that already exists, it asks the user to confirm that they would like to override the existing file.
![image](https://github.com/user-attachments/assets/ccb19814-39da-4712-a25e-488700c9ca9b)

