### PR TITLE
FIX (CodeAnalyzer) @W-17370746@ - Java Version identification bug fixed

### DIFF
--- a/src/lib/JreSetupManager.ts
+++ b/src/lib/JreSetupManager.ts
@@ -116,7 +116,13 @@ class JreSetupManager extends AsyncCreatable {
 	}
 
 	private async verifyJavaVersion(javaHome: string): Promise<void> {
-		const versionCommandOut = await this.fetchJavaVersion(javaHome);
+		let versionCommandOut: string;
+		try {
+			versionCommandOut = await this.fetchJavaVersion(javaHome);
+		} catch (e) {
+			const msg: string = e instanceof Error ? e.message : e as string;
+			throw new SfError(msg, 'CouldNotFindJavaVersion');
+		}
 
 		// We are using "java -version" below which has output that typically looks like:
 		// * (from MacOS): "openjdk version "11.0.6" 2020-01-14 LTS\nOpenJDK Runtime Environment Zulu11.37+17-CA (build 11.0.6+10-LTS)\nOpenJDK 64-Bit Server VM Zulu11.37+17-CA (build 11.0.6+10-LTS, mixed mode)\n"

--- a/test/lib/JreSetupManager.test.ts
+++ b/test/lib/JreSetupManager.test.ts
@@ -203,6 +203,30 @@ describe('JreSetupManager #verifyJreSetup', () => {
 			statStub.restore();
 		});
 
+		it('should fail when valid path is found, but Java version cannot be returned', async () => {
+			// More stubbing
+			Sinon.stub(Config.prototype, 'getJavaHome').returns(javaHomeValidPath);
+			// FileHandler claims the path is valid.
+			Sinon.stub(FileHandler.prototype, 'stats').resolves();
+			// Error indicates that version could not be retrieved.
+			Sinon.stub(childProcess, 'execFile').yields(error, emptyStdout, 'irrelevant');
+
+			// Execute and verify
+			let threw = false;
+			let name: string = '';
+			let message: string = '';
+			try {
+				await verifyJreSetup();
+			} catch (err) {
+				threw = true;
+				name = err.name;
+				message = err instanceof Error ? err.message : err as string;
+			}
+			expect(threw).equals(true);
+			expect(message).contains('Could not fetch Java version from path');
+			expect(name).equals('CouldNotFindJavaVersion');
+		});
+
 		it('should fail when valid path is found, but Java version is not acceptable', async () => {
 			// More stubbing
 			const configGetJavaHomeStub = Sinon.stub(Config.prototype, 'getJavaHome').returns(javaHomeValidPath);


### PR DESCRIPTION
Explanation of bug: The bug occurred when `javaHome` was set to a valid path to a real folder, but that folder wasn't a functional Java home (i.e. would throw an error if you used it for `blah -version`).
This happens because an invalid path is caught in an earlier step, and a valid path that corresponds to an unacceptable version of Java is caught in a later step. Both of those cases are properly handled by throwing an SfError. Here, we were just rejecting a Promise, which was bubbling back up through the call stack in an unfriendly way. Properly throwing an SfError resolves the issue.