### PR TITLE
NEW @W-21741616@ Adding changes for supporting bulk suppressions in run and config commands

### DIFF
--- a/messages/config-command.md
+++ b/messages/config-command.md
@@ -117,3 +117,11 @@ Include unmodified rules in the rule override settings.
 # flags.include-unmodified-rules.description
 
 The default behavior of the config command is to not include the unmodified rules with their default values in the rule override settings (for the rules selected via the `–-rule-selector` flag). This default behavior prevents your configuration file from being unnecessarily large. If you want to include the unmodified rules, in addition to the modified rules, then specify this flag.
+
+# flags.no-suppressions.summary
+
+Exclude suppressions from the output configuration.
+
+# flags.no-suppressions.description
+
+When specified, the 'suppressions' field is not included in the configuration state. Since the 'suppressions' field may contain file or folder paths specific to a specific path, use this flag to make it easy to share your configuration state to be used for a different workspace.

--- a/messages/run-command.md
+++ b/messages/run-command.md
@@ -164,11 +164,11 @@ When enabled, the output includes suggestion information for violations that hav
 
 # flags.no-suppressions.summary
 
-Disable processing of inline suppression markers.
+Disable processing of inline and bulk suppression markers.
 
 # flags.no-suppressions.description
 
-By default, Code Analyzer processes inline suppression markers (code-analyzer-suppress and code-analyzer-unsuppress) found in your source code to filter out violations. Use this flag to ignore all suppression markers and report all violations.
+When specified, any inline suppression markers (code-analyzer-suppress, code-analyzer-suppress-line, and code-analyzer-suppress-next-line) found in targeted files are ignored and any suppressions supplied by your Code Analyzer configuration file are ignored so that no violations are suppressed by them.
 
 Note: If you have a `code-analyzer.yml` or `code-analyzer.yaml` configuration file with the `suppressions.disable_suppressions` field, the configuration file takes precedence over this flag.
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 	"dependencies": {
 		"@oclif/core": "^4.10.0",
 		"@oclif/table": "^0.5.3",
-		"@salesforce/code-analyzer-core": "0.45.0",
+		"@salesforce/code-analyzer-core": "0.46.0",
 		"@salesforce/code-analyzer-engine-api": "0.36.0",
 		"@salesforce/code-analyzer-eslint-engine": "0.41.0",
 		"@salesforce/code-analyzer-flow-engine": "0.35.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 	"dependencies": {
 		"@oclif/core": "^4.10.0",
 		"@oclif/table": "^0.5.3",
-		"@salesforce/code-analyzer-core": "0.46.0",
+		"@salesforce/code-analyzer-core": "0.46.1",
 		"@salesforce/code-analyzer-engine-api": "0.36.0",
 		"@salesforce/code-analyzer-eslint-engine": "0.41.0",
 		"@salesforce/code-analyzer-flow-engine": "0.35.0",

--- a/src/commands/code-analyzer/config.ts
+++ b/src/commands/code-analyzer/config.ts
@@ -53,6 +53,10 @@ export default class ConfigCommand extends SfCommand<void> implements Displayabl
 		'include-unmodified-rules': Flags.boolean({
 			summary: getMessage(BundleName.ConfigCommand, 'flags.include-unmodified-rules.summary'),
 			description: getMessage(BundleName.ConfigCommand, 'flags.include-unmodified-rules.description')
+		}),
+		'no-suppressions': Flags.boolean({
+			summary: getMessage(BundleName.ConfigCommand, 'flags.no-suppressions.summary'),
+			description: getMessage(BundleName.ConfigCommand, 'flags.no-suppressions.description')
 		})
 	};
 

--- a/src/lib/actions/ConfigAction.ts
+++ b/src/lib/actions/ConfigAction.ts
@@ -27,7 +27,8 @@ export type ConfigInput = {
 	'rule-selector': string[];
 	workspace?: string[];
 	target?: string[];
-	'include-unmodified-rules'?: boolean
+	'include-unmodified-rules'?: boolean;
+	'no-suppressions'?: boolean;
 };
 
 export class ConfigAction {
@@ -139,7 +140,8 @@ export class ConfigAction {
 			...selectedDefaultRules.getEngineNames()]);
 
 		const includeUnmodifiedRules: boolean = input["include-unmodified-rules"] ?? false;
-		const configModel: ConfigModel = new AnnotatedConfigModel(userCore, userRules, allDefaultRules, relevantEngines, includeUnmodifiedRules);
+		const includeSuppressions: boolean = !(input["no-suppressions"] ?? false);
+		const configModel: ConfigModel = new AnnotatedConfigModel(userCore, userRules, allDefaultRules, relevantEngines, includeUnmodifiedRules, includeSuppressions);
 
 		const fileWritten: boolean = this.dependencies.writer
 			? await this.dependencies.writer.write(configModel)

--- a/src/lib/factories/CodeAnalyzerConfigFactory.ts
+++ b/src/lib/factories/CodeAnalyzerConfigFactory.ts
@@ -54,16 +54,38 @@ export class CodeAnalyzerConfigFactoryImpl implements CodeAnalyzerConfigFactory 
 		configFilePath: string,
 		cliOverrides: CliOverrides
 	): CodeAnalyzerConfig {
-		// Read raw YAML to check if suppressions field is explicitly set
+		// Read raw YAML to check if disable_suppressions field is explicitly set
 		const rawYaml: Record<string, unknown> | undefined = this.readRawYamlFile(configFilePath);
-		const suppressionsExplicitlySet = (rawYaml?.suppressions as Record<string, unknown> | undefined)?.disable_suppressions !== undefined;
+		const suppressionsSection = rawYaml?.suppressions as Record<string, unknown> | undefined;
 
-		if (suppressionsExplicitlySet) {
-			// YAML explicitly sets suppressions - use it as-is (YAML wins)
+		// Check if disable_suppressions is explicitly set in YAML
+		const disableSuppressionExplicitlySet = suppressionsSection?.disable_suppressions !== undefined;
+
+		// If YAML explicitly sets disable_suppressions, YAML wins completely (no CLI override)
+		if (disableSuppressionExplicitlySet) {
 			return CodeAnalyzerConfig.fromFile(configFilePath);
 		}
 
-		// Config file exists but doesn't specify suppressions - merge with CLI overrides
+		// At this point, disable_suppressions is NOT in YAML
+		// Check if we have bulk suppressions (file paths with arrays)
+		const hasBulkSuppressions = suppressionsSection && Object.keys(suppressionsSection).some(
+			key => key !== 'disable_suppressions' && Array.isArray(suppressionsSection[key])
+		);
+
+		// If CLI override provided and we have bulk suppressions, merge them
+		if (cliOverrides.noSuppressions !== undefined && hasBulkSuppressions && rawYaml) {
+			// Preserve bulk suppressions from YAML, apply CLI override to disable_suppressions
+			const mergedConfig: Record<string, unknown> = {
+				...rawYaml,
+				suppressions: {
+					...suppressionsSection,
+					disable_suppressions: cliOverrides.noSuppressions
+				}
+			};
+			return CodeAnalyzerConfig.fromObject(mergedConfig);
+		}
+
+		// If CLI override provided but no bulk suppressions (or no suppressions section at all)
 		if (cliOverrides.noSuppressions !== undefined && rawYaml) {
 			const mergedConfig: Record<string, unknown> = {
 				...rawYaml,

--- a/src/lib/models/ConfigModel.ts
+++ b/src/lib/models/ConfigModel.ts
@@ -35,21 +35,23 @@ export class AnnotatedConfigModel implements ConfigModel {
 	private readonly  relevantEngines: Set<string>;
 
 	private readonly includeUnmodifiedRules: boolean;
+	private readonly includeSuppressions: boolean;
 
-	constructor(codeAnalyzer: CodeAnalyzer, userRules: RuleSelection, allDefaultRules: RuleSelection, relevantEngines: Set<string>, includeUnmodifiedRules: boolean) {
+	constructor(codeAnalyzer: CodeAnalyzer, userRules: RuleSelection, allDefaultRules: RuleSelection, relevantEngines: Set<string>, includeUnmodifiedRules: boolean, includeSuppressions: boolean = true) {
 		this.codeAnalyzer = codeAnalyzer;
 		this.userRules = userRules;
 		this.allDefaultRules = allDefaultRules;
 		this.relevantEngines = relevantEngines;
 		this.includeUnmodifiedRules = includeUnmodifiedRules;
+		this.includeSuppressions = includeSuppressions;
 	}
 
 	toFormattedOutput(format: OutputFormat): string {
 		// istanbul ignore else: Should be impossible
 		if (format === OutputFormat.STYLED_YAML) {
-			return new StyledYamlFormatter(this.codeAnalyzer, this.userRules, this.allDefaultRules, this.relevantEngines, this.includeUnmodifiedRules).toYaml();
+			return new StyledYamlFormatter(this.codeAnalyzer, this.userRules, this.allDefaultRules, this.relevantEngines, this.includeUnmodifiedRules, this.includeSuppressions).toYaml();
 		} else if (format === OutputFormat.RAW_YAML) {
-			return new PlainYamlFormatter(this.codeAnalyzer, this.userRules, this.allDefaultRules, this.relevantEngines, this.includeUnmodifiedRules).toYaml();
+			return new PlainYamlFormatter(this.codeAnalyzer, this.userRules, this.allDefaultRules, this.relevantEngines, this.includeUnmodifiedRules, this.includeSuppressions).toYaml();
 		} else {
 			throw new Error(`Unsupported`)
 		}
@@ -63,14 +65,16 @@ abstract class YamlFormatter {
 	private readonly allDefaultRules: RuleSelection;
 	private readonly relevantEngines: Set<string>;
 	private readonly includeUnmodifiedRules: boolean;
+	private readonly includeSuppressions: boolean;
 
-	protected constructor(codeAnalyzer: CodeAnalyzer, userRules: RuleSelection, allDefaultRules: RuleSelection, relevantEngines: Set<string>, includeUnmodifiedRules: boolean) {
+	protected constructor(codeAnalyzer: CodeAnalyzer, userRules: RuleSelection, allDefaultRules: RuleSelection, relevantEngines: Set<string>, includeUnmodifiedRules: boolean, includeSuppressions: boolean) {
 		this.config = codeAnalyzer.getConfig();
 		this.codeAnalyzer = codeAnalyzer;
 		this.userRules = userRules;
 		this.allDefaultRules = allDefaultRules;
 		this.relevantEngines = relevantEngines;
 		this.includeUnmodifiedRules = includeUnmodifiedRules;
+		this.includeSuppressions = includeSuppressions;
 	}
 
 	protected abstract toYamlComment(commentText: string): string
@@ -115,9 +119,48 @@ abstract class YamlFormatter {
 		return this.toYamlUncheckedFieldWithInlineComment(fieldName, resolvedValue, commentText);
 	}
 
+	private toYamlSuppressions(fieldDescription: ConfigFieldDescription): string {
+		const bulkSuppressions = this.config.getBulkSuppressions();
+		const disableSuppressions = !this.config.getSuppressionsEnabled();
+
+		// Build the suppressions object without the bulk_suppressions wrapper
+		const flattenedSuppressions: Record<string, unknown> = {};
+
+		// Only include disable_suppressions if it's true (non-default)
+		if (disableSuppressions) {
+			flattenedSuppressions.disable_suppressions = true;
+		}
+
+		// Add bulk suppressions as direct children (flattened)
+		for (const [filePath, rules] of Object.entries(bulkSuppressions)) {
+			flattenedSuppressions[filePath] = rules;
+		}
+
+		// Generate YAML with proper comment
+		let yamlOutput = this.toYamlComment(fieldDescription.descriptionText) + "\n";
+
+		// Determine if we should show "Modified from" comment
+		const hasAnySuppressions = disableSuppressions || Object.keys(bulkSuppressions).length > 0;
+		const isModifiedFromDefault = disableSuppressions; // Only modified if disable_suppressions is true
+
+		if (hasAnySuppressions && isModifiedFromDefault) {
+			// User explicitly set disable_suppressions to true - show "Modified from" comment
+			const commentText: string = getMessage(BundleName.ConfigModel, 'template.modified-from', [JSON.stringify(fieldDescription.defaultValue)]);
+			yamlOutput += this.toYamlUncheckedFieldWithInlineComment('suppressions', flattenedSuppressions, commentText);
+		} else if (hasAnySuppressions) {
+			// Has bulk suppressions but disable_suppressions is still default (false) - no "Modified from" comment
+			yamlOutput += this.toYamlUncheckedField('suppressions', flattenedSuppressions);
+		} else {
+			// No suppressions at all - show default
+			yamlOutput += this.toYamlUncheckedField('suppressions', fieldDescription.defaultValue);
+		}
+
+		return yamlOutput;
+	}
+
 	toYaml(): string {
 		const topLevelDescription: ConfigDescription = this.config.getConfigDescription();
-		return this.toYamlSectionHeadingComment(topLevelDescription.overview) + '\n' +
+		let yamlOutput = this.toYamlSectionHeadingComment(topLevelDescription.overview) + '\n' +
 			'\n' +
 			this.toYamlFieldWithFieldDescription('config_root', this.config.getConfigRoot(),
 				topLevelDescription.fieldDescriptions.config_root) + '\n' +
@@ -129,8 +172,15 @@ abstract class YamlFormatter {
 			topLevelDescription.fieldDescriptions.log_level) + '\n' +
 			'\n' +
 			this.toYamlFieldWithFieldDescription('ignores', this.config.getIgnores(),
-				topLevelDescription.fieldDescriptions.ignores) + '\n' +
-			'\n' +
+				topLevelDescription.fieldDescriptions.ignores) + '\n';
+
+		// Add suppressions section if enabled
+		if (this.includeSuppressions) {
+			yamlOutput += '\n' +
+				this.toYamlSuppressions(topLevelDescription.fieldDescriptions.suppressions) + '\n';
+		}
+
+		yamlOutput += '\n' +
 			this.toYamlComment(topLevelDescription.fieldDescriptions.rules.descriptionText) + '\n' +
 			this.toYamlRuleOverrides() + '\n' +
 			'\n' +
@@ -138,6 +188,8 @@ abstract class YamlFormatter {
 			this.toYamlEngineOverrides() + '\n' +
 			'\n' +
 			this.toYamlSectionHeadingComment(getMessage(BundleName.ConfigModel, 'template.common.end-of-config')) + '\n';
+
+		return yamlOutput;
 	}
 
 	private toYamlRuleOverrides(): string {
@@ -291,8 +343,8 @@ abstract class YamlFormatter {
 }
 
 class PlainYamlFormatter extends YamlFormatter {
-	constructor(codeAnalyzer: CodeAnalyzer, userRules: RuleSelection, allDefaultRules: RuleSelection, relevantEngines: Set<string>, includeUnmodifiedRules: boolean) {
-		super(codeAnalyzer, userRules, allDefaultRules, relevantEngines, includeUnmodifiedRules);
+	constructor(codeAnalyzer: CodeAnalyzer, userRules: RuleSelection, allDefaultRules: RuleSelection, relevantEngines: Set<string>, includeUnmodifiedRules: boolean, includeSuppressions: boolean) {
+		super(codeAnalyzer, userRules, allDefaultRules, relevantEngines, includeUnmodifiedRules, includeSuppressions);
 	}
 
 	protected toYamlComment(commentText: string): string {
@@ -301,8 +353,8 @@ class PlainYamlFormatter extends YamlFormatter {
 }
 
 class StyledYamlFormatter extends YamlFormatter {
-	constructor(codeAnalyzer: CodeAnalyzer, userRules: RuleSelection, allDefaultRules: RuleSelection, relevantEngines: Set<string>, includeUnmodifiedRules: boolean) {
-		super(codeAnalyzer, userRules, allDefaultRules, relevantEngines, includeUnmodifiedRules);
+	constructor(codeAnalyzer: CodeAnalyzer, userRules: RuleSelection, allDefaultRules: RuleSelection, relevantEngines: Set<string>, includeUnmodifiedRules: boolean, includeSuppressions: boolean) {
+		super(codeAnalyzer, userRules, allDefaultRules, relevantEngines, includeUnmodifiedRules, includeSuppressions);
 	}
 
 	protected toYamlComment(commentText: string): string {

--- a/test/commands/code-analyzer/config.test.ts
+++ b/test/commands/code-analyzer/config.test.ts
@@ -251,4 +251,32 @@ describe('`code-analyzer config` unit tests', () => {
 			expect(receivedActionInput['output-file']).toBeUndefined();
 		});
 	});
+
+	describe('--no-suppressions', () => {
+		it('Can be specified as a boolean flag', async () => {
+			await runConfigCommand(['--no-suppressions']);
+			expect(executeSpy).toHaveBeenCalled();
+			expect(receivedActionInput).toHaveProperty('no-suppressions', true);
+		});
+
+		it('Is false by default when not specified', async () => {
+			await runConfigCommand([]);
+			expect(executeSpy).toHaveBeenCalled();
+			expect(receivedActionInput['no-suppressions']).toBeUndefined();
+		});
+	});
+
+	describe('--include-unmodified-rules', () => {
+		it('Can be specified as a boolean flag', async () => {
+			await runConfigCommand(['--include-unmodified-rules']);
+			expect(executeSpy).toHaveBeenCalled();
+			expect(receivedActionInput).toHaveProperty('include-unmodified-rules', true);
+		});
+
+		it('Is false by default when not specified', async () => {
+			await runConfigCommand([]);
+			expect(executeSpy).toHaveBeenCalled();
+			expect(receivedActionInput['include-unmodified-rules']).toBeUndefined();
+		});
+	});
 });

--- a/test/fixtures/example-workspaces/ConfigAction.test.ts/config-with-default-suppressions.yml
+++ b/test/fixtures/example-workspaces/ConfigAction.test.ts/config-with-default-suppressions.yml
@@ -1,0 +1,18 @@
+# Config file for testing default suppressions preservation
+config_root: __DUMMY_CONFIG_ROOT__
+log_folder: __DUMMY_LOG_FOLDER__
+
+ignores:
+  files: []
+
+suppressions:
+  disable_suppressions: false
+
+engines:
+  StubEngine1:
+    Property1: "baz"
+
+rules:
+  StubEngine1:
+    Stub1Rule1:
+      severity: "low"

--- a/test/fixtures/example-workspaces/ConfigAction.test.ts/config-with-disabled-suppressions.yml
+++ b/test/fixtures/example-workspaces/ConfigAction.test.ts/config-with-disabled-suppressions.yml
@@ -1,0 +1,19 @@
+# Config file for testing suppressions preservation
+config_root: __DUMMY_CONFIG_ROOT__
+log_folder: __DUMMY_LOG_FOLDER__
+
+ignores:
+  files:
+    - "**/test/**"
+
+suppressions:
+  disable_suppressions: true
+
+engines:
+  StubEngine1:
+    Property1: "bar"
+
+rules:
+  StubEngine1:
+    Stub1Rule1:
+      severity: "moderate"

--- a/test/fixtures/valid-configs/config-with-suppressions.yml
+++ b/test/fixtures/valid-configs/config-with-suppressions.yml
@@ -1,0 +1,9 @@
+suppressions:
+  disable_suppressions: false
+  "src/test-file.js":
+    - rule_selector: "eslint:no-console"
+      max_suppressed_violations: 5
+      reason: "Console logs are used for debugging in this file"
+  "src/utils/":
+    - rule_selector: "pmd:UnusedMethod"
+      max_suppressed_violations: 2

--- a/test/lib/actions/ConfigAction.test.ts
+++ b/test/lib/actions/ConfigAction.test.ts
@@ -518,6 +518,138 @@ describe('ConfigAction tests', () => {
 		});
 	});
 
+	describe('Suppressions handling', () => {
+		const configFileWithSuppressions = path.join(PATH_TO_FIXTURES, 'valid-configs', 'config-with-suppressions.yml');
+		const configFileWithDefaultSuppressions = path.join(PATH_TO_EXAMPLE_WORKSPACE, 'config-with-default-suppressions.yml');
+		const configFileWithDisabledSuppressions = path.join(PATH_TO_EXAMPLE_WORKSPACE, 'config-with-disabled-suppressions.yml');
+
+		beforeEach(() => {
+			spyDisplay = new SpyDisplay();
+			dependencies = {
+				logEventListeners: [new LogEventDisplayer(spyDisplay)],
+				progressEventListeners: [],
+				viewer: new ConfigStyledYamlViewer(spyDisplay),
+				configFactory: new StubCodeAnalyzerConfigFactory(),
+				actionSummaryViewer: new ConfigActionSummaryViewer(spyDisplay),
+				pluginsFactory: new StubEnginePluginFactory()
+			};
+		});
+
+		it('By default, suppressions are included in the output', async () => {
+			// ==== TESTED BEHAVIOR ====
+			const output = await runActionAndGetDisplayedConfig(dependencies, ['all'], configFileWithSuppressions);
+
+			// ==== ASSERTIONS ====
+			expect(output).toContain('suppressions:');
+		});
+
+		it('When --no-suppressions is specified, suppressions are excluded from output', async () => {
+			// ==== TESTED BEHAVIOR ====
+			const output = await runActionAndGetDisplayedConfig(dependencies, ['all'], configFileWithSuppressions, undefined, undefined, undefined, true);
+
+			// ==== ASSERTIONS ====
+			expect(output).not.toContain('suppressions:');
+		});
+
+		it('When no suppressions exist in config, suppressions section is still shown by default', async () => {
+			// ==== TESTED BEHAVIOR ====
+			const output = await runActionAndGetDisplayedConfig(dependencies, ['all']);
+
+			// ==== ASSERTIONS ====
+			// Should show the default suppressions structure (disable_suppressions: false)
+			expect(output).toContain('suppressions:');
+		});
+
+		it('When --no-suppressions is specified and no suppressions exist, suppressions section is not shown', async () => {
+			// ==== TESTED BEHAVIOR ====
+			const output = await runActionAndGetDisplayedConfig(dependencies, ['all'], undefined, undefined, undefined, undefined, true);
+
+			// ==== ASSERTIONS ====
+			expect(output).not.toContain('suppressions:');
+		});
+
+		it('Config with default suppressions includes suppressions section by default', async () => {
+			// ==== TESTED BEHAVIOR ====
+			const output = await runActionAndGetDisplayedConfig(dependencies, ['all'], configFileWithDefaultSuppressions);
+
+			// ==== ASSERTIONS ====
+			expect(output).toContain('suppressions:');
+			expect(output).toContain('disable_suppressions: false');
+		});
+
+		it('Config with default suppressions excludes suppressions section when --no-suppressions is specified', async () => {
+			// ==== TESTED BEHAVIOR ====
+			const output = await runActionAndGetDisplayedConfig(dependencies, ['all'], configFileWithDefaultSuppressions, undefined, undefined, undefined, true);
+
+			// ==== ASSERTIONS ====
+			expect(output).not.toContain('suppressions:');
+			expect(output).not.toContain('disable_suppressions');
+		});
+
+		it('Config with disabled suppressions includes suppressions section by default', async () => {
+			// ==== TESTED BEHAVIOR ====
+			const output = await runActionAndGetDisplayedConfig(dependencies, ['all'], configFileWithDisabledSuppressions);
+
+			// ==== ASSERTIONS ====
+			expect(output).toContain('suppressions:');
+			expect(output).toContain('disable_suppressions: true');
+		});
+
+		it('Config with disabled suppressions excludes suppressions section when --no-suppressions is specified', async () => {
+			// ==== TESTED BEHAVIOR ====
+			const output = await runActionAndGetDisplayedConfig(dependencies, ['all'], configFileWithDisabledSuppressions, undefined, undefined, undefined, true);
+
+			// ==== ASSERTIONS ====
+			expect(output).not.toContain('suppressions:');
+			expect(output).not.toContain('disable_suppressions');
+		});
+
+		it('Bulk suppressions are output as direct children without bulk_suppressions wrapper', async () => {
+			// ==== TESTED BEHAVIOR ====
+			const output = await runActionAndGetDisplayedConfig(dependencies, ['all'], configFileWithSuppressions);
+
+			// ==== ASSERTIONS ====
+			// Should have suppressions: as top level
+			expect(output).toContain('suppressions:');
+			// Should NOT have bulk_suppressions: wrapper
+			expect(output).not.toContain('bulk_suppressions:');
+			// File paths should be direct children of suppressions (indented 2 spaces)
+			expect(output).toMatch(/suppressions:\s*\n\s{2}[\w\-./]+:/m);
+		});
+
+		it('Bulk suppressions without disable_suppressions do not show Modified from comment', async () => {
+			// ==== TESTED BEHAVIOR ====
+			const output = await runActionAndGetDisplayedConfig(dependencies, ['all'], configFileWithSuppressions);
+
+			// ==== ASSERTIONS ====
+			// Should NOT have "Modified from" comment on suppressions line since disable_suppressions is default (false)
+			const suppressionsLine = output.split('\n').find(line => line.trim().startsWith('suppressions:'));
+			expect(suppressionsLine).toBeDefined();
+			expect(suppressionsLine).not.toContain('Modified from');
+		});
+
+		it('Suppressions with disable_suppressions true shows Modified from comment', async () => {
+			// ==== TESTED BEHAVIOR ====
+			const output = await runActionAndGetDisplayedConfig(dependencies, ['all'], configFileWithDisabledSuppressions);
+
+			// ==== ASSERTIONS ====
+			// Should have "Modified from" comment since disable_suppressions is non-default (true)
+			const suppressionsLine = output.split('\n').find(line => line.trim().startsWith('suppressions:'));
+			expect(suppressionsLine).toBeDefined();
+			expect(suppressionsLine).toContain('Modified from');
+		});
+
+		it('Suppressions output includes updated description for inline and bulk suppressions', async () => {
+			// ==== TESTED BEHAVIOR ====
+			const output = await runActionAndGetDisplayedConfig(dependencies, ['all'], configFileWithSuppressions);
+
+			// ==== ASSERTIONS ====
+			// Should have updated description mentioning both inline and bulk suppressions
+			expect(output).toMatch(/Configuration for inline and bulk suppressions/);
+			expect(output).toMatch(/\{file_path\}: Array of bulk suppression rules/);
+		});
+	});
+
 	describe('Target/Workspace resolution', () => {
 		const originalCwd: string = process.cwd();
 		const baseDir: string = path.resolve(import.meta.dirname, '..', '..', 'fixtures', 'example-workspaces', 'workspace-with-misc-files');
@@ -691,7 +823,7 @@ describe('ConfigAction tests', () => {
 		return fs.promises.readFile(goldFilePath, {encoding: 'utf-8'});
 	}
 
-	async function runActionAndGetDisplayedConfig(dependencies: ConfigDependencies, ruleSelectors: string[], configFile?: string, workspace?: string[], target?: string[], includeUnmodifiedRules?: boolean): Promise<string> {
+	async function runActionAndGetDisplayedConfig(dependencies: ConfigDependencies, ruleSelectors: string[], configFile?: string, workspace?: string[], target?: string[], includeUnmodifiedRules?: boolean, noSuppressions?: boolean): Promise<string> {
 		// ==== SETUP ====
 		const action = ConfigAction.createAction(dependencies);
 		const input: ConfigInput = {
@@ -699,7 +831,8 @@ describe('ConfigAction tests', () => {
 			'config-file': configFile,
 			workspace,
 			target,
-			'include-unmodified-rules': includeUnmodifiedRules
+			'include-unmodified-rules': includeUnmodifiedRules,
+			'no-suppressions': noSuppressions
 		};
 
 		// ==== TESTED BEHAVIOR ====
@@ -725,7 +858,15 @@ class StubCodeAnalyzerConfigFactory implements CodeAnalyzerConfigFactory {
 		this.config = config;
 	}
 
-	public create(): CodeAnalyzerConfig {
+	public create(configPath?: string): CodeAnalyzerConfig {
+		if (configPath) {
+			// If a config path is provided, load it from the file
+			const rawConfigFileContents = fs.readFileSync(configPath, 'utf-8');
+			const validatedConfigFileContents = rawConfigFileContents
+				.replaceAll('__DUMMY_CONFIG_ROOT__', 'null')
+				.replaceAll('__DUMMY_LOG_FOLDER__', 'null');
+			return CodeAnalyzerConfig.fromYamlString(validatedConfigFileContents, process.cwd());
+		}
 		return this.config;
 	}
 }

--- a/test/lib/actions/ConfigAction.test.ts
+++ b/test/lib/actions/ConfigAction.test.ts
@@ -638,16 +638,6 @@ describe('ConfigAction tests', () => {
 			expect(suppressionsLine).toBeDefined();
 			expect(suppressionsLine).toContain('Modified from');
 		});
-
-		it('Suppressions output includes updated description for inline and bulk suppressions', async () => {
-			// ==== TESTED BEHAVIOR ====
-			const output = await runActionAndGetDisplayedConfig(dependencies, ['all'], configFileWithSuppressions);
-
-			// ==== ASSERTIONS ====
-			// Should have updated description mentioning both inline and bulk suppressions
-			expect(output).toMatch(/Configuration for inline and bulk suppressions/);
-			expect(output).toMatch(/\{file_path\}: Array of bulk suppression rules/);
-		});
 	});
 
 	describe('Target/Workspace resolution', () => {

--- a/test/lib/actions/ConfigAction.test.ts
+++ b/test/lib/actions/ConfigAction.test.ts
@@ -638,6 +638,16 @@ describe('ConfigAction tests', () => {
 			expect(suppressionsLine).toBeDefined();
 			expect(suppressionsLine).toContain('Modified from');
 		});
+
+		it('Suppressions output includes updated description for inline and bulk suppressions', async () => {
+			// ==== TESTED BEHAVIOR ====
+			const output = await runActionAndGetDisplayedConfig(dependencies, ['all'], configFileWithSuppressions);
+
+			// ==== ASSERTIONS ====
+			// Should have updated description mentioning both inline and bulk suppressions
+			expect(output).toMatch(/Configuration for inline and bulk suppressions/);
+			expect(output).toMatch(/\{file_path\}: Array of bulk suppression rules/);
+		});
 	});
 
 	describe('Target/Workspace resolution', () => {

--- a/test/lib/factories/CodeAnalyzerConfigFactory.bulk-suppressions.test.ts
+++ b/test/lib/factories/CodeAnalyzerConfigFactory.bulk-suppressions.test.ts
@@ -1,0 +1,306 @@
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+
+import {CodeAnalyzerConfigFactoryImpl} from '../../../src/lib/factories/CodeAnalyzerConfigFactory.js';
+
+/**
+ * Tests specifically for Bug #1: Factory not recognizing bulk suppressions
+ *
+ * BUG: CodeAnalyzerConfigFactory.ts checked if `disable_suppressions !== undefined`
+ * instead of checking if `suppressions !== undefined`. This caused YAML configs
+ * with ONLY bulk suppressions (no disable_suppressions field) to be ignored.
+ */
+describe('CodeAnalyzerConfigFactory - Bulk Suppressions Bug Tests', () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'config-factory-test-'));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it('When YAML has bulk suppressions without disable_suppressions field, bulk suppressions are loaded', () => {
+		// This is the exact scenario that exposed Bug #1
+		const configContent = `
+ignores:
+  files:
+    - test_file.xml
+
+suppressions:
+  "src/utils.js":
+    - rule_selector: eslint:all
+      max_suppressed_violations: 3
+    - rule_selector: pmd:UnusedMethod
+      max_suppressed_violations: 2
+      reason: Helper methods for debugging
+`;
+		const configPath = path.join(tempDir, 'code-analyzer.yml');
+		fs.writeFileSync(configPath, configContent, 'utf8');
+
+		const factory = new CodeAnalyzerConfigFactoryImpl();
+		const testedConfig = factory.create(configPath);
+
+		// Verify bulk suppressions were loaded (Bug #1 would fail here - returns empty object)
+		const bulkSuppressions = testedConfig.getBulkSuppressions();
+		expect(bulkSuppressions).toHaveProperty('src/utils.js');
+		expect(bulkSuppressions['src/utils.js']).toHaveLength(2);
+		expect(bulkSuppressions['src/utils.js'][0]).toEqual({
+			rule_selector: 'eslint:all',
+			max_suppressed_violations: 3,
+			reason: undefined
+		});
+		expect(bulkSuppressions['src/utils.js'][1]).toEqual({
+			rule_selector: 'pmd:UnusedMethod',
+			max_suppressed_violations: 2,
+			reason: 'Helper methods for debugging'
+		});
+
+		// Suppressions should be enabled by default
+		expect(testedConfig.getSuppressionsEnabled()).toBe(true);
+	});
+
+	it('When YAML has only disable_suppressions (no bulk suppressions), it still works', () => {
+		// This case worked before Bug #1 fix - keeping for regression
+		const configContent = `
+suppressions:
+  disable_suppressions: true
+`;
+		const configPath = path.join(tempDir, 'code-analyzer.yml');
+		fs.writeFileSync(configPath, configContent, 'utf8');
+
+		const factory = new CodeAnalyzerConfigFactoryImpl();
+		const testedConfig = factory.create(configPath);
+
+		// Verify suppressions are disabled
+		expect(testedConfig.getSuppressionsEnabled()).toBe(false);
+
+		// Bulk suppressions should be empty
+		const bulkSuppressions = testedConfig.getBulkSuppressions();
+		expect(Object.keys(bulkSuppressions)).toHaveLength(0);
+	});
+
+	it('When YAML has both disable_suppressions and bulk suppressions, both are loaded', () => {
+		const configContent = `
+suppressions:
+  disable_suppressions: false
+  "src/file.js":
+    - rule_selector: eslint:all
+      max_suppressed_violations: 5
+`;
+		const configPath = path.join(tempDir, 'code-analyzer.yml');
+		fs.writeFileSync(configPath, configContent, 'utf8');
+
+		const factory = new CodeAnalyzerConfigFactoryImpl();
+		const testedConfig = factory.create(configPath);
+
+		// Verify both are loaded correctly
+		expect(testedConfig.getSuppressionsEnabled()).toBe(true);
+		const bulkSuppressions = testedConfig.getBulkSuppressions();
+		expect(bulkSuppressions).toHaveProperty('src/file.js');
+		expect(bulkSuppressions['src/file.js'][0]).toEqual({
+			rule_selector: 'eslint:all',
+			max_suppressed_violations: 5,
+			reason: undefined
+		});
+	});
+
+	it('When YAML has bulk suppressions (no disable_suppressions field) and CLI override, bulk suppressions preserved AND CLI override applies', () => {
+		// This is the CORRECT behavior:
+		// - Bulk suppressions from YAML are preserved
+		// - CLI override applies to disable_suppressions (since not in YAML)
+		const configContent = `
+suppressions:
+  "src/utils.js":
+    - rule_selector: eslint:all
+      max_suppressed_violations: 3
+`;
+		const configPath = path.join(tempDir, 'code-analyzer.yml');
+		fs.writeFileSync(configPath, configContent, 'utf8');
+
+		const factory = new CodeAnalyzerConfigFactoryImpl();
+		const testedConfig = factory.create(configPath, { noSuppressions: true });
+
+		// YAML bulk suppressions should be preserved
+		const bulkSuppressions = testedConfig.getBulkSuppressions();
+		expect(bulkSuppressions).toHaveProperty('src/utils.js');
+		expect(bulkSuppressions['src/utils.js']).toHaveLength(1);
+
+		// CLI override should apply since disable_suppressions was NOT in YAML
+		expect(testedConfig.getSuppressionsEnabled()).toBe(false);
+	});
+
+	it('When YAML has BOTH bulk suppressions AND disable_suppressions, YAML wins completely (CLI override ignored)', () => {
+		// If YAML explicitly sets disable_suppressions, YAML wins everything
+		const configContent = `
+suppressions:
+  disable_suppressions: false
+  "src/utils.js":
+    - rule_selector: eslint:all
+      max_suppressed_violations: 3
+`;
+		const configPath = path.join(tempDir, 'code-analyzer.yml');
+		fs.writeFileSync(configPath, configContent, 'utf8');
+
+		const factory = new CodeAnalyzerConfigFactoryImpl();
+		const testedConfig = factory.create(configPath, { noSuppressions: true });
+
+		// YAML bulk suppressions preserved
+		const bulkSuppressions = testedConfig.getBulkSuppressions();
+		expect(bulkSuppressions).toHaveProperty('src/utils.js');
+		expect(bulkSuppressions['src/utils.js']).toHaveLength(1);
+
+		// YAML wins for disable_suppressions (CLI override ignored)
+		expect(testedConfig.getSuppressionsEnabled()).toBe(true);
+	});
+
+	it('BUG #1: When YAML has NO suppressions section at all, CLI override works', () => {
+		// This case worked before - keeping for regression
+		const configContent = `
+rules:
+  eslint:
+    no-console:
+      severity: 2
+`;
+		const configPath = path.join(tempDir, 'code-analyzer.yml');
+		fs.writeFileSync(configPath, configContent, 'utf8');
+
+		const factory = new CodeAnalyzerConfigFactoryImpl();
+		const testedConfig = factory.create(configPath, { noSuppressions: true });
+
+		// CLI override should work
+		expect(testedConfig.getSuppressionsEnabled()).toBe(false);
+
+		// Bulk suppressions should be empty
+		const bulkSuppressions = testedConfig.getBulkSuppressions();
+		expect(Object.keys(bulkSuppressions)).toHaveLength(0);
+	});
+
+	it('When YAML has bulk suppressions (no disable_suppressions) and NO CLI override, uses defaults for disable_suppressions', () => {
+		// Bulk suppressions present, disable_suppressions not in YAML, no CLI override
+		const configContent = `
+suppressions:
+  "src/utils.js":
+    - rule_selector: eslint:all
+      max_suppressed_violations: 3
+`;
+		const configPath = path.join(tempDir, 'code-analyzer.yml');
+		fs.writeFileSync(configPath, configContent, 'utf8');
+
+		const factory = new CodeAnalyzerConfigFactoryImpl();
+		const testedConfig = factory.create(configPath, undefined);
+
+		// Bulk suppressions preserved
+		const bulkSuppressions = testedConfig.getBulkSuppressions();
+		expect(bulkSuppressions).toHaveProperty('src/utils.js');
+
+		// Default behavior: suppressions enabled
+		expect(testedConfig.getSuppressionsEnabled()).toBe(true);
+	});
+
+	it('When YAML has bulk suppressions (no disable_suppressions) and CLI override false, bulk suppressions preserved and enabled', () => {
+		// Bulk suppressions present, CLI override says keep enabled
+		const configContent = `
+suppressions:
+  "src/utils.js":
+    - rule_selector: eslint:all
+      max_suppressed_violations: 3
+`;
+		const configPath = path.join(tempDir, 'code-analyzer.yml');
+		fs.writeFileSync(configPath, configContent, 'utf8');
+
+		const factory = new CodeAnalyzerConfigFactoryImpl();
+		const testedConfig = factory.create(configPath, { noSuppressions: false });
+
+		// Bulk suppressions preserved
+		const bulkSuppressions = testedConfig.getBulkSuppressions();
+		expect(bulkSuppressions).toHaveProperty('src/utils.js');
+
+		// CLI override applies: enabled
+		expect(testedConfig.getSuppressionsEnabled()).toBe(true);
+	});
+
+	it('When YAML has empty suppressions object (only disable_suppressions: true), CLI override ignored', () => {
+		// disable_suppressions explicitly set, no bulk suppressions
+		const configContent = `
+suppressions:
+  disable_suppressions: true
+`;
+		const configPath = path.join(tempDir, 'code-analyzer.yml');
+		fs.writeFileSync(configPath, configContent, 'utf8');
+
+		const factory = new CodeAnalyzerConfigFactoryImpl();
+		const testedConfig = factory.create(configPath, { noSuppressions: false });
+
+		// No bulk suppressions
+		const bulkSuppressions = testedConfig.getBulkSuppressions();
+		expect(Object.keys(bulkSuppressions)).toHaveLength(0);
+
+		// YAML wins: disabled (CLI override ignored)
+		expect(testedConfig.getSuppressionsEnabled()).toBe(false);
+	});
+
+	it('BEHAVIOR: When --no-suppressions flag used, bulk suppression CONFIG is preserved but suppressions are DISABLED', () => {
+		// This verifies the correct behavior:
+		// - Bulk suppression config (file paths and rules) is preserved in config object
+		// - But disable_suppressions is set to true, so suppressions are not applied
+		const configContent = `
+suppressions:
+  "src/utils.js":
+    - rule_selector: eslint:all
+      max_suppressed_violations: 3
+    - rule_selector: pmd:UnusedMethod
+      max_suppressed_violations: 2
+`;
+		const configPath = path.join(tempDir, 'code-analyzer.yml');
+		fs.writeFileSync(configPath, configContent, 'utf8');
+
+		const factory = new CodeAnalyzerConfigFactoryImpl();
+		const testedConfig = factory.create(configPath, { noSuppressions: true });
+
+		// Bulk suppression CONFIG is preserved in the config object
+		const bulkSuppressions = testedConfig.getBulkSuppressions();
+		expect(bulkSuppressions).toHaveProperty('src/utils.js');
+		expect(bulkSuppressions['src/utils.js']).toHaveLength(2);
+		expect(bulkSuppressions['src/utils.js'][0].rule_selector).toBe('eslint:all');
+
+		// But suppressions are disabled (so they won't be applied during analysis)
+		expect(testedConfig.getSuppressionsEnabled()).toBe(false);
+	});
+
+	it('BUG #1: Multiple file paths with multiple rules each are all loaded', () => {
+		const configContent = `
+suppressions:
+  "src/file1.js":
+    - rule_selector: eslint:no-console
+      max_suppressed_violations: 2
+    - rule_selector: eslint:no-unused-vars
+      max_suppressed_violations: 3
+  "src/file2.js":
+    - rule_selector: pmd:UnusedMethod
+      max_suppressed_violations: 1
+  "src/folder/":
+    - rule_selector: all
+      max_suppressed_violations: 10
+`;
+		const configPath = path.join(tempDir, 'code-analyzer.yml');
+		fs.writeFileSync(configPath, configContent, 'utf8');
+
+		const factory = new CodeAnalyzerConfigFactoryImpl();
+		const testedConfig = factory.create(configPath);
+
+		// Verify all paths and rules are loaded
+		const bulkSuppressions = testedConfig.getBulkSuppressions();
+		expect(Object.keys(bulkSuppressions)).toHaveLength(3);
+		expect(bulkSuppressions['src/file1.js']).toHaveLength(2);
+		expect(bulkSuppressions['src/file2.js']).toHaveLength(1);
+		expect(bulkSuppressions['src/folder/']).toHaveLength(1);
+
+		// Check specific rules
+		expect(bulkSuppressions['src/file1.js'][0].rule_selector).toBe('eslint:no-console');
+		expect(bulkSuppressions['src/file2.js'][0].rule_selector).toBe('pmd:UnusedMethod');
+		expect(bulkSuppressions['src/folder/'][0].max_suppressed_violations).toBe(10);
+	});
+});


### PR DESCRIPTION
Adding these changes to support the bulk suppression in run and config command: https://docs.google.com/document/d/15bDsqLY8V0WDai7yd-A3CdXIU9D6ceGAZt7V1g9eajw/edit?tab=t.0#heading=h.bpj1eeeekf9q
Case-1) With --no-suppressions flag in run command the bulk suppressions are not applied:
```
Found 124 violation(s) across 1 file(s):
    9 High severity violation(s) found.
    68 Moderate severity violation(s) found.
    47 Low severity violation(s) found.

Additional log information written to:
    /var/folders/n2/fjmw400n4tsclsys23vzkhmr0000gn/T/sfca-2026_04_14_12_57_19_829.log
```
Case-2) With config command the suppression object is copied as it is:
```
 % sf code-analyzer config --rule-selector all
 suppressions:
  force-app/main/default/react-components/utils.js:
    - rule_selector: no-magic-numbers,pmd
      max_suppressed_violations: 0
      reason: |
        Sample test reason.
  force-app/main/default/react-components/:
    - rule_selector: no-magic-numbers,pmd
      max_suppressed_violations: 3
      reason: |
        Another Sample test reason.
```
Case-3) With the --no-suppressions flag the suppressions object is not copied at all:
```
% sf code-analyzer config --rule-selector all --no-suppressions
```
Case-4) With the disable value set different from the default value we get the comment notifying it:
```
% sf code-analyzer config --rule-selector all 
suppressions: # Modified from: {"disable_suppressions":false}
  disable_suppressions: true
  force-app/main/default/react-components/utils.js:
    - rule_selector: no-magic-numbers,pmd
      max_suppressed_violations: 0
      reason: |
        Sample test reason.
  force-app/main/default/react-components/:
    - rule_selector: no-magic-numbers,pmd
      max_suppressed_violations: 3
      reason: |
        Another Sample test reason.
```