### PR TITLE
NEW @W-22393672@ Expose ApexGuru engine in CLI with --target-org flag for login

### DIFF
--- a/messages/run-command.md
+++ b/messages/run-command.md
@@ -86,6 +86,14 @@ Each targeted file must live within the workspace that you specified with the `â
 
 If you don't specify the `--target` flag, then all the files within your workspace (specified by the `--workspace` flag) are targeted for analysis.
 
+# flags.target-org.summary
+
+Target org username or alias for remote analysis engines.
+
+# flags.target-org.description
+
+Specify the username or alias of a Salesforce org when using engines that require remote connectivity, such as ApexGuru. The org must be authenticated with the Salesforce CLI.
+
 # flags.rule-selector.summary
 
 Selection of rules, based on engine name, severity level, rule name, tag, or a combination of criteria separated by colons.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 			"dependencies": {
 				"@oclif/core": "^4.11.6",
 				"@oclif/table": "^0.5.9",
+				"@salesforce/code-analyzer-apexguru-engine": "0.39.0",
 				"@salesforce/code-analyzer-core": "0.49.0",
 				"@salesforce/code-analyzer-engine-api": "0.39.0",
 				"@salesforce/code-analyzer-eslint-engine": "0.44.0",
@@ -3016,6 +3017,75 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@isaacs/cliui": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^5.1.2",
+				"string-width-cjs": "npm:string-width@^4.2.0",
+				"strip-ansi": "^7.0.1",
+				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+				"wrap-ansi": "^8.1.0",
+				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"license": "MIT"
+		},
+		"node_modules/@isaacs/cliui/node_modules/string-width": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+			"license": "MIT",
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.1.0",
+				"string-width": "^5.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
 		"node_modules/@istanbuljs/schema": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -3072,9 +3142,9 @@
 			}
 		},
 		"node_modules/@jsforce/jsforce-node": {
-			"version": "3.10.13",
-			"resolved": "https://registry.npmjs.org/@jsforce/jsforce-node/-/jsforce-node-3.10.13.tgz",
-			"integrity": "sha512-Ft42/lp3WaVxijcX88Rb3yIxujk/u3LwL3913OTcB4WCpwjB9xTqP6jkVTKt2riXg+ZlNiS62SMpQeC3U1Efkw==",
+			"version": "3.10.17",
+			"resolved": "https://registry.npmjs.org/@jsforce/jsforce-node/-/jsforce-node-3.10.17.tgz",
+			"integrity": "sha512-gYWiK0Y68dMUTdlPjkF+Bw3r7pmfTbqzs7/6ZChg2Md14NyzXk/usp+y8hHj6vc1SF3s7e6j5OUzUasYF5RJWQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@sindresorhus/is": "^4",
@@ -3083,13 +3153,12 @@
 				"csv-stringify": "^6.6.0",
 				"faye": "^1.4.0",
 				"form-data": "^4.0.4",
-				"https-proxy-agent": "^5.0.0",
 				"multistream": "^3.1.0",
-				"node-fetch": "^2.6.1",
+				"undici": "^8.5.0",
 				"xml2js": "^0.6.2"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=22"
 			}
 		},
 		"node_modules/@jsonjoy.com/base64": {
@@ -3576,6 +3645,16 @@
 			"resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
 			"integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
 			"license": "MIT"
+		},
+		"node_modules/@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=14"
+			}
 		},
 		"node_modules/@pnpm/config.env-replace": {
 			"version": "1.1.0",
@@ -4184,6 +4263,145 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
 			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
 			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/@salesforce/code-analyzer-apexguru-engine": {
+			"version": "0.39.0",
+			"resolved": "https://registry.npmjs.org/@salesforce/code-analyzer-apexguru-engine/-/code-analyzer-apexguru-engine-0.39.0.tgz",
+			"integrity": "sha512-1o6yFhbr7N67YD6jY/H5VLihV5bVtsFIokQysJfxpPsTXzthy3DB3EVQ5098mSJbiBVfZroX6LbLqQJvzsHJ0A==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@salesforce/code-analyzer-engine-api": "0.39.0",
+				"@salesforce/core": "^8.31.2",
+				"archiver": "^7.0.1",
+				"form-data": "^4.0.6"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@salesforce/code-analyzer-apexguru-engine/node_modules/@salesforce/core": {
+			"version": "8.31.4",
+			"resolved": "https://registry.npmjs.org/@salesforce/core/-/core-8.31.4.tgz",
+			"integrity": "sha512-G/zgo9ygO+0l2x9gCOnp6BR7q2Rlt8MHDoj4DIpu2utsZznIcH7iNTEoKjul1BMKDPARuBGUp0Tyr0c8dLf32g==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@jsforce/jsforce-node": "^3.10.17",
+				"@salesforce/kit": "^3.2.4",
+				"@salesforce/ts-types": "^2.0.12",
+				"ajv": "^8.18.0",
+				"change-case": "^4.1.2",
+				"fast-levenshtein": "^3.0.0",
+				"faye": "^1.4.1",
+				"form-data": "^4.0.5",
+				"js2xmlparser": "^4.0.1",
+				"jsonwebtoken": "9.0.3",
+				"jszip": "3.10.1",
+				"memfs": "4.38.1",
+				"pino": "^9.7.0",
+				"pino-abstract-transport": "^1.2.0",
+				"pino-pretty": "^11.3.0",
+				"proper-lockfile": "^4.1.2",
+				"semver": "^7.8.0",
+				"ts-retry-promise": "^0.8.1",
+				"zod": "^4.1.12"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@salesforce/code-analyzer-apexguru-engine/node_modules/ajv": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/@salesforce/code-analyzer-apexguru-engine/node_modules/change-case": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+			"integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+			"license": "MIT",
+			"dependencies": {
+				"camel-case": "^4.1.2",
+				"capital-case": "^1.0.4",
+				"constant-case": "^3.0.4",
+				"dot-case": "^3.0.4",
+				"header-case": "^2.0.4",
+				"no-case": "^3.0.4",
+				"param-case": "^3.0.4",
+				"pascal-case": "^3.1.2",
+				"path-case": "^3.0.4",
+				"sentence-case": "^3.0.4",
+				"snake-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/@salesforce/code-analyzer-apexguru-engine/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT"
+		},
+		"node_modules/@salesforce/code-analyzer-apexguru-engine/node_modules/jsonwebtoken": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+			"integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+			"license": "MIT",
+			"dependencies": {
+				"jws": "^4.0.1",
+				"lodash.includes": "^4.3.0",
+				"lodash.isboolean": "^3.0.3",
+				"lodash.isinteger": "^4.0.4",
+				"lodash.isnumber": "^3.0.3",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.once": "^4.0.0",
+				"ms": "^2.1.1",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": ">=12",
+				"npm": ">=6"
+			}
+		},
+		"node_modules/@salesforce/code-analyzer-apexguru-engine/node_modules/jwa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+			"license": "MIT",
+			"dependencies": {
+				"buffer-equal-constant-time": "^1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/@salesforce/code-analyzer-apexguru-engine/node_modules/jws": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+			"license": "MIT",
+			"dependencies": {
+				"jwa": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/@salesforce/code-analyzer-apexguru-engine/node_modules/zod": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
@@ -7157,18 +7375,6 @@
 				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/agent-base": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-			"license": "MIT",
-			"dependencies": {
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6.0.0"
-			}
-		},
 		"node_modules/ajv": {
 			"version": "6.14.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -7243,6 +7449,92 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=14"
+			}
+		},
+		"node_modules/archiver": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+			"integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+			"license": "MIT",
+			"dependencies": {
+				"archiver-utils": "^5.0.2",
+				"async": "^3.2.4",
+				"buffer-crc32": "^1.0.0",
+				"readable-stream": "^4.0.0",
+				"readdir-glob": "^1.1.2",
+				"tar-stream": "^3.0.0",
+				"zip-stream": "^6.0.1"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/archiver-utils": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+			"integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+			"license": "MIT",
+			"dependencies": {
+				"glob": "^10.0.0",
+				"graceful-fs": "^4.2.0",
+				"is-stream": "^2.0.1",
+				"lazystream": "^1.0.0",
+				"lodash": "^4.17.15",
+				"normalize-path": "^3.0.0",
+				"readable-stream": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/archiver-utils/node_modules/readable-stream": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+			"license": "MIT",
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/archiver-utils/node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
+			}
+		},
+		"node_modules/archiver/node_modules/readable-stream": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+			"license": "MIT",
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/archiver/node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
 			}
 		},
 		"node_modules/arg": {
@@ -7562,6 +7854,112 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"license": "MIT"
 		},
+		"node_modules/bare-events": {
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+			"integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"bare-abort-controller": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-abort-controller": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/bare-fs": {
+			"version": "4.7.2",
+			"resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+			"integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-events": "^2.5.4",
+				"bare-path": "^3.0.0",
+				"bare-stream": "^2.6.4",
+				"bare-url": "^2.2.2",
+				"fast-fifo": "^1.3.2"
+			},
+			"engines": {
+				"bare": ">=1.16.0"
+			},
+			"peerDependencies": {
+				"bare-buffer": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-buffer": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/bare-os": {
+			"version": "3.9.3",
+			"resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.3.tgz",
+			"integrity": "sha512-fF4Q7QsyKVF5Rj0qvI8BgUNjqzC2JvQlpTaPLjVJVxYVUX5Zr9un+y3w1HmA4nNKdFmRBT8z/WmrjvXzXVerKQ==",
+			"license": "Apache-2.0",
+			"engines": {
+				"bare": ">=1.14.0"
+			}
+		},
+		"node_modules/bare-path": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+			"integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-os": "^3.0.1"
+			}
+		},
+		"node_modules/bare-stream": {
+			"version": "2.13.3",
+			"resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+			"integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"b4a": "^1.8.1",
+				"streamx": "^2.25.0",
+				"teex": "^1.0.1"
+			},
+			"peerDependencies": {
+				"bare-abort-controller": "*",
+				"bare-buffer": "*",
+				"bare-events": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-abort-controller": {
+					"optional": true
+				},
+				"bare-buffer": {
+					"optional": true
+				},
+				"bare-events": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/bare-stream/node_modules/b4a": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+			"integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"react-native-b4a": "*"
+			},
+			"peerDependenciesMeta": {
+				"react-native-b4a": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/bare-url": {
+			"version": "2.4.5",
+			"resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+			"integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-path": "^3.0.0"
+			}
+		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -7693,6 +8091,15 @@
 			"dependencies": {
 				"base64-js": "^1.3.1",
 				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/buffer-crc32": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+			"integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/buffer-equal-constant-time": {
@@ -8055,6 +8462,47 @@
 				"node": ">=14"
 			}
 		},
+		"node_modules/compress-commons": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+			"integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+			"license": "MIT",
+			"dependencies": {
+				"crc-32": "^1.2.0",
+				"crc32-stream": "^6.0.0",
+				"is-stream": "^2.0.1",
+				"normalize-path": "^3.0.0",
+				"readable-stream": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/compress-commons/node_modules/readable-stream": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+			"license": "MIT",
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/compress-commons/node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
+			}
+		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -8113,6 +8561,56 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
 			"license": "MIT"
+		},
+		"node_modules/crc-32": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+			"integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+			"license": "Apache-2.0",
+			"bin": {
+				"crc32": "bin/crc32.njs"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/crc32-stream": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+			"integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+			"license": "MIT",
+			"dependencies": {
+				"crc-32": "^1.2.0",
+				"readable-stream": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/crc32-stream/node_modules/readable-stream": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+			"license": "MIT",
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/crc32-stream/node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
+			}
 		},
 		"node_modules/create-require": {
 			"version": "1.1.1",
@@ -8416,6 +8914,12 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/eastasianwidth": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+			"license": "MIT"
 		},
 		"node_modules/ecdsa-sig-formatter": {
 			"version": "1.0.11",
@@ -9692,6 +10196,15 @@
 				"node": ">=0.8.x"
 			}
 		},
+		"node_modules/events-universal": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+			"integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-events": "^2.7.0"
+			}
+		},
 		"node_modules/execa": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -9743,6 +10256,12 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"license": "MIT"
+		},
+		"node_modules/fast-fifo": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+			"integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
 			"license": "MIT"
 		},
 		"node_modules/fast-glob": {
@@ -10031,17 +10550,33 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/foreground-child": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+			"license": "ISC",
+			"dependencies": {
+				"cross-spawn": "^7.0.6",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/form-data": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+			"integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
 				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.2",
-				"mime-types": "^2.1.12"
+				"hasown": "^2.0.4",
+				"mime-types": "^2.1.35"
 			},
 			"engines": {
 				"node": ">= 6"
@@ -10258,6 +10793,27 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/glob": {
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/glob-parent": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -10284,6 +10840,30 @@
 			},
 			"peerDependencies": {
 				"tslib": "2"
+			}
+		},
+		"node_modules/glob/node_modules/brace-expansion": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+			"integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/glob/node_modules/minimatch": {
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/globals": {
@@ -10474,9 +11054,9 @@
 			}
 		},
 		"node_modules/hasown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
 			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.2"
@@ -10608,19 +11188,6 @@
 			},
 			"engines": {
 				"node": ">=10.19.0"
-			}
-		},
-		"node_modules/https-proxy-agent": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "6",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/human-signals": {
@@ -11342,7 +11909,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
 			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -11545,6 +12111,21 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
 			}
 		},
 		"node_modules/jake": {
@@ -11771,6 +12352,18 @@
 			},
 			"engines": {
 				"node": ">=0.10"
+			}
+		},
+		"node_modules/lazystream": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+			"integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+			"license": "MIT",
+			"dependencies": {
+				"readable-stream": "^2.0.5"
+			},
+			"engines": {
+				"node": ">= 0.6.3"
 			}
 		},
 		"node_modules/levn": {
@@ -12101,6 +12694,15 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -12208,26 +12810,6 @@
 				"tslib": "^2.0.3"
 			}
 		},
-		"node_modules/node-fetch": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-			"license": "MIT",
-			"dependencies": {
-				"whatwg-url": "^5.0.0"
-			},
-			"engines": {
-				"node": "4.x || >=6.0.0"
-			},
-			"peerDependencies": {
-				"encoding": "^0.1.0"
-			},
-			"peerDependenciesMeta": {
-				"encoding": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/node-releases": {
 			"version": "2.0.27",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -12260,6 +12842,15 @@
 			},
 			"engines": {
 				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/normalize-url": {
@@ -12662,6 +13253,12 @@
 				"node": ">= 14"
 			}
 		},
+		"node_modules/package-json-from-dist": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+			"license": "BlueOak-1.0.0"
+		},
 		"node_modules/pako": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -12780,6 +13377,28 @@
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
 			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"license": "MIT"
+		},
+		"node_modules/path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/path-scurry/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"license": "ISC"
 		},
 		"node_modules/path-to-regexp": {
 			"version": "6.3.0",
@@ -13244,6 +13863,36 @@
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 			"license": "MIT"
+		},
+		"node_modules/readdir-glob": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+			"integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"minimatch": "^5.1.0"
+			}
+		},
+		"node_modules/readdir-glob/node_modules/brace-expansion": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+			"integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/readdir-glob/node_modules/minimatch": {
+			"version": "5.1.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+			"integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/real-require": {
 			"version": "0.2.0",
@@ -14120,6 +14769,17 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/streamx": {
+			"version": "2.28.0",
+			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+			"integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+			"license": "MIT",
+			"dependencies": {
+				"events-universal": "^1.0.0",
+				"fast-fifo": "^1.3.2",
+				"text-decoder": "^1.1.0"
+			}
+		},
 		"node_modules/string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -14144,6 +14804,51 @@
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
 				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs": {
+			"name": "string-width",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
 			},
 			"engines": {
 				"node": ">=8"
@@ -14301,6 +15006,28 @@
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
+		"node_modules/strip-ansi-cjs": {
+			"name": "strip-ansi",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/strip-bom": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -14396,6 +15123,41 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/tar-stream": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+			"integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+			"license": "MIT",
+			"dependencies": {
+				"b4a": "^1.6.4",
+				"bare-fs": "^4.5.5",
+				"fast-fifo": "^1.2.0",
+				"streamx": "^2.15.0"
+			}
+		},
+		"node_modules/tar-stream/node_modules/b4a": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+			"integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"react-native-b4a": "*"
+			},
+			"peerDependenciesMeta": {
+				"react-native-b4a": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/teex": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+			"integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+			"license": "MIT",
+			"dependencies": {
+				"streamx": "^2.12.5"
+			}
+		},
 		"node_modules/terminal-link": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-3.0.0.tgz",
@@ -14437,6 +15199,29 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/text-decoder": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+			"integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"b4a": "^1.6.4"
+			}
+		},
+		"node_modules/text-decoder/node_modules/b4a": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+			"integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"react-native-b4a": "*"
+			},
+			"peerDependenciesMeta": {
+				"react-native-b4a": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/text-table": {
@@ -14590,12 +15375,6 @@
 			"engines": {
 				"node": ">=16"
 			}
-		},
-		"node_modules/tr46": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-			"license": "MIT"
 		},
 		"node_modules/tree-dump": {
 			"version": "1.1.0",
@@ -15072,6 +15851,15 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/undici": {
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+			"integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
 		"node_modules/undici-types": {
 			"version": "6.21.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -15396,12 +16184,6 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/webidl-conversions": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-			"license": "BSD-2-Clause"
-		},
 		"node_modules/websocket-driver": {
 			"version": "0.7.4",
 			"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
@@ -15423,16 +16205,6 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=0.8.0"
-			}
-		},
-		"node_modules/whatwg-url": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-			"license": "MIT",
-			"dependencies": {
-				"tr46": "~0.0.3",
-				"webidl-conversions": "^3.0.0"
 			}
 		},
 		"node_modules/which": {
@@ -15602,6 +16374,45 @@
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
+		"node_modules/wrap-ansi-cjs": {
+			"name": "wrap-ansi",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/wrap-ansi/node_modules/ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -15747,6 +16558,45 @@
 			"resolved": "https://registry.npmjs.org/yoga-wasm-web/-/yoga-wasm-web-0.3.3.tgz",
 			"integrity": "sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA==",
 			"license": "MIT"
+		},
+		"node_modules/zip-stream": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+			"integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+			"license": "MIT",
+			"dependencies": {
+				"archiver-utils": "^5.0.0",
+				"compress-commons": "^6.0.2",
+				"readable-stream": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/zip-stream/node_modules/readable-stream": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+			"license": "MIT",
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/zip-stream/node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
+			}
 		},
 		"node_modules/zod": {
 			"version": "3.25.76",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 	"dependencies": {
 		"@oclif/core": "^4.11.6",
 		"@oclif/table": "^0.5.9",
+		"@salesforce/code-analyzer-apexguru-engine": "0.39.0",
 		"@salesforce/code-analyzer-core": "0.49.0",
 		"@salesforce/code-analyzer-engine-api": "0.39.0",
 		"@salesforce/code-analyzer-eslint-engine": "0.44.0",

--- a/src/commands/code-analyzer/run.ts
+++ b/src/commands/code-analyzer/run.ts
@@ -37,6 +37,12 @@ export default class RunCommand extends SfCommand<void> implements Displayable {
 			multiple: true,
 			delimiter: ','
 		}),
+		'target-org': Flags.string({
+			summary: getMessage(BundleName.RunCommand, 'flags.target-org.summary'),
+			description: getMessage(BundleName.RunCommand, 'flags.target-org.description'),
+			// eslint-disable-next-line sf-plugin/dash-o
+			char: 'o'
+		}),
 		// === Flags pertaining to rule selection ===
 		'rule-selector': Flags.string({
 			summary: getMessage(BundleName.RunCommand, 'flags.rule-selector.summary'),
@@ -102,6 +108,7 @@ export default class RunCommand extends SfCommand<void> implements Displayable {
 			'severity-threshold': parsedFlags['severity-threshold'] === undefined ? undefined :
 				convertThresholdToEnum(parsedFlags['severity-threshold'].toLowerCase()),
 			'target': parsedFlags['target'],
+			'target-org': parsedFlags['target-org'],
 			'include-fixes': parsedFlags['include-fixes'],
 			'include-suggestions': parsedFlags['include-suggestions'],
 			'no-suppressions': parsedFlags['no-suppressions']

--- a/src/lib/actions/RunAction.ts
+++ b/src/lib/actions/RunAction.ts
@@ -1,4 +1,4 @@
-import {SfError} from '@salesforce/core';
+import {AuthInfo, SfError} from '@salesforce/core';
 import {
 	CodeAnalyzer,
 	CodeAnalyzerConfig,
@@ -54,6 +54,11 @@ export class RunAction {
 	}
 
 	public async execute(input: RunInput): Promise<void> {
+		// Validate org authentication upfront before config creation
+		if (input['target-org']) {
+			await this.validateTargetOrg(input['target-org']);
+		}
+
 		const cliOverrides = (input['no-suppressions'] !== undefined || input['target-org'] !== undefined)
 			? {
 				noSuppressions: input['no-suppressions'],
@@ -111,6 +116,22 @@ export class RunAction {
 
 	public static createAction(dependencies: RunDependencies): RunAction {
 		return new RunAction(dependencies);
+	}
+
+	private async validateTargetOrg(orgNameOrAlias: string): Promise<void> {
+		try {
+			await AuthInfo.create({ username: orgNameOrAlias });
+		} catch (error) {
+			if (error instanceof Error) {
+				const errorMessage = [
+					`Org '${orgNameOrAlias}' not found or not authenticated.`,
+					`  • Run 'sf org list' to see available orgs`,
+					`  • Run 'sf org login web --alias ${orgNameOrAlias}' to authenticate a new org`
+				].join('\n');
+				throw new SfError(errorMessage, 'OrgAuthenticationError');
+			}
+			throw error;
+		}
 	}
 
 	private emitEngineTelemetry(ruleSelection: RuleSelection, results: RunResults, coreEngineNames: string[]): void {

--- a/src/lib/actions/RunAction.ts
+++ b/src/lib/actions/RunAction.ts
@@ -39,6 +39,7 @@ export type RunInput = {
 	'rule-selector': string[];
 	'severity-threshold'?: SeverityLevel;
 	target?: string[];
+	'target-org'?: string;
 	workspace: string[];
 	'include-fixes'?: boolean;
 	'include-suggestions'?: boolean;
@@ -53,8 +54,11 @@ export class RunAction {
 	}
 
 	public async execute(input: RunInput): Promise<void> {
-		const cliOverrides = input['no-suppressions'] !== undefined
-			? { noSuppressions: input['no-suppressions'] }
+		const cliOverrides = (input['no-suppressions'] !== undefined || input['target-org'] !== undefined)
+			? {
+				noSuppressions: input['no-suppressions'],
+				targetOrg: input['target-org']
+			}
 			: undefined;
 		const config: CodeAnalyzerConfig = this.dependencies.configFactory.create(
 			input['config-file'],

--- a/src/lib/factories/CodeAnalyzerConfigFactory.ts
+++ b/src/lib/factories/CodeAnalyzerConfigFactory.ts
@@ -5,6 +5,7 @@ import * as yaml from 'js-yaml';
 
 export type CliOverrides = {
 	noSuppressions?: boolean;
+	targetOrg?: string;
 	// Future CLI flag overrides can be added here
 }
 
@@ -18,7 +19,7 @@ export class CodeAnalyzerConfigFactoryImpl implements CodeAnalyzerConfigFactory 
 
 	public create(configPath?: string, cliOverrides?: CliOverrides): CodeAnalyzerConfig {
 		// Fast path: If no CLI overrides, use existing simple logic
-		if (!cliOverrides || cliOverrides.noSuppressions === undefined) {
+		if (!cliOverrides || (cliOverrides.noSuppressions === undefined && cliOverrides.targetOrg === undefined)) {
 			return this.getConfigFromProvidedPath(configPath)
 			|| this.seekConfigInCurrentDirectory()
 			|| CodeAnalyzerConfig.withDefaults();
@@ -62,7 +63,7 @@ export class CodeAnalyzerConfigFactoryImpl implements CodeAnalyzerConfigFactory 
 		const disableSuppressionExplicitlySet = suppressionsSection?.disable_suppressions !== undefined;
 
 		// If YAML explicitly sets disable_suppressions, YAML wins completely (no CLI override)
-		if (disableSuppressionExplicitlySet) {
+		if (disableSuppressionExplicitlySet && !cliOverrides.targetOrg) {
 			return CodeAnalyzerConfig.fromFile(configFilePath);
 		}
 
@@ -72,42 +73,63 @@ export class CodeAnalyzerConfigFactoryImpl implements CodeAnalyzerConfigFactory 
 			key => key !== 'disable_suppressions' && Array.isArray(suppressionsSection[key])
 		);
 
-		// If CLI override provided and we have bulk suppressions, merge them
-		if (cliOverrides.noSuppressions !== undefined && hasBulkSuppressions && rawYaml) {
-			// Preserve bulk suppressions from YAML, apply CLI override to disable_suppressions
-			const mergedConfig: Record<string, unknown> = {
-				...rawYaml,
+		// Build merged config with any CLI overrides
+		let mergedConfig: Record<string, unknown> = rawYaml ? { ...rawYaml } : {};
+
+		// Apply suppressions override if needed
+		if (cliOverrides.noSuppressions !== undefined && hasBulkSuppressions) {
+			mergedConfig = {
+				...mergedConfig,
 				suppressions: {
 					...suppressionsSection,
 					disable_suppressions: cliOverrides.noSuppressions
 				}
 			};
-			return CodeAnalyzerConfig.fromObject(mergedConfig);
-		}
-
-		// If CLI override provided but no bulk suppressions (or no suppressions section at all)
-		if (cliOverrides.noSuppressions !== undefined && rawYaml) {
-			const mergedConfig: Record<string, unknown> = {
-				...rawYaml,
+		} else if (cliOverrides.noSuppressions !== undefined) {
+			mergedConfig = {
+				...mergedConfig,
 				suppressions: { disable_suppressions: cliOverrides.noSuppressions }
 			};
-			return CodeAnalyzerConfig.fromObject(mergedConfig);
 		}
 
-		// Config file exists, no CLI override, use config as-is with defaults
-		return CodeAnalyzerConfig.fromFile(configFilePath);
+		// Apply target-org override to apexguru engine config
+		if (cliOverrides.targetOrg) {
+			const enginesSection = mergedConfig.engines as Record<string, Record<string, unknown>> | undefined;
+			mergedConfig = {
+				...mergedConfig,
+				engines: {
+					...(enginesSection || {}),
+					apexguru: {
+						...(enginesSection?.apexguru || {}),
+						target_org: cliOverrides.targetOrg
+					}
+				}
+			};
+		}
+
+		return rawYaml ? CodeAnalyzerConfig.fromObject(mergedConfig) : CodeAnalyzerConfig.fromFile(configFilePath);
 	}
 
 	private createConfigFromCliOverrides(cliOverrides: CliOverrides): CodeAnalyzerConfig {
-		// Apply CLI overrides if provided
+		// Build config from CLI overrides
+		const configObject: Record<string, unknown> = {};
+
 		if (cliOverrides?.noSuppressions) {
-			return CodeAnalyzerConfig.fromObject({
-				suppressions: { disable_suppressions: true }
-			});
+			configObject.suppressions = { disable_suppressions: true };
 		}
 
-		// No config file, no CLI overrides - use defaults (suppressions enabled)
-		return CodeAnalyzerConfig.withDefaults();
+		if (cliOverrides?.targetOrg) {
+			configObject.engines = {
+				apexguru: {
+					target_org: cliOverrides.targetOrg
+				}
+			};
+		}
+
+		// If we have overrides, create config from them; otherwise use defaults
+		return Object.keys(configObject).length > 0
+			? CodeAnalyzerConfig.fromObject(configObject)
+			: CodeAnalyzerConfig.withDefaults();
 	}
 
 	private getConfigFilePath(configPath?: string): string|undefined {

--- a/src/lib/factories/EnginePluginsFactory.ts
+++ b/src/lib/factories/EnginePluginsFactory.ts
@@ -5,6 +5,7 @@ import * as RetireJSEngineModule from '@salesforce/code-analyzer-retirejs-engine
 import * as RegexEngineModule from '@salesforce/code-analyzer-regex-engine';
 import * as FlowEngineModule from '@salesforce/code-analyzer-flow-engine';
 import * as SfgeEngineModule from '@salesforce/code-analyzer-sfge-engine';
+import * as ApexGuruEngineModule from '@salesforce/code-analyzer-apexguru-engine';
 
 export interface EnginePluginsFactory {
 	create(): EnginePlugin[];
@@ -18,7 +19,8 @@ export class EnginePluginsFactoryImpl implements EnginePluginsFactory {
 			RetireJSEngineModule.createEnginePlugin(),
 			RegexEngineModule.createEnginePlugin(),
 			FlowEngineModule.createEnginePlugin(),
-			SfgeEngineModule.createEnginePlugin()
+			SfgeEngineModule.createEnginePlugin(),
+			ApexGuruEngineModule.createEnginePlugin()
 		];
 	}
 }

--- a/test/commands/code-analyzer/run.test.ts
+++ b/test/commands/code-analyzer/run.test.ts
@@ -67,10 +67,57 @@ describe('`code-analyzer run` end to end tests', () => {
 	});
 });
 
+describe('`code-analyzer run` with --target-org flag', () => {
+	const origDir: string = process.cwd();
+	const apexWorkspace: string = path.resolve(rootFolderWithPackageJson, 'test', 'fixtures', 'example-workspaces', 'workspace-with-misc-files');
+
+	beforeAll(async () => {
+		process.chdir(apexWorkspace);
+		await config.load();
+	});
+
+	afterAll(async () => {
+		process.chdir(origDir);
+	});
+
+	it('Accepts --target-org flag with org value', async () => {
+		const outputInterceptor: ConsoleOuputInterceptor = new ConsoleOuputInterceptor();
+		try {
+			outputInterceptor.start();
+			await runRunCommand(['--target-org', 'test-org', '-r', 'apexguru', '-t', 'world.cls']);
+		} catch (error) {
+			// ApexGuru may fail if org is not authenticated, which is expected in test environment
+			// We're testing that the flag is accepted and parsed, not that ApexGuru runs successfully
+		} finally {
+			outputInterceptor.stop();
+		}
+
+		// Should not throw parsing errors for the flag itself
+		expect(outputInterceptor.out).not.toContain('Unknown flag');
+		expect(outputInterceptor.out).not.toContain('Unexpected argument');
+	});
+
+	it('Accepts -o shorthand for --target-org', async () => {
+		const outputInterceptor: ConsoleOuputInterceptor = new ConsoleOuputInterceptor();
+		try {
+			outputInterceptor.start();
+			await runRunCommand(['-o', 'my-org', '-r', 'apexguru', '-t', 'world.cls']);
+		} catch (error) {
+			// ApexGuru may fail if org is not authenticated, which is expected in test environment
+		} finally {
+			outputInterceptor.stop();
+		}
+
+		// Should not throw parsing errors for the flag itself
+		expect(outputInterceptor.out).not.toContain('Unknown flag');
+		expect(outputInterceptor.out).not.toContain('Unexpected argument');
+	});
+});
+
 describe('`code-analyzer run` end to end tests for inline suppressions', () => {
 	const origDir: string = process.cwd();
 	const suppressionWorkspace: string = path.resolve(rootFolderWithPackageJson, 'test', 'fixtures', 'example-workspaces', 'workspace-with-suppressions');
-	
+
 	beforeAll(async () => {
 		process.chdir(suppressionWorkspace);
 		await config.load();
@@ -466,6 +513,22 @@ describe('`code-analyzer run` unit tests', () => {
 			await runRunCommand([]);
 			expect(createActionSpy).toHaveBeenCalled();
 			expect(receivedActionDependencies.telemetryEmitter!.constructor.name).toEqual('SfCliTelemetryEmitter');
+		});
+	});
+
+	describe('--target-org', () => {
+		it('Can be supplied with a value', async () => {
+			const inputValue = 'test-org';
+			await runRunCommand(['--target-org', inputValue]);
+			expect(executeSpy).toHaveBeenCalled();
+			expect(receivedActionInput).toHaveProperty('target-org', inputValue);
+		});
+
+		it('Can be referenced by its shortname, -o', async () => {
+			const inputValue = 'my-org';
+			await runRunCommand(['-o', inputValue]);
+			expect(executeSpy).toHaveBeenCalled();
+			expect(receivedActionInput).toHaveProperty('target-org', inputValue);
 		});
 	});
 

--- a/test/lib/actions/RunAction.test.ts
+++ b/test/lib/actions/RunAction.test.ts
@@ -479,6 +479,44 @@ describe('RunAction tests', () => {
 			expect(runOptions.includeFixes).toBe(true);
 			expect(runOptions.includeSuggestions).toBe(true);
 		});
+
+		describe('target-org', () => {
+			it('RunInput accepts target-org field', async () => {
+				const input: RunInput = {
+					'rule-selector': ['all'],
+					'workspace': ['.'],
+					'output-file': [],
+					'target-org': 'test-org'
+				};
+
+				await action.execute(input);
+
+				// Verify execution completes without type errors
+				expect(engine1.runRulesCallHistory).toHaveLength(1);
+			});
+
+			it('target-org is passed through to engine config', async () => {
+				const targetOrg = 'my-test-org';
+				const configFactorySpy = vi.spyOn(dependencies.configFactory, 'create');
+
+				const input: RunInput = {
+					'rule-selector': ['all'],
+					'workspace': ['.'],
+					'output-file': [],
+					'target-org': targetOrg
+				};
+
+				await action.execute(input);
+
+				// Verify configFactory.create was called with target-org override
+				expect(configFactorySpy).toHaveBeenCalledWith(
+					undefined,
+					expect.objectContaining({
+						targetOrg: targetOrg
+					})
+				);
+			});
+		});
 	});
 });
 

--- a/test/lib/actions/RunAction.test.ts
+++ b/test/lib/actions/RunAction.test.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 import ansis from 'ansis';
-import {SfError} from '@salesforce/core';
+import {AuthInfo, SfError} from '@salesforce/core';
 import {SeverityLevel} from '@salesforce/code-analyzer-core';
 import {SpyResultsViewer} from '../../stubs/SpyResultsViewer.js';
 import {SpyResultsWriter} from '../../stubs/SpyResultsWriter.js';
@@ -482,6 +482,9 @@ describe('RunAction tests', () => {
 
 		describe('target-org', () => {
 			it('RunInput accepts target-org field', async () => {
+				// Mock AuthInfo.create to succeed
+				vi.spyOn(AuthInfo, 'create').mockResolvedValue({} as AuthInfo);
+
 				const input: RunInput = {
 					'rule-selector': ['all'],
 					'workspace': ['.'],
@@ -496,6 +499,9 @@ describe('RunAction tests', () => {
 			});
 
 			it('target-org is passed through to engine config', async () => {
+				// Mock AuthInfo.create to succeed
+				vi.spyOn(AuthInfo, 'create').mockResolvedValue({} as AuthInfo);
+
 				const targetOrg = 'my-test-org';
 				const configFactorySpy = vi.spyOn(dependencies.configFactory, 'create');
 
@@ -515,6 +521,67 @@ describe('RunAction tests', () => {
 						targetOrg: targetOrg
 					})
 				);
+			});
+
+			it('validates org authentication before config creation', async () => {
+				const targetOrg = 'test-org';
+				const authInfoSpy = vi.spyOn(AuthInfo, 'create').mockResolvedValue({} as AuthInfo);
+
+				const input: RunInput = {
+					'rule-selector': ['all'],
+					'workspace': ['.'],
+					'output-file': [],
+					'target-org': targetOrg
+				};
+
+				await action.execute(input);
+
+				// Verify AuthInfo.create was called with the org name
+				expect(authInfoSpy).toHaveBeenCalledWith({ username: targetOrg });
+			});
+
+			it('throws clear error when org is not authenticated', async () => {
+				const targetOrg = 'unauthenticated-org';
+				// Mock AuthInfo.create to throw an error (org not found/authenticated)
+				vi.spyOn(AuthInfo, 'create').mockRejectedValue(new Error('No authorization information found'));
+
+				const input: RunInput = {
+					'rule-selector': ['all'],
+					'workspace': ['.'],
+					'output-file': [],
+					'target-org': targetOrg
+				};
+
+				// Execute and expect it to throw
+				let thrownError: Error | null = null;
+				try {
+					await action.execute(input);
+				} catch (e) {
+					thrownError = e as Error;
+				}
+
+				// Verify the error is an SfError with actionable message
+				expect(thrownError).toBeInstanceOf(SfError);
+				expect((thrownError as SfError).name).toEqual('OrgAuthenticationError');
+				expect((thrownError as SfError).message).toContain(`Org '${targetOrg}' not found or not authenticated`);
+				expect((thrownError as SfError).message).toContain('sf org list');
+				expect((thrownError as SfError).message).toContain('sf org login web');
+			});
+
+			it('does not validate org when target-org is not provided', async () => {
+				const authInfoSpy = vi.spyOn(AuthInfo, 'create');
+
+				const input: RunInput = {
+					'rule-selector': ['all'],
+					'workspace': ['.'],
+					'output-file': []
+					// No target-org provided
+				};
+
+				await action.execute(input);
+
+				// Verify AuthInfo.create was NOT called
+				expect(authInfoSpy).not.toHaveBeenCalled();
 			});
 		});
 	});

--- a/test/lib/factories/CodeAnalyzerConfigFactory.test.ts
+++ b/test/lib/factories/CodeAnalyzerConfigFactory.test.ts
@@ -281,5 +281,60 @@ describe('CodeAnalyzerConfigFactoryImpl', () => {
 				}
 			});
 		});
+
+		describe('targetOrg override', () => {
+			it('When no config file and targetOrg override is provided, applies it to apexguru engine', () => {
+				const factory = new CodeAnalyzerConfigFactoryImpl();
+				const testedConfig = factory.create(undefined, { targetOrg: 'my-org@example.com' });
+
+				expect(testedConfig.getEngineOverridesFor('apexguru')).toEqual({
+					target_org: 'my-org@example.com'
+				});
+			});
+
+			it('When config file exists (without engines) and targetOrg override is provided, applies it to apexguru engine', () => {
+				const factory = new CodeAnalyzerConfigFactoryImpl();
+				const configPath = path.resolve('test', 'fixtures', 'valid-configs', 'config-without-suppressions-field.yml');
+
+				const testedConfig = factory.create(configPath, { targetOrg: 'my-org@example.com' });
+
+				expect(testedConfig.getEngineOverridesFor('apexguru')).toEqual({
+					target_org: 'my-org@example.com'
+				});
+				// Original config values should still be loaded
+				expect(testedConfig.getRuleOverridesFor('stubEngine1')).toEqual({
+					stub1RuleC: {
+						severity: 4,
+						tags: ['TestTag']
+					}
+				});
+			});
+
+			it('When YAML config explicitly disables suppressions and targetOrg override is provided, both are applied', () => {
+				const factory = new CodeAnalyzerConfigFactoryImpl();
+				const configPath = path.resolve('test', 'fixtures', 'valid-configs', 'config-with-suppressions-disabled.yml');
+
+				const testedConfig = factory.create(configPath, { targetOrg: 'my-org@example.com' });
+
+				// YAML suppressions setting preserved (disabled), targetOrg also applied
+				expect(testedConfig.getSuppressionsEnabled()).toBe(false);
+				expect(testedConfig.getEngineOverridesFor('apexguru')).toEqual({
+					target_org: 'my-org@example.com'
+				});
+			});
+
+			it('When both noSuppressions and targetOrg overrides are provided, both are applied', () => {
+				const factory = new CodeAnalyzerConfigFactoryImpl();
+				const testedConfig = factory.create(undefined, {
+					noSuppressions: true,
+					targetOrg: 'my-org@example.com'
+				});
+
+				expect(testedConfig.getSuppressionsEnabled()).toBe(false);
+				expect(testedConfig.getEngineOverridesFor('apexguru')).toEqual({
+					target_org: 'my-org@example.com'
+				});
+			});
+		});
 	});
 });

--- a/test/lib/factories/EnginePluginsFactory.test.ts
+++ b/test/lib/factories/EnginePluginsFactory.test.ts
@@ -6,12 +6,13 @@ describe('EnginePluginsFactoryImpl', () => {
 		const pluginsFactory = new EnginePluginsFactoryImpl();
 		const enginePlugins = pluginsFactory.create();
 
-		expect(enginePlugins).toHaveLength(6);
+		expect(enginePlugins).toHaveLength(7);
 		expect(enginePlugins[0].getAvailableEngineNames()).toEqual(['eslint']);
 		expect(enginePlugins[1].getAvailableEngineNames()).toEqual(['pmd', 'cpd']);
 		expect(enginePlugins[2].getAvailableEngineNames()).toEqual(['retire-js']);
 		expect(enginePlugins[3].getAvailableEngineNames()).toEqual(['regex']);
 		expect(enginePlugins[4].getAvailableEngineNames()).toEqual(['flow']);
 		expect(enginePlugins[5].getAvailableEngineNames()).toEqual(['sfge']);
+		expect(enginePlugins[6].getAvailableEngineNames()).toEqual(['apexguru']);
 	});
 });

--- a/test/stubs/StubRunResults.ts
+++ b/test/stubs/StubRunResults.ts
@@ -14,14 +14,6 @@ export class StubEmptyResults implements RunResults {
 		throw new Error('Method not implemented.');
 	}
 
-	/**
-	 * Based on the way the tests currently use this stub, this method is never called,
-	 * so it should be fine for it to be unimplemented.
-	 */
-	getEngineInsights(_engineName: string): Record<string, unknown> | undefined {
-		return undefined;
-	}
-
 	getViolationCount(): number {
 		return 0;
 	}
@@ -65,6 +57,22 @@ export class StubEmptyResults implements RunResults {
 	toFormattedOutput(format: OutputFormat): string {
 		return `Results formatted as ${format}`;
 	}
+
+	/**
+	 * Based on the way the tests currently use this stub, this method is never called,
+	 * so it should be fine for it to be unimplemented.
+	 */
+	getInsights(): Record<string, unknown> | undefined {
+		return undefined;
+	}
+
+	/**
+	 * Based on the way the tests currently use this stub, this method is never called,
+	 * so it should be fine for it to be unimplemented.
+	 */
+	getEngineInsights(_engineName: string): Record<string, unknown> | undefined {
+		return undefined;
+	}
 }
 
 export class StubNonEmptyResults implements RunResults {
@@ -75,15 +83,6 @@ export class StubNonEmptyResults implements RunResults {
 	getRunDirectory(): string {
 		throw new Error('Method not implemented.');
 	}
-
-	/**
-	 * Based on the way the tests currently use this stub, this method is never called,
-	 * so it should be fine for it to be unimplemented.
-	 */
-	getEngineInsights(_engineName: string): Record<string, unknown> | undefined {
-		return undefined;
-	}
-
 	getViolationCount(): number {
 		return 5;
 	}
@@ -126,5 +125,21 @@ export class StubNonEmptyResults implements RunResults {
 	 */
 	toFormattedOutput(format: OutputFormat): string {
 		return `Results formatted as ${format}`;
+	}
+
+	/**
+	 * Based on the way the tests currently use this stub, this method is never called,
+	 * so it should be fine for it to be unimplemented.
+	 */
+	getInsights(): Record<string, unknown> | undefined {
+		return undefined;
+	}
+
+	/**
+	 * Based on the way the tests currently use this stub, this method is never called,
+	 * so it should be fine for it to be unimplemented.
+	 */
+	getEngineInsights(_engineName: string): Record<string, unknown> | undefined {
+		return undefined;
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `--target-org` (`-o`) flag to the `run` command for the ApexGuru engine
- Wires `target-org` through `CodeAnalyzerConfigFactory` so the apexguru engine receives it via config overrides
- Adds the `@salesforce/code-analyzer-apexguru-engine` dependency and registers it in `EnginePluginsFactory`


## Test plan
- [x] Unit tests pass locally (`npm test`)
- [x] Branch coverage above 90% threshold (91.6%)
- [x] Lint clean
- [ ] CI green on the new PR